### PR TITLE
Fix(ai-gateway): Return model objects

### DIFF
--- a/AIGateway/src/routers/tenant_chat.py
+++ b/AIGateway/src/routers/tenant_chat.py
@@ -127,7 +127,10 @@ async def get_providers(request: Request):
             provider = info.get("litellm_provider", "unknown")
             if provider not in providers:
                 providers[provider] = []
-            providers[provider].append(model_name)
+            providers[provider].append({
+                "id": model_name,
+                "mode": info.get("mode", "chat"),
+            })
 
         return {
             "data": {


### PR DESCRIPTION
## Describe your changes

The /internal/providers endpoint was returning each model as a plain string, but the frontend Add Endpoint dropdown filters by a `mode` field on each entry — so every provider's model list was filtered to empty and users couldn't select a
model when creating an endpoint. 

## Please ensure all items are checked off before requesting a review:

- [x] I deployed the code locally.
- [x] I have performed a self-review of my code.
- [ ] I have included the issue # in the PR.
- [x] I have labelled the PR correctly.
- [x] The issue I am working on is assigned to me.
- [x] I have avoided using hardcoded values to ensure scalability and maintain consistency across the application.
- [x] I have ensured that font sizes, color choices, and other UI elements are referenced from the theme.
- [x] My pull request is focused and addresses a single, specific feature.
- [ ] If there are UI changes, I have attached a screenshot or video to this PR.
