### PR TITLE
Allow clearing Owner/Reviewer/Approver in ISO 42001, ISO 27001, and NIST drawers

### DIFF
--- a/Clients/src/presentation/components/Drawer/AnnexDrawerDialog/index.tsx
+++ b/Clients/src/presentation/components/Drawer/AnnexDrawerDialog/index.tsx
@@ -30,7 +30,7 @@ import DatePicker from "../../Inputs/Datepicker";
 import Select from "../../Inputs/Select";
 import TabBar from "../../TabBar";
 import StandardModal from "../../Modals/StandardModal";
-import { useState, useEffect, lazy, Suspense, useRef } from "react";
+import { useState, useEffect, useMemo, lazy, Suspense, useRef } from "react";
 import { Dayjs } from "dayjs";
 import dayjs from "dayjs";
 import { CustomizableButton } from "../../button/customizable-button";
@@ -108,6 +108,18 @@ const VWISO42001AnnexDrawerDialog = ({
   const [fetchedAnnex, setFetchedAnnex] = useState<AnnexCategoryISO>();
   const [isLoading, setIsLoading] = useState(false);
   const [projectMembers, setProjectMembers] = useState<User[]>([]);
+  const memberOptions = useMemo(
+    () => [
+      { _id: "" as string | number, name: "(none)" },
+      ...projectMembers.map((user) => ({
+        _id: user.id as string | number,
+        name: `${user.name}`,
+        email: user.email,
+        surname: user.surname,
+      })),
+    ],
+    [projectMembers],
+  );
   const [isLinkedRisksModalOpen, setIsLinkedRisksModalOpen] = useState<boolean>(false);
   const [evidenceFiles, setEvidenceFiles] = useState<FileData[]>([]);
   const theme = useTheme();
@@ -793,12 +805,7 @@ const VWISO42001AnnexDrawerDialog = ({
                   label="Owner:"
                   value={formData.owner ? parseInt(formData.owner) : ""}
                   onChange={handleSelectChange("owner")}
-                  items={projectMembers.map((user) => ({
-                    _id: user.id,
-                    name: `${user.name}`,
-                    email: user.email,
-                    surname: user.surname,
-                  }))}
+                  items={memberOptions}
                   disabled={!formData.is_applicable || isEditingDisabled}
                   sx={inputStyles}
                   placeholder={"Select owner"}
@@ -809,12 +816,7 @@ const VWISO42001AnnexDrawerDialog = ({
                   label="Reviewer:"
                   value={formData.reviewer ? parseInt(formData.reviewer) : ""}
                   onChange={handleSelectChange("reviewer")}
-                  items={projectMembers.map((user) => ({
-                    _id: user.id,
-                    name: `${user.name}`,
-                    email: user.email,
-                    surname: user.surname,
-                  }))}
+                  items={memberOptions}
                   disabled={!formData.is_applicable || isEditingDisabled}
                   sx={inputStyles}
                   placeholder={"Select reviewer"}
@@ -825,12 +827,7 @@ const VWISO42001AnnexDrawerDialog = ({
                   label="Approver:"
                   value={formData.approver ? parseInt(formData.approver) : ""}
                   onChange={handleSelectChange("approver")}
-                  items={projectMembers.map((user) => ({
-                    _id: user.id,
-                    name: `${user.name}`,
-                    email: user.email,
-                    surname: user.surname,
-                  }))}
+                  items={memberOptions}
                   disabled={!formData.is_applicable || isEditingDisabled}
                   sx={inputStyles}
                   placeholder={"Select approver"}

--- a/Clients/src/presentation/components/Drawer/ClauseDrawerDialog/index.tsx
+++ b/Clients/src/presentation/components/Drawer/ClauseDrawerDialog/index.tsx
@@ -11,7 +11,7 @@
  * - Notes: Collaboration notes (lazy-loaded)
  */
 
-import React, { useState, useEffect, Suspense, lazy, useRef } from "react";
+import React, { useState, useEffect, useMemo, Suspense, lazy, useRef } from "react";
 import {
   Box,
   Button,
@@ -116,6 +116,18 @@ const ISO42001ClauseDrawerDialog: React.FC<ISO42001ClauseDrawerProps> = ({
   const [alert, setAlert] = useState<AlertProps | null>(null);
   const [activeTab, setActiveTab] = useState("details");
   const [projectMembers, setProjectMembers] = useState<User[]>([]);
+  const memberOptions = useMemo(
+    () => [
+      { _id: "" as string | number, name: "(none)" },
+      ...projectMembers.map((user) => ({
+        _id: user.id as string | number,
+        name: `${user.name}`,
+        email: user.email,
+        surname: user.surname,
+      })),
+    ],
+    [projectMembers],
+  );
 
   // ========================================================================
   // STATE - FORM DATA
@@ -542,9 +554,9 @@ const ISO42001ClauseDrawerDialog: React.FC<ISO42001ClauseDrawerProps> = ({
       // Add form fields
       formDataToSend.append("status", formData.status);
       formDataToSend.append("implementation_description", formData.implementation_description);
-      if (formData.owner) formDataToSend.append("owner", formData.owner);
-      if (formData.reviewer) formDataToSend.append("reviewer", formData.reviewer);
-      if (formData.approver) formDataToSend.append("approver", formData.approver);
+      formDataToSend.append("owner", formData.owner || "");
+      formDataToSend.append("reviewer", formData.reviewer || "");
+      formDataToSend.append("approver", formData.approver || "");
       formDataToSend.append("auditor_feedback", formData.auditor_feedback);
 
       if (date) {
@@ -858,12 +870,7 @@ const ISO42001ClauseDrawerDialog: React.FC<ISO42001ClauseDrawerProps> = ({
                   label="Owner:"
                   value={formData.owner ? parseInt(formData.owner) : ""}
                   onChange={handleSelectChange("owner")}
-                  items={projectMembers.map((user) => ({
-                    _id: user.id,
-                    name: `${user.name}`,
-                    email: user.email,
-                    surname: user.surname,
-                  }))}
+                  items={memberOptions}
                   sx={inputStyles}
                   placeholder="Select owner"
                   disabled={isEditingDisabled}
@@ -874,12 +881,7 @@ const ISO42001ClauseDrawerDialog: React.FC<ISO42001ClauseDrawerProps> = ({
                   label="Reviewer:"
                   value={formData.reviewer ? parseInt(formData.reviewer) : ""}
                   onChange={handleSelectChange("reviewer")}
-                  items={projectMembers.map((user) => ({
-                    _id: user.id,
-                    name: `${user.name}`,
-                    email: user.email,
-                    surname: user.surname,
-                  }))}
+                  items={memberOptions}
                   sx={inputStyles}
                   placeholder="Select reviewer"
                   disabled={isEditingDisabled}
@@ -890,12 +892,7 @@ const ISO42001ClauseDrawerDialog: React.FC<ISO42001ClauseDrawerProps> = ({
                   label="Approver:"
                   value={formData.approver ? parseInt(formData.approver) : ""}
                   onChange={handleSelectChange("approver")}
-                  items={projectMembers.map((user) => ({
-                    _id: user.id,
-                    name: `${user.name}`,
-                    email: user.email,
-                    surname: user.surname,
-                  }))}
+                  items={memberOptions}
                   sx={inputStyles}
                   placeholder="Select approver"
                   disabled={isEditingDisabled}

--- a/Clients/src/presentation/components/Drawer/ISO27001AnnexDrawerDialog/index.tsx
+++ b/Clients/src/presentation/components/Drawer/ISO27001AnnexDrawerDialog/index.tsx
@@ -25,7 +25,7 @@ import RichTextEditor from "../../RichTextEditor";
 import { inputStyles } from "../ClauseDrawerDialog";
 import DatePicker from "../../Inputs/Datepicker";
 import Select from "../../Inputs/Select";
-import { useState, useEffect, lazy, Suspense, useRef } from "react";
+import { useState, useEffect, useMemo, lazy, Suspense, useRef } from "react";
 import TabBar from "../../TabBar";
 import StandardModal from "../../Modals/StandardModal";
 import {
@@ -131,6 +131,18 @@ const VWISO27001AnnexDrawerDialog = ({
   const [fetchedAnnex, setFetchedAnnex] = useState<AnnexControlData>();
   const [isLoading, setIsLoading] = useState(false);
   const [projectMembers, setProjectMembers] = useState<User[]>([]);
+  const memberOptions = useMemo(
+    () => [
+      { _id: "", name: "(none)" },
+      ...projectMembers.map((user) => ({
+        _id: user.id.toString(),
+        name: user.name,
+        email: user.email,
+        surname: user.surname,
+      })),
+    ],
+    [projectMembers],
+  );
   const [activeTab, setActiveTab] = useState("details");
   const [isLinkedRisksModalOpen, setIsLinkedRisksModalOpen] = useState<boolean>(false);
   const [isRiskDetailModalOpen, setIsRiskDetailModalOpen] = useState(false);
@@ -533,16 +545,9 @@ const VWISO27001AnnexDrawerDialog = ({
       formDataToSend.append("implementation_description", formData.implementation_description);
       formDataToSend.append("status", formData.status);
 
-      // Only append user fields if they have valid values
-      if (formData.owner && formData.owner.trim() !== "") {
-        formDataToSend.append("owner", formData.owner);
-      }
-      if (formData.reviewer && formData.reviewer.trim() !== "") {
-        formDataToSend.append("reviewer", formData.reviewer);
-      }
-      if (formData.approver && formData.approver.trim() !== "") {
-        formDataToSend.append("approver", formData.approver);
-      }
+      formDataToSend.append("owner", formData.owner || "");
+      formDataToSend.append("reviewer", formData.reviewer || "");
+      formDataToSend.append("approver", formData.approver || "");
 
       formDataToSend.append("auditor_feedback", formData.auditor_feedback);
       if (date) formDataToSend.append("due_date", date.toString());
@@ -839,12 +844,7 @@ const VWISO27001AnnexDrawerDialog = ({
                 label="Owner:"
                 value={formData.owner || ""}
                 onChange={handleSelectChange("owner")}
-                items={projectMembers.map((user) => ({
-                  _id: user.id.toString(),
-                  name: user.name,
-                  email: user.email,
-                  surname: user.surname,
-                }))}
+                items={memberOptions}
                 disabled={isEditingDisabled}
                 sx={inputStyles}
                 placeholder={"Select owner"}
@@ -856,12 +856,7 @@ const VWISO27001AnnexDrawerDialog = ({
                 label="Reviewer:"
                 value={formData.reviewer || ""}
                 onChange={handleSelectChange("reviewer")}
-                items={projectMembers.map((user) => ({
-                  _id: user.id.toString(),
-                  name: user.name,
-                  email: user.email,
-                  surname: user.surname,
-                }))}
+                items={memberOptions}
                 disabled={isEditingDisabled}
                 sx={inputStyles}
                 placeholder={"Select reviewer"}
@@ -873,12 +868,7 @@ const VWISO27001AnnexDrawerDialog = ({
                 label="Approver:"
                 value={formData.approver || ""}
                 onChange={handleSelectChange("approver")}
-                items={projectMembers.map((user) => ({
-                  _id: user.id.toString(),
-                  name: user.name,
-                  email: user.email,
-                  surname: user.surname,
-                }))}
+                items={memberOptions}
                 disabled={isEditingDisabled}
                 sx={inputStyles}
                 placeholder={"Select approver"}

--- a/Clients/src/presentation/components/Drawer/ISO27001ClauseDrawerDialog/index.tsx
+++ b/Clients/src/presentation/components/Drawer/ISO27001ClauseDrawerDialog/index.tsx
@@ -27,7 +27,7 @@ import { FileData } from "../../../../domain/types/File";
 import Select from "../../Inputs/Select";
 import DatePicker from "../../Inputs/Datepicker";
 import { Dayjs } from "dayjs";
-import { useState, useEffect, Suspense, lazy, useRef } from "react";
+import { useState, useEffect, useMemo, Suspense, lazy, useRef } from "react";
 import { CustomizableButton } from "../../button/customizable-button";
 import TabBar from "../../TabBar";
 import { text } from "../../../themes/palette";
@@ -128,6 +128,18 @@ const VWISO27001ClauseDrawerDialog = ({
   const [alert, setAlert] = useState<AlertProps | null>(null);
   const [activeTab, setActiveTab] = useState("details");
   const [projectMembers, setProjectMembers] = useState<User[]>([]);
+  const memberOptions = useMemo(
+    () => [
+      { _id: "", name: "(none)" },
+      ...projectMembers.map((user) => ({
+        _id: user.id.toString(),
+        name: user.name,
+        email: user.email,
+        surname: user.surname,
+      })),
+    ],
+    [projectMembers],
+  );
   const theme = useTheme();
 
   // ========================================================================
@@ -943,12 +955,7 @@ const VWISO27001ClauseDrawerDialog = ({
                   label="Owner:"
                   value={formData.owner || ""}
                   onChange={handleSelectChange("owner")}
-                  items={projectMembers.map((user) => ({
-                    _id: user.id.toString(),
-                    name: user.name,
-                    email: user.email,
-                    surname: user.surname,
-                  }))}
+                  items={memberOptions}
                   sx={inputStyles}
                   placeholder={"Select owner"}
                   disabled={isEditingDisabled}
@@ -960,12 +967,7 @@ const VWISO27001ClauseDrawerDialog = ({
                   label="Reviewer:"
                   value={formData.reviewer || ""}
                   onChange={handleSelectChange("reviewer")}
-                  items={projectMembers.map((user) => ({
-                    _id: user.id.toString(),
-                    name: user.name,
-                    email: user.email,
-                    surname: user.surname,
-                  }))}
+                  items={memberOptions}
                   sx={inputStyles}
                   placeholder={"Select reviewer"}
                   disabled={isEditingDisabled}
@@ -977,12 +979,7 @@ const VWISO27001ClauseDrawerDialog = ({
                   label="Approver:"
                   value={formData.approver || ""}
                   onChange={handleSelectChange("approver")}
-                  items={projectMembers.map((user) => ({
-                    _id: user.id.toString(),
-                    name: user.name,
-                    email: user.email,
-                    surname: user.surname,
-                  }))}
+                  items={memberOptions}
                   sx={inputStyles}
                   placeholder={"Select approver"}
                   disabled={isEditingDisabled}

--- a/Clients/src/presentation/components/Drawer/NISTAIRMFDashboardDrawerDialog/index.tsx
+++ b/Clients/src/presentation/components/Drawer/NISTAIRMFDashboardDrawerDialog/index.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, Suspense, useRef, lazy } from "react";
+import React, { useState, useEffect, useMemo, Suspense, useRef, lazy } from "react";
 import { Dayjs } from "dayjs";
 import dayjs from "dayjs";
 import { Box, IconButton, Tooltip } from "@mui/material";
@@ -71,6 +71,18 @@ const NISTAIRMFDrawerDialog: React.FC<NISTAIRMFDrawerProps> = ({
   const [isLoading, setIsLoading] = useState(false);
   const [alert, setAlert] = useState<AlertProps | null>(null);
   const [projectMembers, setProjectMembers] = useState<User[]>([]);
+  const memberOptions = useMemo(
+    () => [
+      { _id: "" as string | number, name: "(none)" },
+      ...projectMembers.map((user) => ({
+        _id: user.id as string | number,
+        name: `${user.name}`,
+        email: user.email,
+        surname: user.surname,
+      })),
+    ],
+    [projectMembers],
+  );
   const [activeTab, setActiveTab] = useState("details");
 
   // Risk linking state
@@ -358,9 +370,9 @@ const NISTAIRMFDrawerDialog: React.FC<NISTAIRMFDrawerProps> = ({
       formDataToSend.append("auditor_feedback", formData.auditor_feedback);
       formDataToSend.append("tags", JSON.stringify(formData.tags));
 
-      if (formData.owner) formDataToSend.append("owner", formData.owner);
-      if (formData.reviewer) formDataToSend.append("reviewer", formData.reviewer);
-      if (formData.approver) formDataToSend.append("approver", formData.approver);
+      formDataToSend.append("owner", formData.owner || "");
+      formDataToSend.append("reviewer", formData.reviewer || "");
+      formDataToSend.append("approver", formData.approver || "");
       if (date) formDataToSend.append("due_date", date.toISOString());
 
       // Add file handling fields (ISO pattern)
@@ -640,12 +652,7 @@ const NISTAIRMFDrawerDialog: React.FC<NISTAIRMFDrawerProps> = ({
                       label="Owner:"
                       value={formData.owner ? parseInt(formData.owner) : ""}
                       onChange={handleSelectChange("owner")}
-                      items={projectMembers.map((user) => ({
-                        _id: user.id,
-                        name: `${user.name}`,
-                        email: user.email,
-                        surname: user.surname,
-                      }))}
+                      items={memberOptions}
                       sx={inputStyles}
                       placeholder={"Select owner"}
                       disabled={isEditingDisabled}
@@ -656,12 +663,7 @@ const NISTAIRMFDrawerDialog: React.FC<NISTAIRMFDrawerProps> = ({
                       label="Reviewer:"
                       value={formData.reviewer ? parseInt(formData.reviewer) : ""}
                       onChange={handleSelectChange("reviewer")}
-                      items={projectMembers.map((user) => ({
-                        _id: user.id,
-                        name: `${user.name}`,
-                        email: user.email,
-                        surname: user.surname,
-                      }))}
+                      items={memberOptions}
                       sx={inputStyles}
                       placeholder={"Select reviewer"}
                       disabled={isEditingDisabled}
@@ -672,12 +674,7 @@ const NISTAIRMFDrawerDialog: React.FC<NISTAIRMFDrawerProps> = ({
                       label="Approver:"
                       value={formData.approver ? parseInt(formData.approver) : ""}
                       onChange={handleSelectChange("approver")}
-                      items={projectMembers.map((user) => ({
-                        _id: user.id,
-                        name: `${user.name}`,
-                        email: user.email,
-                        surname: user.surname,
-                      }))}
+                      items={memberOptions}
                       sx={inputStyles}
                       placeholder={"Select approver"}
                       disabled={isEditingDisabled}

--- a/Servers/controllers/iso27001.ctrl.ts
+++ b/Servers/controllers/iso27001.ctrl.ts
@@ -74,7 +74,7 @@ async function notifyIso27001Assignment(
         subclause_order_no: number;
         requirement_summary: string;
       }>(
-        `SELECT scs.clause_id, c.arrangement as clause_arrangement, c.title as clause_title, scs.order_no as subclause_order_no, scs.requirement_summary
+        `SELECT scs.clause_id, c.order_no as clause_arrangement, c.title as clause_title, scs.order_no as subclause_order_no, scs.requirement_summary
          FROM subclauses_iso27001 sc
          JOIN subclauses_struct_iso27001 scs ON sc.subclause_meta_id = scs.id
          JOIN clauses_struct_iso27001 c ON scs.clause_id = c.id

--- a/Servers/utils/iso27001.utils.ts
+++ b/Servers/utils/iso27001.utils.ts
@@ -827,19 +827,19 @@ export const updateSubClauseQuery = async (
     "auditor_feedback",
   ]
     .reduce((acc: string[], field) => {
-      if (subClause[field as keyof IISO27001SubClause] != undefined) {
-        let value = subClause[field as keyof IISO27001SubClause];
+      if (subClause[field as keyof IISO27001SubClause] !== undefined) {
+        let value = subClause[field as keyof IISO27001SubClause] as any;
 
-        // Handle empty strings for integer fields
         if (["owner", "reviewer", "approver"].includes(field)) {
-          if (value === "" || value === null || value === undefined) {
-            return acc; // Skip this field if it's empty
+          if (value === "" || value === null) {
+            value = null;
+          } else {
+            const numValue = parseInt(value as string);
+            if (isNaN(numValue)) return acc;
+            value = numValue;
           }
-          const numValue = parseInt(value as string);
-          if (isNaN(numValue)) {
-            return acc; // Skip this field if it's not a valid number
-          }
-          value = numValue;
+        } else if (value === "") {
+          return acc;
         }
 
         updateSubClause[field as keyof IISO27001SubClause] = value;
@@ -982,19 +982,19 @@ export const updateAnnexControlQuery = async (
     "auditor_feedback",
   ]
     .reduce((acc: string[], field) => {
-      if (annexControl[field as keyof IISO27001AnnexControl] != undefined) {
-        let value = annexControl[field as keyof IISO27001AnnexControl];
+      if (annexControl[field as keyof IISO27001AnnexControl] !== undefined) {
+        let value = annexControl[field as keyof IISO27001AnnexControl] as any;
 
-        // Handle empty strings for integer fields
         if (["owner", "reviewer", "approver"].includes(field)) {
-          if (value === "" || value === null || value === undefined) {
-            return acc; // Skip this field if it's empty
+          if (value === "" || value === null) {
+            value = null;
+          } else {
+            const numValue = parseInt(value as string);
+            if (isNaN(numValue)) return acc;
+            value = numValue;
           }
-          const numValue = parseInt(value as string);
-          if (isNaN(numValue)) {
-            return acc; // Skip this field if it's not a valid number
-          }
-          value = numValue;
+        } else if (value === "") {
+          return acc;
         }
 
         updateAnnexControl[field as keyof IISO27001AnnexControl] = value;

--- a/Servers/utils/iso42001.utils.ts
+++ b/Servers/utils/iso42001.utils.ts
@@ -820,23 +820,18 @@ export const updateSubClauseQuery = async (
     "auditor_feedback",
   ]
     .reduce((acc: string[], field) => {
-      if (subClause[field as keyof SubClauseISO] != undefined) {
-        let value = subClause[field as keyof SubClauseISO];
+      if (subClause[field as keyof SubClauseISO] !== undefined) {
+        let value = subClause[field as keyof SubClauseISO] as any;
 
-        // Handle empty strings for integer fields - skip if empty
         if (["owner", "reviewer", "approver"].includes(field)) {
-          if (value === "" || value === null || value === undefined) {
-            return acc; // Skip this field if it's empty
+          if (value === "" || value === null) {
+            value = null;
+          } else {
+            const numValue = parseInt(value as string);
+            if (isNaN(numValue)) return acc;
+            value = numValue;
           }
-          const numValue = parseInt(value as string);
-          if (isNaN(numValue)) {
-            return acc; // Skip this field if it's not a valid number
-          }
-          value = numValue;
-        }
-
-        // Skip empty strings for other fields too
-        if (value === "") {
+        } else if (value === "") {
           return acc;
         }
 
@@ -983,23 +978,18 @@ export const updateAnnexCategoryQuery = async (
     "auditor_feedback",
   ]
     .reduce((acc: string[], field) => {
-      if (annexCategory[field as keyof AnnexCategoryISO] != undefined) {
-        let value = annexCategory[field as keyof AnnexCategoryISO];
+      if (annexCategory[field as keyof AnnexCategoryISO] !== undefined) {
+        let value = annexCategory[field as keyof AnnexCategoryISO] as any;
 
-        // Handle empty strings for integer fields - skip if empty
         if (["owner", "reviewer", "approver"].includes(field)) {
-          if (value === "" || value === null || value === undefined) {
-            return acc; // Skip this field if it's empty
+          if (value === "" || value === null) {
+            value = null;
+          } else {
+            const numValue = parseInt(value as string);
+            if (isNaN(numValue)) return acc;
+            value = numValue;
           }
-          const numValue = parseInt(value as string);
-          if (isNaN(numValue)) {
-            return acc; // Skip this field if it's not a valid number
-          }
-          value = numValue;
-        }
-
-        // Skip empty strings for other fields too
-        if (value === "") {
+        } else if (value === "") {
           return acc;
         }
 

--- a/Servers/utils/nist_ai_rmf.subcategory.utils.ts
+++ b/Servers/utils/nist_ai_rmf.subcategory.utils.ts
@@ -169,30 +169,24 @@ export const updateNISTAIRMFSubcategoryByIdQuery = async (
     "auditor_feedback",
   ]
     .filter((f) => {
-      // Handle other fields
-      if (
-        subcategory[f as keyof NISTAIMRFSubcategoryModel] !== undefined &&
-        subcategory[f as keyof NISTAIMRFSubcategoryModel] !== null &&
-        subcategory[f as keyof NISTAIMRFSubcategoryModel] !== ""
-      ) {
-        let value = subcategory[f as keyof NISTAIMRFSubcategoryModel];
+      const incoming = subcategory[f as keyof NISTAIMRFSubcategoryModel];
+      if (incoming === undefined) return false;
 
-        // Handle empty strings for integer fields (owner, reviewer, approver)
-        if (["owner", "reviewer", "approver"].includes(f)) {
-          if (value === "" || value === null || value === undefined) {
-            return false; // Skip this field if it's empty
-          }
+      let value: any = incoming;
+      if (["owner", "reviewer", "approver"].includes(f)) {
+        if (value === "" || value === null) {
+          value = null;
+        } else {
           const numValue = parseInt(value as string);
-          if (isNaN(numValue)) {
-            return false; // Skip this field if it's not a valid number
-          }
+          if (isNaN(numValue)) return false;
           value = numValue;
         }
-
-        updateFields[f as keyof NISTAIMRFSubcategoryModel] = value;
-        return true;
+      } else if (value === "") {
+        return false;
       }
-      return false;
+
+      updateFields[f as keyof NISTAIMRFSubcategoryModel] = value;
+      return true;
     })
     .map((f) => `${f} = :${f}`)
     .join(", ");


### PR DESCRIPTION
## Summary

Once a value was set on the Owner / Reviewer / Approver dropdowns in the ISO 42001, ISO 27001, and NIST AI RMF framework drawers, there was no way to unset it through the UI. This mirrored the EU AI Act control bug fixed earlier and shared the same root cause: an empty string was silently ignored by both the frontend submit guards and the backend update util.

## Changes

**Frontend (5 drawers)**

- Prepend a `(none)` entry to the Owner/Reviewer/Approver Selects so the user has a way to clear an assignment.
- Drop truthy guards in the FormData submit so an empty string for the cleared field actually reaches the backend.

**Backend (3 utils)**

- Update queries now treat empty string and null as "set this column to NULL", instead of silently skipping the field.
- Same anti-pattern existed verbatim in `iso42001.utils.ts` (`updateAnnexCategoryQuery`, `updateSubClauseQuery`), `iso27001.utils.ts` (`updateAnnexControlQuery`, `updateSubClauseQuery`), and `nist_ai_rmf.subcategory.utils.ts` (`updateNISTAIRMFSubcategoryByIdQuery`).

Status fields are intentionally left alone — every status enum value is meaningful, and `Not started` already serves as the natural reset.

## Verified locally

Verified all 5 backend endpoints round-trip correctly via direct API tests (set Owner = userId → owner = userId; clear Owner = "" → owner = null; transaction commits; DB rows match):

| Endpoint | Set | Clear |
|---|---|---|
| `iso-42001/saveClauses` | ✅ | ✅ |
| `iso-42001/saveAnnexes` | ✅ | ✅ |
| `iso-27001/saveClauses` | ✅ | ✅ |
| `iso-27001/saveAnnexes` | ✅ | ✅ |
| `nist-ai-rmf/subcategories` | ✅ | ✅ |

`npm run build` and format-check pass for both Servers and Clients. 109 jest tests pass.

## Known follow-ups

- The EU AI Act ControlPane fix and these 5 drawers all duplicate a `memberOptions` useMemo block. Worth extracting a shared `useMemberOptions(projectMembers)` hook in a follow-up.
- Pre-existing SQL bug in the ISO 27001 saveClauses notifier path: it references `clauses_struct_iso27001.arrangement` which doesn't exist. Crashes the backend on assignment notifications. Not introduced here; needs a separate fix.