### PR TITLE
Fix ISO 27001 notifier query referencing non-existent arrangement column

### DIFF
--- a/Servers/controllers/iso27001.ctrl.ts
+++ b/Servers/controllers/iso27001.ctrl.ts
@@ -66,15 +66,14 @@ async function notifyIso27001Assignment(
     let description: string | undefined;
 
     if (entityType === "ISO 27001 Subclause") {
-      // Query for parent clause info, subclause order_no for full identifier (e.g., "4.1 Understanding the organization"), and subclause description
       const result = await sequelize.query<{
         clause_id: number;
-        clause_arrangement: number;
+        clause_arrangement: string;
         clause_title: string;
         subclause_order_no: number;
         requirement_summary: string;
       }>(
-        `SELECT scs.clause_id, c.arrangement as clause_arrangement, c.title as clause_title, scs.order_no as subclause_order_no, scs.requirement_summary
+        `SELECT scs.clause_id, c.clause_id as clause_arrangement, c.title as clause_title, scs.order_no as subclause_order_no, scs.requirement_summary
          FROM subclauses_iso27001 sc
          JOIN subclauses_struct_iso27001 scs ON sc.subclause_meta_id = scs.id
          JOIN clauses_struct_iso27001 c ON scs.clause_id = c.id


### PR DESCRIPTION
## Summary

Assigning Owner / Reviewer / Approver to an ISO 27001 subclause crashed the backend with:

```
ERROR: column "arrangement" does not exist
```

The assignment notifier in `iso27001.ctrl.ts` issues a SELECT to build the entity name for the in-app notification. The query referenced `clauses_struct_iso27001.arrangement`, but that column doesn't exist — the human-readable clause identifier ("4", "5", etc.) lives in the `clause_id` column.

## Fix

Replaced `c.arrangement` with `c.clause_id` in the subclause notifier query, preserving the `clause_arrangement` alias so the result shape and downstream formatters at lines 90 and 94 are unchanged.

## Verified locally

A PATCH to `/iso-27001/saveClauses/2` with a new owner now returns 200 and the backend stays alive — the exact scenario that previously crashed the process. TypeScript and prettier checks pass.

## Notes

The annex notifier query (line 110) uses `a.arrangement` against `annex_struct_iso27001`, which **does** have an `arrangement` column. That path was always working and is left untouched.

Discovered while reviewing the ISO/NIST clear-option PR (#3834). Pre-existing on develop.