### PR TITLE
Fix(ai): Use Chat Completions for non-OpenAI providers in AI SDK calls

### DIFF
--- a/Servers/advisor/aiSdkAgent.ts
+++ b/Servers/advisor/aiSdkAgent.ts
@@ -62,13 +62,19 @@ function createModel(
     return anthropic(params.model);
   }
 
-  // OpenAI, OpenRouter, and Custom all use the OpenAI-compatible interface
+  // OpenAI, OpenRouter, and Custom all use the OpenAI-compatible interface.
+  // Only native OpenAI implements the Responses API — OpenRouter and most
+  // OpenAI-compatible servers only implement Chat Completions, so force
+  // .chat() for them. Calling openai(model) defaults to Responses in v3.
   const openai = createOpenAI({
     apiKey: params.apiKey,
     baseURL: params.baseURL,
     headers: params.headers,
   });
-  return openai(params.model);
+  if (params.provider === "OpenAI") {
+    return openai(params.model);
+  }
+  return openai.chat(params.model);
 }
 
 /**

--- a/Servers/services/intakeLLM.service.ts
+++ b/Servers/services/intakeLLM.service.ts
@@ -36,11 +36,15 @@ async function getModelFromKey(llmKeyId: number, organizationId: number) {
     return anthropic((llmKey as any).model || "claude-sonnet-4-20250514");
   }
 
+  const customBaseURL = (llmKey as any).url || undefined;
   const openai = createOpenAI({
     apiKey: (llmKey as any).key,
-    baseURL: (llmKey as any).url || undefined,
+    baseURL: customBaseURL,
   });
-  return openai((llmKey as any).model || "gpt-4o-mini");
+  const modelId = (llmKey as any).model || "gpt-4o-mini";
+  // Only native OpenAI implements the Responses API. Any custom baseURL
+  // (OpenRouter, vLLM, Together, etc.) must use Chat Completions.
+  return customBaseURL ? openai.chat(modelId) : openai(modelId);
 }
 
 // ============================================================================

--- a/Servers/services/intakeRiskScoring.service.ts
+++ b/Servers/services/intakeRiskScoring.service.ts
@@ -393,11 +393,15 @@ For each dimension, provide a refined score adjustment (-15 to +15). Respond ONL
       });
       model = anthropic((llmKey as any).model || "claude-sonnet-4-20250514");
     } else {
+      const customBaseURL = (llmKey as any).url || undefined;
       const openai = createOpenAI({
         apiKey: (llmKey as any).key,
-        baseURL: (llmKey as any).url || undefined,
+        baseURL: customBaseURL,
       });
-      model = openai((llmKey as any).model || "gpt-4o-mini");
+      const modelId = (llmKey as any).model || "gpt-4o-mini";
+      // Only native OpenAI implements the Responses API. Any custom baseURL
+      // (OpenRouter, vLLM, Together, etc.) must use Chat Completions.
+      model = customBaseURL ? openai.chat(modelId) : openai(modelId);
     }
 
     const result = await generateText({

--- a/Servers/services/reporting/aiSummarizer.ts
+++ b/Servers/services/reporting/aiSummarizer.ts
@@ -50,12 +50,16 @@ async function getModelFromKey(llmKeyId: number | undefined, organizationId: num
     return anthropic((llmKey as any).model || "claude-sonnet-4-20250514");
   }
 
+  const customBaseURL = (llmKey as any).url || undefined;
   const openai = createOpenAI({
     apiKey: (llmKey as any).key,
-    baseURL: (llmKey as any).url || undefined,
+    baseURL: customBaseURL,
     headers: (llmKey as any).custom_headers || undefined,
   });
-  return openai((llmKey as any).model || "gpt-4o-mini");
+  const modelId = (llmKey as any).model || "gpt-4o-mini";
+  // Only native OpenAI implements the Responses API. Any custom baseURL
+  // (OpenRouter, vLLM, Together, etc.) must use Chat Completions.
+  return customBaseURL ? openai.chat(modelId) : openai(modelId);
 }
 
 // ============================================================================


### PR DESCRIPTION
## Describe your changes

The AI advisor and three intake/reporting services were calling `openai(model)` on `@ai-sdk/openai v3`, which now defaults to the Responses API endpoint. OpenRouter and other OpenAI-compatible servers only implement Chat Completions, so requests were failing with Invalid Responses API request.

## Please ensure all items are checked off before requesting a review:

- [x] I deployed the code locally.
- [x] I have performed a self-review of my code.
- [ ] I have included the issue # in the PR.
- [x] I have labelled the PR correctly.
- [x] The issue I am working on is assigned to me.
- [x] I have avoided using hardcoded values to ensure scalability and maintain consistency across the application.
- [x] I have ensured that font sizes, color choices, and other UI elements are referenced from the theme.
- [x] My pull request is focused and addresses a single, specific feature.
- [ ] If there are UI changes, I have attached a screenshot or video to this PR.
