### PR TITLE
docs: link CodeRules from CLAUDE.md reference tables

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,6 @@
 # VerifyWise - Development Guide
 
-> **Last Updated:** 2026-03-25
+> **Last Updated:** 2026-05-05
 
 This document contains cross-cutting rules for the VerifyWise codebase. Directory-scoped guides load automatically when working in each area:
 
@@ -168,7 +168,8 @@ Read the relevant file BEFORE implementing changes in that area:
 |---------------------|---------------|
 | Adding a new feature (full guide) | `docs/technical/guides/adding-new-feature.md` |
 | Adding a new framework | `docs/technical/guides/adding-new-framework.md` |
-| Code style | `docs/technical/guides/code-style.md` |
+| Code style (short version) | `docs/technical/guides/code-style.md` |
+| Detailed coding standards (TS, React, backend, security, testing) | `CodeRules/README.md` |
 | Plugin system | `docs/technical/infrastructure/plugin-system.md` |
 | Approval workflows | `docs/technical/domains/approvals.md` |
 | AI Detection | `docs/technical/domains/ai-detection.md` |

--- a/Clients/CLAUDE.md
+++ b/Clients/CLAUDE.md
@@ -1,6 +1,6 @@
 # Clients — Frontend Development Guide
 
-> **Last Updated:** 2026-03-24
+> **Last Updated:** 2026-05-05
 
 ---
 
@@ -70,5 +70,7 @@ Read the relevant file BEFORE implementing changes in that area:
 | Frontend styling                    | `docs/technical/frontend/styling.md`          |
 | Frontend components                 | `docs/technical/frontend/components.md`       |
 | Redux, Axios, frontend architecture | `docs/technical/frontend/overview.md`         |
+| TypeScript standards & naming       | `CodeRules/02-typescript/`                    |
+| React component & hook conventions  | `CodeRules/03-react/`                         |
 
 > All `docs/` paths are relative to the repository root.

--- a/Servers/CLAUDE.md
+++ b/Servers/CLAUDE.md
@@ -1,6 +1,6 @@
 # Servers — Backend Development Guide
 
-> **Last Updated:** 2026-03-24
+> **Last Updated:** 2026-05-05
 
 ---
 
@@ -167,7 +167,9 @@ Read the relevant file BEFORE implementing changes in that area:
 | Adding a new feature (full guide)         | `docs/technical/guides/adding-new-feature.md`     |
 | Adding a new framework                    | `docs/technical/guides/adding-new-framework.md`   |
 | API conventions                           | `docs/technical/guides/api-conventions.md`        |
-| Code style                                | `docs/technical/guides/code-style.md`             |
+| Code style (short version)                | `docs/technical/guides/code-style.md`             |
+| Detailed backend coding standards         | `CodeRules/04-backend/`                           |
+| TypeScript standards & naming             | `CodeRules/02-typescript/`                        |
 | API routes & endpoints                    | `docs/technical/api/endpoints.md`                 |
 | Background jobs (BullMQ)                  | `docs/technical/infrastructure/automations.md`    |
 | Email templates (MJML)                    | `docs/technical/infrastructure/email-service.md`  |


### PR DESCRIPTION
## Summary

CodeRules/ holds the detailed coding standards (TS, React, backend, security, testing) but was only mentioned once in the root CLAUDE.md under Additional Resources, easy to miss. This adds explicit rows to the Detailed References tables in all three CLAUDE.md files so the standards are discoverable from the same place every other guide is linked.

## Changes

- Root CLAUDE.md: add CodeRules/README.md row; label code-style.md as the short version.
- Clients/CLAUDE.md: link CodeRules/02-typescript and 03-react.
- Servers/CLAUDE.md: link CodeRules/04-backend and 02-typescript; label code-style.md as short version.
- Bump Last Updated dates on all three files.