### PR TITLE
refactor(avatar): migrate raw MUI Avatar to VWAvatar in Activity and HistorySidebar

### DIFF
--- a/Clients/src/presentation/components/ModelInventoryHistory/HistorySidebar.tsx
+++ b/Clients/src/presentation/components/ModelInventoryHistory/HistorySidebar.tsx
@@ -1,13 +1,6 @@
 import React from "react";
-import {
-  Box,
-  Typography,
-  Stack,
-  CircularProgress,
-  useTheme,
-  Collapse,
-  Avatar,
-} from "@mui/material";
+import { Box, Typography, Stack, CircularProgress, useTheme, Collapse } from "@mui/material";
+import VWAvatar from "../Avatar/VWAvatar";
 import { Clock } from "lucide-react";
 import {
   useModelInventoryChangeHistory,
@@ -194,19 +187,15 @@ const HistorySidebar: React.FC<HistorySidebarProps> = ({ isOpen, modelInventoryI
       >
         {/* Header */}
         <Stack direction="row" gap="8px" alignItems="center" marginBottom="8px">
-          <Avatar
-            src={avatarUrls[firstEntry.changed_by_user_id] || undefined}
-            alt={userName}
-            sx={{
-              width: 28,
-              height: 28,
-              backgroundColor: theme.palette.primary.main,
-              fontSize: 11,
-              fontWeight: 600,
+          <VWAvatar
+            user={{
+              firstname: firstEntry.user_name || userName,
+              lastname: firstEntry.user_surname || "",
+              pathToImage: avatarUrls[firstEntry.changed_by_user_id] || undefined,
             }}
-          >
-            {userName.charAt(0).toUpperCase()}
-          </Avatar>
+            size="small"
+            showBorder={false}
+          />
           <Box sx={{ flex: 1 }}>
             <Typography
               sx={{

--- a/Clients/src/presentation/pages/ProjectView/Activity/index.tsx
+++ b/Clients/src/presentation/pages/ProjectView/Activity/index.tsx
@@ -4,7 +4,8 @@
  */
 
 import React from "react";
-import { Box, Typography, Stack, CircularProgress, useTheme, Avatar } from "@mui/material";
+import { Box, Typography, Stack, CircularProgress, useTheme } from "@mui/material";
+import VWAvatar from "../../../components/Avatar/VWAvatar";
 import { Clock } from "lucide-react";
 import {
   useEntityChangeHistory,
@@ -221,19 +222,15 @@ const Activity: React.FC<ActivityProps> = ({ entityType, entityId }) => {
         }}
       >
         <Stack direction="row" gap="12px" alignItems="center" marginBottom="16px">
-          <Avatar
-            src={avatarUrls[firstEntry.changed_by_user_id] || undefined}
-            alt={userName}
-            sx={{
-              width: 36,
-              height: 36,
-              backgroundColor: theme.palette.primary.main,
-              fontSize: 14,
-              fontWeight: 600,
+          <VWAvatar
+            user={{
+              firstname: firstEntry.user_name || userName,
+              lastname: firstEntry.user_surname || "",
+              pathToImage: avatarUrls[firstEntry.changed_by_user_id] || undefined,
             }}
-          >
-            {userName.charAt(0).toUpperCase()}
-          </Avatar>
+            size="small"
+            showBorder={false}
+          />
           <Box sx={{ flex: 1 }}>
             <Typography
               sx={{


### PR DESCRIPTION
## Describe your changes

- ProjectView/Activity/index.tsx — migrated user avatar in the project activity feed to VWAvatar
- ModelInventoryHistory/HistorySidebar.tsx — migrated user avatar in the model change history sidebar to VWAvatar

Why
Raw Avatar from MUI was used directly instead of the design system wrapper. VWAvatar ensures consistent sizing, theming, and initials fallback across all user identity surfaces.

## Write your issue number after "Fixes "

Fixes #3848 

## Please ensure all items are checked off before requesting a review:

- [ ] I deployed the code locally.
- [ ] I have performed a self-review of my code.
- [ ] I have included the issue # in the PR.
- [ ] I have labelled the PR correctly.
- [ ] The issue I am working on is assigned to me.
- [ ] I have avoided using hardcoded values to ensure scalability and maintain consistency across the application.
- [ ] I have ensured that font sizes, color choices, and other UI elements are referenced from the theme.
- [ ] My pull request is focused and addresses a single, specific feature.
- [ ] If there are UI changes, I have attached a screenshot or video to this PR.

<img width="344" height="374" alt="Screenshot 2026-05-07 at 5 35 10 PM" src="https://github.com/user-attachments/assets/dc7fb1e3-2b11-4b85-897d-7e88e4c52615" />

<img width="360" height="280" alt="Screenshot 2026-05-07 at 5 49 45 PM" src="https://github.com/user-attachments/assets/a810e934-3a48-49f6-85c2-5ade9f8ab9f4" />

