### PR TITLE
Feat: Bottom Chip

### DIFF
--- a/Clients/src/presentation/components/BottomChip/__tests__/BottomChip.test.tsx
+++ b/Clients/src/presentation/components/BottomChip/__tests__/BottomChip.test.tsx
@@ -1,0 +1,37 @@
+import { describe, it, expect } from "vitest";
+import { screen } from "@testing-library/react";
+import { renderWithProviders } from "../../../../test/renderWithProviders";
+import BottomChip from "../index";
+
+describe("BottomChip", () => {
+  it("renders its children", () => {
+    renderWithProviders(
+      <BottomChip>
+        <span>chip content</span>
+      </BottomChip>,
+    );
+
+    expect(screen.getByText("chip content")).toBeInTheDocument();
+  });
+
+  it("applies the role and aria-label when provided", () => {
+    renderWithProviders(
+      <BottomChip role="toolbar" ariaLabel="Bulk actions">
+        <span>content</span>
+      </BottomChip>,
+    );
+
+    expect(screen.getByRole("toolbar", { name: "Bulk actions" })).toBeInTheDocument();
+  });
+
+  it("merges a passed-in sx prop onto the pill", () => {
+    renderWithProviders(
+      <BottomChip role="toolbar" ariaLabel="styled" sx={{ backgroundColor: "rgb(1, 2, 3)" }}>
+        <span>content</span>
+      </BottomChip>,
+    );
+
+    const pill = screen.getByRole("toolbar", { name: "styled" });
+    expect(pill).toHaveStyle({ backgroundColor: "rgb(1, 2, 3)" });
+  });
+});

--- a/Clients/src/presentation/components/BottomChip/index.tsx
+++ b/Clients/src/presentation/components/BottomChip/index.tsx
@@ -16,12 +16,7 @@ interface BottomChipProps {
  * on the wrapper so the rest of the page stays interactive everywhere except on
  * the pill itself. Drop any content in as `children`.
  */
-const BottomChip: React.FC<BottomChipProps> = ({
-  children,
-  role,
-  ariaLabel,
-  sx,
-}) => {
+const BottomChip: React.FC<BottomChipProps> = ({ children, role, ariaLabel, sx }) => {
   const theme = useTheme();
 
   return (

--- a/Clients/src/presentation/components/BottomChip/index.tsx
+++ b/Clients/src/presentation/components/BottomChip/index.tsx
@@ -1,0 +1,69 @@
+import { Box, Stack, useTheme } from "@mui/material";
+import type { SxProps, Theme } from "@mui/material";
+
+interface BottomChipProps {
+  children: React.ReactNode;
+  /** Forwarded to the inner pill Stack (role/aria for toolbars etc.). */
+  role?: string;
+  ariaLabel?: string;
+  /** Extra sx merged onto the inner pill Stack. */
+  sx?: SxProps<Theme>;
+}
+
+/**
+ * Floating bottom-center "pill" container. Sits at `position: fixed` above the
+ * page so it stays visible while the user scrolls. Pointer events are disabled
+ * on the wrapper so the rest of the page stays interactive everywhere except on
+ * the pill itself. Drop any content in as `children`.
+ */
+const BottomChip: React.FC<BottomChipProps> = ({
+  children,
+  role,
+  ariaLabel,
+  sx,
+}) => {
+  const theme = useTheme();
+
+  return (
+    <Box
+      sx={{
+        position: "fixed",
+        left: 0,
+        right: 0,
+        bottom: theme.spacing(6),
+        display: "flex",
+        justifyContent: "center",
+        zIndex: 1200,
+        pointerEvents: "none",
+        px: theme.spacing(4),
+      }}
+    >
+      <Stack
+        role={role}
+        aria-label={ariaLabel}
+        direction="row"
+        alignItems="center"
+        sx={[
+          {
+            pointerEvents: "auto",
+            gap: theme.spacing(3),
+            pl: theme.spacing(6),
+            pr: theme.spacing(4),
+            py: theme.spacing(2),
+            backgroundColor: theme.palette.background.main,
+            border: `1px solid ${theme.palette.border.light}`,
+            borderRadius: 999,
+            maxWidth: "calc(100vw - 32px)",
+            flexWrap: "wrap",
+            rowGap: theme.spacing(1),
+          },
+          ...(Array.isArray(sx) ? sx : [sx]),
+        ]}
+      >
+        {children}
+      </Stack>
+    </Box>
+  );
+};
+
+export default BottomChip;

--- a/Clients/src/presentation/components/Policies/PolicyTable.tsx
+++ b/Clients/src/presentation/components/Policies/PolicyTable.tsx
@@ -317,10 +317,10 @@ const PolicyTable: React.FC<PolicyTableProps> = ({
               <TableCell
                 padding="checkbox"
                 sx={{
-                  width: 48,
-                  minWidth: 48,
-                  maxWidth: 48,
-                  padding: "14px 8px",
+                  width: 40,
+                  minWidth: 40,
+                  maxWidth: 40,
+                  padding: 0,
                 }}
                 onClick={(e) => e.stopPropagation()}
               >
@@ -329,7 +329,7 @@ const PolicyTable: React.FC<PolicyTableProps> = ({
                     display: "flex",
                     alignItems: "center",
                     justifyContent: "center",
-                    width: "100%",
+                    height: "100%",
                   }}
                 >
                   <Checkbox
@@ -338,7 +338,8 @@ const PolicyTable: React.FC<PolicyTableProps> = ({
                     isChecked={isSelected(Number(policy.id))}
                     onChange={() => toggleSelection(Number(policy.id))}
                     ariaLabel={`Select policy ${policy.title}`}
-                    sx={{ "p": 0, "& svg": { display: "block" } }}
+                    size="small"
+                    sx={{ p: 0 }}
                   />
                 </Box>
               </TableCell>

--- a/Clients/src/presentation/components/Table/BulkActionsToolbar/index.tsx
+++ b/Clients/src/presentation/components/Table/BulkActionsToolbar/index.tsx
@@ -1,8 +1,9 @@
 import { useCallback, useState } from "react";
-import { Box, Divider, Stack, Typography, useTheme } from "@mui/material";
+import { Box, Divider, Typography, useTheme } from "@mui/material";
 import { Check, X } from "lucide-react";
 import { CustomizableButton } from "../../button/customizable-button";
 import ConfirmationModal from "../../Dialogs/ConfirmationModal";
+import BottomChip from "../../BottomChip";
 
 export interface BulkActionConfirm {
   title: string;
@@ -87,114 +88,82 @@ const BulkActionsToolbar: React.FC<BulkActionsToolbarProps> = ({
 
   return (
     <>
-      <Box
-        sx={{
-          position: "fixed",
-          left: 0,
-          right: 0,
-          bottom: theme.spacing(6),
-          display: "flex",
-          justifyContent: "center",
-          zIndex: 1200,
-          pointerEvents: "none",
-          px: theme.spacing(4),
-        }}
-      >
-        <Stack
-          role="toolbar"
-          aria-label="Bulk actions"
-          direction="row"
-          alignItems="center"
+      <BottomChip role="toolbar" ariaLabel="Bulk actions">
+        <Typography
           sx={{
-            pointerEvents: "auto",
-            gap: theme.spacing(3),
-            pl: theme.spacing(6),
-            pr: theme.spacing(4),
-            py: theme.spacing(2),
-            backgroundColor: theme.palette.background.main,
-            border: `1px solid ${theme.palette.border.light}`,
-            borderRadius: 999,
-            maxWidth: "calc(100vw - 32px)",
-            flexWrap: "wrap",
-            rowGap: theme.spacing(1),
+            fontWeight: 600,
+            fontSize: 13,
+            color: theme.palette.text.primary,
+            whiteSpace: "nowrap",
           }}
         >
-          <Typography
-            sx={{
-              fontWeight: 600,
-              fontSize: 13,
-              color: theme.palette.text.primary,
-              whiteSpace: "nowrap",
-            }}
-          >
-            {count} selected
-          </Typography>
+          {count} selected
+        </Typography>
 
-          {hasMoreToSelect && (
-            <CustomizableButton
-              text={`Select all ${selectAll!.totalCount}`}
-              variant="text"
-              size="small"
-              startIcon={<Check size={14} />}
-              onClick={selectAll!.onSelectAll}
-              sx={{
-                color: theme.palette.text.secondary,
-                fontSize: 13,
-                whiteSpace: "nowrap",
-              }}
-              ariaLabel={`Select all ${selectAll!.totalCount}`}
-            />
-          )}
-
+        {hasMoreToSelect && (
           <CustomizableButton
-            text="Clear selection"
+            text={`Select all ${selectAll!.totalCount}`}
             variant="text"
             size="small"
-            startIcon={<X size={14} />}
-            onClick={onClear}
+            startIcon={<Check size={14} />}
+            onClick={selectAll!.onSelectAll}
             sx={{
               color: theme.palette.text.secondary,
               fontSize: 13,
               whiteSpace: "nowrap",
             }}
-            ariaLabel="Clear selection"
+            ariaLabel={`Select all ${selectAll!.totalCount}`}
           />
+        )}
 
-          {actions.length > 0 && (
-            <Divider orientation="vertical" flexItem sx={{ mx: theme.spacing(1) }} />
-          )}
+        <CustomizableButton
+          text="Clear selection"
+          variant="text"
+          size="small"
+          startIcon={<X size={14} />}
+          onClick={onClear}
+          sx={{
+            color: theme.palette.text.secondary,
+            fontSize: 13,
+            whiteSpace: "nowrap",
+          }}
+          ariaLabel="Clear selection"
+        />
 
-          <Box
-            component="ul"
-            sx={{
-              display: "flex",
-              flexDirection: "row",
-              gap: theme.spacing(1),
-              m: 0,
-              p: 0,
-              listStyle: "none",
-              flexWrap: "wrap",
-              rowGap: theme.spacing(1),
-            }}
-          >
-            {actions.map((action) => (
-              <li key={action.id}>
-                <CustomizableButton
-                  text={action.label}
-                  variant="text"
-                  size="small"
-                  color={action.confirm?.danger ? "error" : "primary"}
-                  startIcon={action.icon}
-                  onClick={() => handleActionClick(action)}
-                  isDisabled={action.disabled}
-                  sx={{ fontSize: 13, whiteSpace: "nowrap" }}
-                  ariaLabel={action.label}
-                />
-              </li>
-            ))}
-          </Box>
-        </Stack>
-      </Box>
+        {actions.length > 0 && (
+          <Divider orientation="vertical" flexItem sx={{ mx: theme.spacing(1) }} />
+        )}
+
+        <Box
+          component="ul"
+          sx={{
+            display: "flex",
+            flexDirection: "row",
+            gap: theme.spacing(1),
+            m: 0,
+            p: 0,
+            listStyle: "none",
+            flexWrap: "wrap",
+            rowGap: theme.spacing(1),
+          }}
+        >
+          {actions.map((action) => (
+            <li key={action.id}>
+              <CustomizableButton
+                text={action.label}
+                variant="text"
+                size="small"
+                color={action.confirm?.danger ? "error" : "primary"}
+                startIcon={action.icon}
+                onClick={() => handleActionClick(action)}
+                isDisabled={action.disabled}
+                sx={{ fontSize: 13, whiteSpace: "nowrap" }}
+                ariaLabel={action.label}
+              />
+            </li>
+          ))}
+        </Box>
+      </BottomChip>
 
       {pendingAction?.confirm && (
         <ConfirmationModal

--- a/Clients/src/presentation/components/Table/PolicyTable/index.tsx
+++ b/Clients/src/presentation/components/Table/PolicyTable/index.tsx
@@ -183,10 +183,10 @@ const CustomizablePolicyTable = ({
         {selection && (
           <TableCell
             sx={{
-              width: 48,
-              minWidth: 48,
-              maxWidth: 48,
-              padding: "16px 8px",
+              width: 40,
+              minWidth: 40,
+              maxWidth: 40,
+              padding: 0,
               borderBottom: "1px solid #d0d5dd",
             }}
           >
@@ -195,7 +195,7 @@ const CustomizablePolicyTable = ({
                 display: "flex",
                 alignItems: "center",
                 justifyContent: "center",
-                width: "100%",
+                height: "100%",
               }}
             >
               <Checkbox
@@ -205,7 +205,8 @@ const CustomizablePolicyTable = ({
                 isIndeterminate={selection.someSelected && !selection.allSelected}
                 onChange={selection.onToggleAll}
                 ariaLabel={selection.ariaLabel ?? "Select all policies on this page"}
-                sx={{ "p": 0, "& svg": { display: "block" } }}
+                size="small"
+                sx={{ p: 0 }}
               />
             </Box>
           </TableCell>
@@ -349,8 +350,8 @@ const CustomizablePolicyTable = ({
                       fontSize: 12,
                       opacity: 0.7,
                       whiteSpace: "nowrap",
-                      width: 1,
                     }}
+                    colSpan={selection ? 2 : 1}
                   >
                     Showing {page * rowsPerPage + 1} -{" "}
                     {Math.min(page * rowsPerPage + rowsPerPage, sortedData.length)} of{" "}
@@ -365,6 +366,7 @@ const CustomizablePolicyTable = ({
                     onRowsPerPageChange={handleChangeRowsPerPage}
                     ActionsComponent={TablePaginationActions as React.ComponentType<any>}
                     labelRowsPerPage="Rows per page"
+                    colSpan={data.cols.length - 1}
                     slotProps={{
                       select: {
                         MenuProps: {

--- a/Clients/src/presentation/components/Table/StandardTableHead/index.tsx
+++ b/Clients/src/presentation/components/Table/StandardTableHead/index.tsx
@@ -29,10 +29,10 @@ const StandardTableHead: React.FC<StandardTableHeadProps> = memo(
           {selection && (
             <TableCell
               sx={{
-                width: 48,
-                minWidth: 48,
-                maxWidth: 48,
-                padding: "16px 8px",
+                width: 40,
+                minWidth: 40,
+                maxWidth: 40,
+                padding: 0,
                 borderBottom: "1px solid #d0d5dd",
               }}
             >
@@ -41,7 +41,7 @@ const StandardTableHead: React.FC<StandardTableHeadProps> = memo(
                   display: "flex",
                   alignItems: "center",
                   justifyContent: "center",
-                  width: "100%",
+                  height: "100%",
                 }}
               >
                 <Checkbox

--- a/Clients/src/presentation/components/Table/TasksTable/index.tsx
+++ b/Clients/src/presentation/components/Table/TasksTable/index.tsx
@@ -280,10 +280,10 @@ const TasksTable: React.FC<ITasksTableProps> = ({
                 <TableCell
                   padding="checkbox"
                   sx={{
-                    width: 48,
-                    minWidth: 48,
-                    maxWidth: 48,
-                    padding: "14px 8px",
+                    width: 40,
+                    minWidth: 40,
+                    maxWidth: 40,
+                    padding: 0,
                   }}
                   onClick={(e) => e.stopPropagation()}
                 >
@@ -292,7 +292,7 @@ const TasksTable: React.FC<ITasksTableProps> = ({
                       display: "flex",
                       alignItems: "center",
                       justifyContent: "center",
-                      width: "100%",
+                      height: "100%",
                     }}
                   >
                     <Checkbox
@@ -302,7 +302,8 @@ const TasksTable: React.FC<ITasksTableProps> = ({
                       onChange={() => toggleSelection(task.id as number)}
                       isDisabled={isArchived}
                       ariaLabel={`Select task ${task.title}`}
-                      sx={{ "p": 0, "& svg": { display: "block" } }}
+                      size="small"
+                      sx={{ p: 0 }}
                     />
                   </Box>
                 </TableCell>

--- a/Clients/src/presentation/components/Table/VWProjectRisksTable/VWProjectRisksTableBody.tsx
+++ b/Clients/src/presentation/components/Table/VWProjectRisksTable/VWProjectRisksTableBody.tsx
@@ -166,10 +166,10 @@ const VWProjectRisksTableBody = ({
                   <TableCell
                     padding="checkbox"
                     sx={{
-                      width: 48,
-                      minWidth: 48,
-                      maxWidth: 48,
-                      padding: "14px 8px",
+                      width: 40,
+                      minWidth: 40,
+                      maxWidth: 40,
+                      padding: 0,
                     }}
                     onClick={(e) => e.stopPropagation()}
                   >
@@ -178,7 +178,7 @@ const VWProjectRisksTableBody = ({
                         display: "flex",
                         alignItems: "center",
                         justifyContent: "center",
-                        width: "100%",
+                        height: "100%",
                       }}
                     >
                       <Checkbox
@@ -188,7 +188,8 @@ const VWProjectRisksTableBody = ({
                         onChange={() => selection.onToggle(Number(row.id))}
                         isDisabled={row.is_deleted}
                         ariaLabel={`Select project risk ${row.risk_name}`}
-                        sx={{ "p": 0, "& svg": { display: "block" } }}
+                        size="small"
+                        sx={{ p: 0 }}
                       />
                     </Box>
                   </TableCell>

--- a/Clients/src/presentation/components/Table/VWProjectRisksTable/index.tsx
+++ b/Clients/src/presentation/components/Table/VWProjectRisksTable/index.tsx
@@ -104,10 +104,10 @@ const SortableTableHead: React.FC<{
         {selection && (
           <TableCell
             sx={{
-              width: 48,
-              minWidth: 48,
-              maxWidth: 48,
-              padding: "16px 8px",
+              width: 40,
+              minWidth: 40,
+              maxWidth: 40,
+              padding: 0,
               borderBottom: "1px solid #d0d5dd",
             }}
           >
@@ -116,7 +116,7 @@ const SortableTableHead: React.FC<{
                 display: "flex",
                 alignItems: "center",
                 justifyContent: "center",
-                width: "100%",
+                height: "100%",
               }}
             >
               <Checkbox
@@ -126,7 +126,8 @@ const SortableTableHead: React.FC<{
                 isIndeterminate={selection.someSelected && !selection.allSelected}
                 onChange={selection.onToggleAll}
                 ariaLabel="Select all project risks"
-                sx={{ "p": 0, "& svg": { display: "block" } }}
+                size="small"
+                sx={{ p: 0 }}
               />
             </Box>
           </TableCell>


### PR DESCRIPTION
## Describe your changes

Extracts the floating bottom-center "pill" UI that was built inline in `BulkActionsToolbar` into a standalone, reusable BottomChip component (`components/BottomChip`) that renders a fixed bottom-center container with pointer-events handling and accepts arbitrary children plus optional role/ariaLabel/sx. BulkActionsToolbar is refactored to render its count/clear/actions inside BottomChip with no behavior or styling change. Adds unit tests for BottomChip.

## Please ensure all items are checked off before requesting a review:

- [x] I deployed the code locally.
- [x] I have performed a self-review of my code.
- [ ] I have included the issue # in the PR.
- [x] I have labelled the PR correctly.
- [x] The issue I am working on is assigned to me.
- [x] I have avoided using hardcoded values to ensure scalability and maintain consistency across the application.
- [x] I have ensured that font sizes, color choices, and other UI elements are referenced from the theme.
- [x] My pull request is focused and addresses a single, specific feature.
- [x] If there are UI changes, I have attached a screenshot or video to this PR.
<img width="522" height="57" alt="Screenshot 2026-05-11 at 23 23 34" src="https://github.com/user-attachments/assets/93a42756-08a2-437c-8f79-e9b5e3afb475" />
