### PR TITLE
fix(i18n): add missing de/fr translations for training and policy form

### DIFF
--- a/Clients/src/i18n/translations.ts
+++ b/Clients/src/i18n/translations.ts
@@ -7742,6 +7742,31 @@ export const translations: Record<string, Record<string, string>> = {
     "Training Evidence Hub": "Schulungsnachweiszentrale",
     "Upload certificates, attendance proofs, or other compliance evidence for this training.":
       "Laden Sie Zertifikate, Anwesenheitsnachweise oder andere Compliance-Nachweise für diese Schulung hoch.",
+
+    // Training & evidence modals
+    "Edit training": "Schulung bearbeiten",
+    "Update training": "Schulung aktualisieren",
+    "Create training": "Schulung erstellen",
+    "Edit training evidence": "Schulungsnachweis bearbeiten",
+    "Upload training evidence": "Schulungsnachweis hochladen",
+    "Update evidence": "Nachweis aktualisieren",
+    "Save evidence": "Nachweis speichern",
+    "Add more files": "Weitere Dateien hinzufügen",
+    "Upload files": "Dateien hochladen",
+    "Status is required.": "Status ist erforderlich.",
+    "Number of people is required and must be a positive number.":
+      "Personenanzahl ist erforderlich und muss eine positive Zahl sein.",
+    "Evidence name is required": "Nachweisname ist erforderlich",
+    "Please upload at least one file": "Bitte laden Sie mindestens eine Datei hoch",
+    "Please select a training": "Bitte wählen Sie eine Schulung",
+    "Record and manage your organization's AI literacy and compliance trainings. Enter training details such as name, provider, duration, department, participants, and status to keep a clear history of all AI-related education initiatives.":
+      "Erfassen und verwalten Sie die KI-Kompetenz- und Compliance-Schulungen Ihrer Organisation. Geben Sie Schulungsdetails wie Name, Anbieter, Dauer, Abteilung, Teilnehmer und Status ein, um einen klaren Verlauf aller KI-bezogenen Bildungsinitiativen zu führen.",
+
+    // Policy form
+    "Under Review": "In Überprüfung",
+    "All members selected": "Alle Mitglieder ausgewählt",
+    "No options": "Keine Optionen",
+    "All tags selected": "Alle Tags ausgewählt",
   },
 
   fr: {
@@ -15413,5 +15438,30 @@ export const translations: Record<string, Record<string, string>> = {
     "Training Evidence Hub": "Centre de preuves de formation",
     "Upload certificates, attendance proofs, or other compliance evidence for this training.":
       "Téléversez des certificats, des justificatifs de présence ou d'autres preuves de conformité pour cette formation.",
+
+    // Training & evidence modals
+    "Edit training": "Modifier la formation",
+    "Update training": "Mettre à jour la formation",
+    "Create training": "Créer la formation",
+    "Edit training evidence": "Modifier la preuve de formation",
+    "Upload training evidence": "Téléverser une preuve de formation",
+    "Update evidence": "Mettre à jour la preuve",
+    "Save evidence": "Enregistrer la preuve",
+    "Add more files": "Ajouter d'autres fichiers",
+    "Upload files": "Téléverser des fichiers",
+    "Status is required.": "Le statut est requis.",
+    "Number of people is required and must be a positive number.":
+      "Le nombre de personnes est requis et doit être un nombre positif.",
+    "Evidence name is required": "Le nom de la preuve est requis",
+    "Please upload at least one file": "Veuillez téléverser au moins un fichier",
+    "Please select a training": "Veuillez sélectionner une formation",
+    "Record and manage your organization's AI literacy and compliance trainings. Enter training details such as name, provider, duration, department, participants, and status to keep a clear history of all AI-related education initiatives.":
+      "Enregistrez et gérez les formations à la culture de l'IA et à la conformité de votre organisation. Saisissez les détails de la formation tels que le nom, le fournisseur, la durée, le service, les participants et le statut afin de conserver un historique clair de toutes les initiatives de formation liées à l'IA.",
+
+    // Policy form
+    "Under Review": "En cours de révision",
+    "All members selected": "Tous les membres sélectionnés",
+    "No options": "Aucune option",
+    "All tags selected": "Toutes les étiquettes sélectionnées",
   },
 };


### PR DESCRIPTION
## Summary
- Adds 19 missing German and French translation keys for strings introduced in recent `NewTraining`, `NewTrainingEvidence`, and `PolicyForm` changes.
- Covers modal titles, button labels (Edit/Update/Create training, Save/Update evidence), file upload labels, validation messages, and the long training description.
- Also fills gaps in PolicyForm autocomplete labels ("Under Review", "All members selected", "No options", "All tags selected").

The DOM-based translator (`Clients/src/i18n/domTranslator.ts`) auto-translates any text/attribute that matches a key in `translations.ts`. These additions complete coverage for the strings shipped over the past week so non-English users no longer see English fall-through in these views.