### PR TITLE
docs(user-guide): document training evidence upload and policy owner field

### DIFF
--- a/shared/user-guide-content/content/policies/policy-management.ts
+++ b/shared/user-guide-content/content/policies/policy-management.ts
@@ -104,9 +104,11 @@ export const policyManagementContent: ArticleContent = {
       items: [
         { text: 'Click "Add new policy" in the organizational policies tab' },
         { text: 'Enter a title that clearly describes the policy\'s purpose' },
+        { text: 'Assign a policy owner who is accountable for the policy' },
         { text: 'Write or paste the policy content using the rich text editor' },
         { text: 'Select relevant tags to categorize the policy' },
         { text: 'Set the initial status (typically Draft)' },
+        { text: 'Optionally add team members as reviewers' },
         { text: 'Optionally set a next review date' },
         { text: 'Save the policy' },
       ],
@@ -130,10 +132,12 @@ export const policyManagementContent: ArticleContent = {
     {
       type: 'bullet-list',
       items: [
-        { bold: 'Title', text: 'A clear, descriptive name for the policy' },
+        { bold: 'Title', text: 'A clear, descriptive name for the policy (up to 128 characters)' },
+        { bold: 'Policy owner', text: 'The person accountable for the policy. Owners cannot also be assigned as reviewers on the same policy.' },
         { bold: 'Content', text: 'The full policy text with rich formatting support' },
         { bold: 'Status', text: 'Current lifecycle stage (Draft, Under review, Approved, Published, Archived, Deprecated)' },
         { bold: 'Tags', text: 'Categories like AI ethics, Privacy, Security, EU AI Act, ISO 42001, etc.' },
+        { bold: 'Team members', text: 'Reviewers assigned to evaluate the policy. The policy owner is excluded from this list.' },
         { bold: 'Next review date', text: 'When the policy should be reviewed for updates' },
         { bold: 'Author', text: 'The person who created the policy' },
         { bold: 'Last updated', text: 'When the policy was most recently modified' },

--- a/shared/user-guide-content/content/training/training-tracking.ts
+++ b/shared/user-guide-content/content/training/training-tracking.ts
@@ -188,6 +188,59 @@ export const trainingTrackingContent: ArticleContent = {
     },
     {
       type: 'heading',
+      id: 'uploading-evidence',
+      level: 2,
+      text: 'Uploading training evidence',
+    },
+    {
+      type: 'paragraph',
+      text: 'Each training record has an Evidence tab where you can attach supporting documents such as certificates, attendance records and assessment results. This gives auditors direct proof that the training actually took place and that participants completed it.',
+    },
+    {
+      type: 'paragraph',
+      text: 'To upload evidence:',
+    },
+    {
+      type: 'ordered-list',
+      items: [
+        { text: 'Open a training record and switch to the Evidence tab' },
+        { text: 'Click "Upload evidence"' },
+        { text: 'Enter an evidence name that identifies the document' },
+        { text: 'Choose an evidence type (see the list below)' },
+        { text: 'Optionally add a description with notes about the evidence' },
+        { text: 'Optionally set an expiry date for time-sensitive evidence such as certifications' },
+        { text: 'Drag and drop files into the upload area, or click to browse' },
+        { text: 'Save the evidence' },
+      ],
+    },
+    {
+      type: 'heading',
+      id: 'evidence-types',
+      level: 3,
+      text: 'Evidence types',
+    },
+    {
+      type: 'bullet-list',
+      items: [
+        { bold: 'Training certificate', text: 'A formal certificate of completion issued by the training provider' },
+        { bold: 'Attendance record', text: 'A sign-in sheet, register or other proof that participants attended' },
+        { bold: 'Course completion', text: 'A summary report confirming the course was finished' },
+        { bold: 'Assessment result', text: 'Test or quiz results showing participants met the required level' },
+        { bold: 'Other', text: 'Any other supporting documentation that does not fit the categories above' },
+      ],
+    },
+    {
+      type: 'callout',
+      variant: 'tip',
+      title: 'Set expiry dates for renewable certifications',
+      text: 'When evidence covers a certification that expires (for example, an annual AI ethics training certificate), set the expiry date so you get a reminder when renewal is needed.',
+    },
+    {
+      type: 'paragraph',
+      text: 'You can upload multiple files per evidence record. Use "Add more files" to attach additional documents, or remove individual files before saving. To remove or replace evidence later, open the training record and use the delete action next to each evidence entry.',
+    },
+    {
+      type: 'heading',
       id: 'common-training-types',
       level: 2,
       text: 'Common AI training topics',


### PR DESCRIPTION
## Summary
- Adds a new "Uploading training evidence" section to the training registry guide, covering the Evidence tab, the five evidence types (Training certificate, Attendance record, Course completion, Assessment result, Other), expiry date reminders, and multi-file uploads.
- Updates the policy management guide to document the new Policy owner field and Team members (reviewers), including the mutual-exclusion rule (an owner cannot also be a reviewer on the same policy). Bumps the documented title limit to 128 characters.

Mirrors the same changes into the website user-guide content directory (separate, manual commit by the user).