### PR TITLE
perf(loader): inline splash and prune heavy chunks from modulepreload

### DIFF
--- a/Clients/index.html
+++ b/Clients/index.html
@@ -84,7 +84,7 @@
       }
     </style>
     <div id="root">
-      <div id="vw-splash" aria-hidden="true">
+      <div id="vw-splash" role="status" aria-live="polite" aria-label="Loading">
         <div class="vw-spinner"></div>
       </div>
     </div>

--- a/Clients/index.html
+++ b/Clients/index.html
@@ -49,7 +49,45 @@
         document.documentElement.classList.add("dark-mode");
       }
     </script>
-    <div id="root"></div>
+    <style>
+      #vw-splash {
+        position: fixed;
+        inset: 0;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        background: #fafafa;
+        z-index: 9999;
+        font-family:
+          Inter,
+          -apple-system,
+          BlinkMacSystemFont,
+          "Segoe UI",
+          Roboto,
+          sans-serif;
+      }
+      .dark-mode #vw-splash {
+        background: #0f1419;
+      }
+      #vw-splash .vw-spinner {
+        width: 32px;
+        height: 32px;
+        border: 3px solid rgba(19, 113, 91, 0.15);
+        border-top-color: #13715b;
+        border-radius: 50%;
+        animation: vw-spin 0.8s linear infinite;
+      }
+      @keyframes vw-spin {
+        to {
+          transform: rotate(360deg);
+        }
+      }
+    </style>
+    <div id="root">
+      <div id="vw-splash" aria-hidden="true">
+        <div class="vw-spinner"></div>
+      </div>
+    </div>
     <script type="module" src="/src/main.tsx"></script>
   </body>
 </html>

--- a/Clients/vite.config.ts
+++ b/Clients/vite.config.ts
@@ -35,6 +35,12 @@ export default defineConfig({
     manifest: true,
     chunkSizeWarningLimit: 600,
     cssCodeSplit: true,
+    modulePreload: {
+      // Drop heavy chunks that aren't needed for first paint (charts, rich-text editor,
+      // xlsx) so they don't compete with the critical-path bundle download.
+      resolveDependencies: (_filename, deps) =>
+        deps.filter((d) => !/vendor-charts|vendor-editor|xlsx|ExportMenu/.test(d)),
+    },
     rollupOptions: {
       output: {
         // Add hash to filenames for cache busting


### PR DESCRIPTION
## Summary
- Inline a tiny splash spinner inside `#root` in `index.html` so the visible white-screen is replaced by a centered spinner that paints immediately, before any JS executes. The splash uses VerifyWise primary color (#13715b) and respects dark mode. React replaces it on mount.
- Add `build.modulePreload.resolveDependencies` in `vite.config.ts` to drop `vendor-charts`, `vendor-editor`, `xlsx`, and `ExportMenu` from the modulepreload list. These chunks are only needed deep inside specific pages (policy editor, exports) and were competing for bandwidth with the critical-path bundles on first paint.

## Why
On `test.verifywise.ai` the browser downloads ~1.7 MB of JS over the wire before React can mount. The most visible symptom is a white screen for a few seconds. Two issues compound it:

1. The HTML body is `<div id="root"></div>` — nothing paints until React mounts.
2. The modulepreload list eagerly fetches recharts (~162 KB gzipped) and tiptap (~139 KB gzipped) on every page load, even though almost no first-paint screen uses them.

This PR addresses both with minimal risk.

## Expected impact
- Eliminates the perceived white screen (LCP improves even if total TTI is unchanged).
- Frees ~301 KB of competing gzipped bandwidth at first paint, helping the critical chunks land faster.