### PR TITLE
refactor(evals): migrate raw MUI Buttons to CustomizableButton in DatasetEditorPage

### DIFF
--- a/Clients/src/presentation/pages/EvalsDashboard/DatasetEditorPage.tsx
+++ b/Clients/src/presentation/pages/EvalsDashboard/DatasetEditorPage.tsx
@@ -12,6 +12,7 @@ import {
   AccordionDetails,
   CircularProgress,
 } from "@mui/material";
+import { CustomizableButton } from "../../components/button/customizable-button";
 import VWChip from "../../components/Chip";
 import { useNavigate, useParams, useSearchParams } from "react-router-dom";
 import {
@@ -223,48 +224,32 @@ export default function DatasetEditorPage() {
           </Typography>
         </Stack>
         <Stack direction="row" spacing={1}>
-          <Button
+          <CustomizableButton
+            color="secondary"
             variant="outlined"
             onClick={handleCopyJson}
             startIcon={copied ? <Check size={16} /> : <Copy size={16} />}
-            sx={{
-              "color": copied ? palette.status.success.text : palette.text.secondary,
-              "borderColor": copied ? palette.status.success.text : palette.border.dark,
-              "&:hover": {
-                borderColor: palette.text.disabled,
-                backgroundColor: palette.background.accent,
-              },
-            }}
-          >
-            {copied ? "Copied!" : "Copy JSON"}
-          </Button>
-          <Button
+            text={copied ? "Copied!" : "Copy JSON"}
+          />
+          <CustomizableButton
+            color="secondary"
             variant="outlined"
             onClick={handleDownload}
             startIcon={<Download size={16} />}
-            sx={{
-              "color": palette.text.secondary,
-              "borderColor": palette.border.dark,
-              "&:hover": {
-                borderColor: palette.text.disabled,
-                backgroundColor: palette.background.accent,
-              },
-            }}
-          >
-            Download
-          </Button>
-          <Button
+            text="Download"
+          />
+          <CustomizableButton
             variant="contained"
-            disabled={!isValidToSave || saving || !datasetName.trim()}
+            isDisabled={!isValidToSave || !datasetName.trim()}
+            loading={saving}
             sx={{
               "bgcolor": palette.brand.primary,
               "&:hover": { bgcolor: palette.brand.primaryHover },
             }}
             startIcon={<SaveIcon size={16} />}
             onClick={handleSave}
-          >
-            {saving ? "Saving..." : "Save"}
-          </Button>
+            text="Save"
+          />
         </Stack>
       </Stack>
 


### PR DESCRIPTION
## Describe your changes

Replaced all three raw MUI [Button] instances in DatasetEditorPage.tsx with the project's [CustomizableButton] component.

## Write your issue number after "Fixes "

Fixes #3935 

## Please ensure all items are checked off before requesting a review:

- [x] I deployed the code locally.
- [x] I have performed a self-review of my code.
- [x] I have included the issue # in the PR.
- [x] I have labelled the PR correctly.
- [x] The issue I am working on is assigned to me.
- [x] I have avoided using hardcoded values to ensure scalability and maintain consistency across the application.
- [x] I have ensured that font sizes, color choices, and other UI elements are referenced from the theme.
- [x] My pull request is focused and addresses a single, specific feature.
- [x] If there are UI changes, I have attached a screenshot or video to this PR.

<img width="1000" height="200" alt="Screenshot 2026-05-20 at 6 01 19 PM" src="https://github.com/user-attachments/assets/2037f27b-ba79-463a-a6b5-20f9cbde2dce" />
