### PR TITLE
refactor(project-view): migrate raw MUI Buttons to CustomizableButton in ProjectFrameworks

### DIFF
--- a/Clients/src/presentation/pages/ProjectView/ProjectFrameworks/index.tsx
+++ b/Clients/src/presentation/pages/ProjectView/ProjectFrameworks/index.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect, useMemo, useContext, useCallback } from "react";
-import { Box, Button, Tab, Alert } from "@mui/material";
+import { Box, Tab, Alert } from "@mui/material";
 import TabList from "@mui/lab/TabList";
 import TabPanel from "@mui/lab/TabPanel";
 import TabContext from "@mui/lab/TabContext";
@@ -18,7 +18,8 @@ import { PluginSlot } from "../../../components/PluginSlot";
 import { PLUGIN_SLOTS } from "../../../../domain/constants/pluginSlots";
 import { usePluginRegistry } from "../../../../application/contexts/PluginRegistry.context";
 
-import { containerStyle, headerContainerStyle, addButtonStyle, tabListStyle } from "./styles";
+import { containerStyle, headerContainerStyle, tabListStyle } from "./styles";
+import { CustomizableButton } from "../../../components/button/customizable-button";
 import allowedRoles from "../../../../application/constants/permissions";
 import { TabFilterBar } from "../../../components/FrameworkFilter/TabFilterBar";
 import { useSearchParams } from "react-router-dom";
@@ -219,14 +220,12 @@ const ProjectFrameworks = ({
             This use case doesn't have any compliance frameworks yet. Add a framework to start
             tracking controls and assessments.
           </Box>
-          <Button
+          <CustomizableButton
             variant="contained"
-            sx={addButtonStyle}
             onClick={() => setIsModalOpen(true)}
-            disabled={isManagingFrameworksDisabled}
-          >
-            Add Framework
-          </Button>
+            isDisabled={isManagingFrameworksDisabled}
+            text="Add Framework"
+          />
         </Box>
       );
     }
@@ -328,9 +327,7 @@ const ProjectFrameworks = ({
         <Alert severity="error" sx={{ mb: 2 }}>
           {error}
         </Alert>
-        <Button onClick={refreshFilteredFrameworks} variant="contained">
-          Retry
-        </Button>
+        <CustomizableButton variant="contained" onClick={refreshFilteredFrameworks} text="Retry" />
       </Box>
     );
   }
@@ -341,14 +338,12 @@ const ProjectFrameworks = ({
 
   // Render the "Manage frameworks" button
   const renderManageButton = () => (
-    <Button
+    <CustomizableButton
       variant="contained"
-      sx={addButtonStyle}
       onClick={() => setIsModalOpen(true)}
-      disabled={isManagingFrameworksDisabled}
-    >
-      Manage frameworks/regulations
-    </Button>
+      isDisabled={isManagingFrameworksDisabled}
+      text="Manage frameworks/regulations"
+    />
   );
 
   return (
@@ -461,14 +456,12 @@ const ProjectFrameworks = ({
             This use case doesn't have any compliance frameworks yet. Add a framework to start
             tracking controls and assessments.
           </Box>
-          <Button
+          <CustomizableButton
             variant="contained"
-            sx={addButtonStyle}
             onClick={() => setIsModalOpen(true)}
-            disabled={isManagingFrameworksDisabled}
-          >
-            Add Framework
-          </Button>
+            isDisabled={isManagingFrameworksDisabled}
+            text="Add Framework"
+          />
         </Box>
       )}
     </Box>

--- a/Clients/src/presentation/pages/ProjectView/ProjectFrameworks/styles.ts
+++ b/Clients/src/presentation/pages/ProjectView/ProjectFrameworks/styles.ts
@@ -43,25 +43,6 @@ export const getFrameworkTabStyle =
     width: "142px",
   });
 
-export const addButtonStyle: SxProps<Theme> = (theme) => ({
-  "backgroundColor": theme.palette.primary.main,
-  "border": `1px solid ${theme.palette.primary.main}`,
-  "color": "background.main",
-  "fontFamily": theme.typography.fontFamily,
-  "fontSize": theme.typography.fontSize,
-  "fontWeight": 400,
-  "textTransform": "none",
-  "borderRadius": theme.spacing(1),
-  "boxShadow": "none",
-  "&:hover": {
-    backgroundColor: theme.palette.primary.dark || brand.primaryDark,
-    boxShadow: "none",
-  },
-  "&:focus": {
-    outline: "none",
-  },
-});
-
 export const tabListStyle: SxProps<Theme> = {
   "minHeight": "20px",
   "& .MuiTabs-flexContainer": {


### PR DESCRIPTION
## Describe your changes

Replaces all raw MUI Button instances in ProjectFrameworks/index.tsx with the internal CustomizableButton component to align with the design system convention.

## Write your issue number after "Fixes "

Fixes #3942 

## Please ensure all items are checked off before requesting a review:

- [x] I deployed the code locally.
- [x] I have performed a self-review of my code.
- [x] I have included the issue # in the PR.
- [x] I have labelled the PR correctly.
- [x] The issue I am working on is assigned to me.
- [x] I have avoided using hardcoded values to ensure scalability and maintain consistency across the application.
- [x] I have ensured that font sizes, color choices, and other UI elements are referenced from the theme.
- [x] My pull request is focused and addresses a single, specific feature.
- [x] If there are UI changes, I have attached a screenshot or video to this PR.

<img width="600" height="300" alt="Screenshot 2026-05-21 at 2 00 24 PM" src="https://github.com/user-attachments/assets/fe990351-27fb-47f3-93ec-a06aa6df6bdc" />
