### PR TITLE
refactor(plugins): migrate raw MUI Buttons to CustomizableButton in PluginManagement

### DIFF
--- a/Clients/src/presentation/pages/Plugins/PluginManagement/index.tsx
+++ b/Clients/src/presentation/pages/Plugins/PluginManagement/index.tsx
@@ -612,9 +612,12 @@ const PluginManagement: React.FC = () => {
                       variant="outlined"
                       color="error"
                       onClick={handleUninstallClick}
-                      loading={uninstalling === plugin.installationId}
                       isDisabled={uninstalling === plugin.installationId}
-                      text="Uninstall Plugin"
+                      text={
+                        uninstalling === plugin.installationId
+                          ? "Uninstalling..."
+                          : "Uninstall Plugin"
+                      }
                     />
                   </Box>
                 )}
@@ -857,18 +860,20 @@ const PluginManagement: React.FC = () => {
                               <CustomizableButton
                                 variant="outlined"
                                 onClick={handleTestConnection}
-                                loading={isTestingConnection}
                                 isDisabled={isTestingConnection || isSavingConfig}
                                 sx={testConnectionButton}
-                                text="Test Connection"
+                                text={
+                                  isTestingConnection ? "Testing..." : "Test Connection"
+                                }
                               />
                               <CustomizableButton
                                 variant="contained"
                                 onClick={handleSaveConfiguration}
-                                loading={isSavingConfig}
                                 isDisabled={isSavingConfig || isTestingConnection}
                                 sx={saveConfigButton}
-                                text="Save Configuration"
+                                text={
+                                  isSavingConfig ? "Saving..." : "Save Configuration"
+                                }
                               />
                             </Box>
                           </>

--- a/Clients/src/presentation/pages/Plugins/PluginManagement/index.tsx
+++ b/Clients/src/presentation/pages/Plugins/PluginManagement/index.tsx
@@ -5,7 +5,6 @@ import {
   Stack,
   Typography,
   Chip as MuiChip,
-  Button,
   Card,
   CardContent,
   Divider,
@@ -30,6 +29,7 @@ import {
   Database as DatabaseIcon,
 } from "lucide-react";
 import { PageBreadcrumbs } from "../../../components/breadcrumbs/PageBreadcrumbs";
+import { CustomizableButton } from "../../../components/button/customizable-button";
 import { PageHeader } from "../../../components/Layout/PageHeader";
 import PluginSlot from "../../../components/PluginSlot";
 import { PLUGIN_SLOTS } from "../../../../domain/constants/pluginSlots";
@@ -51,11 +51,8 @@ import { BreadcrumbItem } from "../../../../domain/types/breadcrumbs.types";
 import { ENV_VARs } from "../../../../../env.vars";
 import { getConfigFields, ConfigField } from "./config-fields";
 import {
-  backButton,
   pluginIconPlaceholder,
   installedStatusChip,
-  installButton,
-  uninstallButton,
   formFieldLabel,
   testConnectionButton,
   saveConfigButton,
@@ -343,13 +340,12 @@ const PluginManagement: React.FC = () => {
           <Typography variant="h6" color="text.secondary">
             Plugin not found
           </Typography>
-          <Button
+          <CustomizableButton
             variant="outlined"
             onClick={() => navigate("/plugins/marketplace")}
             sx={{ mt: 2 }}
-          >
-            Go to Marketplace
-          </Button>
+            text="Go to Marketplace"
+          />
         </Box>
       </Stack>
     );
@@ -361,13 +357,11 @@ const PluginManagement: React.FC = () => {
 
       {/* Back Button */}
       <Box>
-        <Button
+        <CustomizableButton
           startIcon={<ArrowLeftIcon size={16} />}
           onClick={() => navigate("/plugins/my-plugins")}
-          sx={backButton}
-        >
-          Back to My Plugins
-        </Button>
+          text="Back to My Plugins"
+        />
       </Box>
 
       <PageHeader title={plugin.displayName} description={plugin.description} />
@@ -558,7 +552,7 @@ const PluginManagement: React.FC = () => {
                   plugin.installationStatus === PluginInstallationStatus.UNINSTALLED ||
                   plugin.installationStatus === PluginInstallationStatus.FAILED) && (
                   <Box sx={{ display: "flex", gap: 2 }}>
-                    <Button
+                    <CustomizableButton
                       variant="contained"
                       onClick={async () => {
                         try {
@@ -600,32 +594,28 @@ const PluginManagement: React.FC = () => {
                           });
                         }
                       }}
-                      disabled={installing === plugin.key}
-                      sx={installButton}
-                    >
-                      {installing === plugin.key
-                        ? "Installing..."
-                        : plugin.installationStatus === PluginInstallationStatus.FAILED
+                      loading={installing === plugin.key}
+                      isDisabled={installing === plugin.key}
+                      text={
+                        plugin.installationStatus === PluginInstallationStatus.FAILED
                           ? "Retry Installation"
-                          : "Install plugin"}
-                    </Button>
+                          : "Install plugin"
+                      }
+                    />
                   </Box>
                 )}
 
                 {/* Uninstall Button - Show when plugin is installed */}
                 {plugin.installationStatus === PluginInstallationStatus.INSTALLED && (
                   <Box sx={{ display: "flex", gap: 2 }}>
-                    <Button
+                    <CustomizableButton
                       variant="outlined"
                       color="error"
                       onClick={handleUninstallClick}
-                      disabled={uninstalling === plugin.installationId}
-                      sx={uninstallButton}
-                    >
-                      {uninstalling === plugin.installationId
-                        ? "Uninstalling..."
-                        : "Uninstall Plugin"}
-                    </Button>
+                      loading={uninstalling === plugin.installationId}
+                      isDisabled={uninstalling === plugin.installationId}
+                      text="Uninstall Plugin"
+                    />
                   </Box>
                 )}
               </Stack>
@@ -864,22 +854,22 @@ const PluginManagement: React.FC = () => {
                             <Box
                               sx={{ display: "flex", justifyContent: "flex-end", gap: 2, mt: 3 }}
                             >
-                              <Button
+                              <CustomizableButton
                                 variant="outlined"
                                 onClick={handleTestConnection}
-                                disabled={isTestingConnection || isSavingConfig}
+                                loading={isTestingConnection}
+                                isDisabled={isTestingConnection || isSavingConfig}
                                 sx={testConnectionButton}
-                              >
-                                {isTestingConnection ? "Testing..." : "Test Connection"}
-                              </Button>
-                              <Button
+                                text="Test Connection"
+                              />
+                              <CustomizableButton
                                 variant="contained"
                                 onClick={handleSaveConfiguration}
-                                disabled={isSavingConfig || isTestingConnection}
+                                loading={isSavingConfig}
+                                isDisabled={isSavingConfig || isTestingConnection}
                                 sx={saveConfigButton}
-                              >
-                                {isSavingConfig ? "Saving..." : "Save Configuration"}
-                              </Button>
+                                text="Save Configuration"
+                              />
                             </Box>
                           </>
                         )}

--- a/Clients/src/presentation/pages/Plugins/PluginManagement/index.tsx
+++ b/Clients/src/presentation/pages/Plugins/PluginManagement/index.tsx
@@ -862,18 +862,14 @@ const PluginManagement: React.FC = () => {
                                 onClick={handleTestConnection}
                                 isDisabled={isTestingConnection || isSavingConfig}
                                 sx={testConnectionButton}
-                                text={
-                                  isTestingConnection ? "Testing..." : "Test Connection"
-                                }
+                                text={isTestingConnection ? "Testing..." : "Test Connection"}
                               />
                               <CustomizableButton
                                 variant="contained"
                                 onClick={handleSaveConfiguration}
                                 isDisabled={isSavingConfig || isTestingConnection}
                                 sx={saveConfigButton}
-                                text={
-                                  isSavingConfig ? "Saving..." : "Save Configuration"
-                                }
+                                text={isSavingConfig ? "Saving..." : "Save Configuration"}
                               />
                             </Box>
                           </>

--- a/Clients/src/presentation/pages/Plugins/PluginManagement/style.ts
+++ b/Clients/src/presentation/pages/Plugins/PluginManagement/style.ts
@@ -38,30 +38,6 @@ export const installedStatusChip: SxProps<Theme> = {
   fontWeight: 500,
 };
 
-// Install button
-export const installButton: SxProps<Theme> = {
-  "backgroundColor": `${brand.primary}`,
-  "textTransform": "none",
-  "fontSize": "13px",
-  "fontWeight": 500,
-  "&:hover": {
-    backgroundColor: `${brand.primaryHover}`,
-  },
-};
-
-// Uninstall button
-export const uninstallButton: SxProps<Theme> = {
-  "textTransform": "none",
-  "fontSize": "13px",
-  "fontWeight": 500,
-  "borderColor": "#dc2626",
-  "color": "#dc2626",
-  "&:hover": {
-    backgroundColor: "rgba(220, 38, 38, 0.04)",
-    borderColor: "#dc2626",
-  },
-};
-
 // Form field label
 export const formFieldLabel: SxProps<Theme> = {
   mb: 0.75,


### PR DESCRIPTION
## Describe your changes

Replaces all raw MUI <Button> components in PluginManagement/index.tsx with the project's <CustomizableButton> wrapper, which reads styling from singleTheme. Also removes redundant style definitions that are now fully handled by the theme.

## Write your issue number after "Fixes "

Fixes #3944 

## Please ensure all items are checked off before requesting a review:

- [x] I deployed the code locally.
- [x] I have performed a self-review of my code.
- [x] I have included the issue # in the PR.
- [x] I have labelled the PR correctly.
- [x] The issue I am working on is assigned to me.
- [x] I have avoided using hardcoded values to ensure scalability and maintain consistency across the application.
- [x] I have ensured that font sizes, color choices, and other UI elements are referenced from the theme.
- [x] My pull request is focused and addresses a single, specific feature.
- [x] If there are UI changes, I have attached a screenshot or video to this PR.


<img width="500" height="300" alt="Screenshot 2026-05-21 at 3 35 03 PM" src="https://github.com/user-attachments/assets/caa0e87b-d995-45b0-8a3a-e677c93cab05" />

