### PR TITLE
fix: remove production debug logs and fix OpenRouter experiment failures

### DIFF
--- a/Clients/src/application/hooks/useDashboardMetrics.ts
+++ b/Clients/src/application/hooks/useDashboardMetrics.ts
@@ -833,18 +833,9 @@ export const useDashboardMetrics = () => {
     try {
       const response = await getAllEntities({ routeUrl: "/compliance/score" });
       const data = response.data || response;
-      console.log("[governance-score] /compliance/score response", { response, data });
 
       if (data && typeof data.overallScore === "number") {
         const modules = data.modules || {};
-        console.log("[governance-score] overallScore + modules", {
-          overallScore: data.overallScore,
-          riskManagement: modules.riskManagement,
-          vendorManagement: modules.vendorManagement,
-          projectGovernance: modules.projectGovernance,
-          modelLifecycle: modules.modelLifecycle,
-          policyDocumentation: modules.policyDocumentation,
-        });
         const metrics: GovernanceScoreMetrics = {
           score: data.overallScore,
           modules: [

--- a/Clients/src/application/redux/auth/authSlice.ts
+++ b/Clients/src/application/redux/auth/authSlice.ts
@@ -14,35 +14,23 @@ const initialState = {
   activeOrganizationId: null as number | null,
 };
 
-export const register = createAsyncThunk("user/register", async (form, thunkApi) => {
-  console.log(form);
-  console.log(thunkApi);
-});
+export const register = createAsyncThunk("user/register", async (_form, _thunkApi) => {});
 
-export const login = createAsyncThunk("user/login", async (form, thunkApi) => {
-  console.log(form);
-  console.log(thunkApi);
-});
+export const login = createAsyncThunk("user/login", async (_form, _thunkApi) => {});
 
-export const update = createAsyncThunk("user/update", async (form, thunkApi) => {
-  console.log(form);
-  console.log(thunkApi);
-});
+export const update = createAsyncThunk("user/update", async (_form, _thunkApi) => {});
 
-export const remove = createAsyncThunk("user/delete", async (form, thunkApi) => {
-  console.log(form);
-  console.log(thunkApi);
-});
+export const remove = createAsyncThunk("user/delete", async (_form, _thunkApi) => {});
 
-export const forgotPassword = createAsyncThunk("user/forgotPassword", async (form, thunkApi) => {
-  console.log(form);
-  console.log(thunkApi);
-});
+export const forgotPassword = createAsyncThunk(
+  "user/forgotPassword",
+  async (_form, _thunkApi) => {},
+);
 
-export const setNewPassword = createAsyncThunk("user/setNewPassword", async (form, thunkApi) => {
-  console.log(form);
-  console.log(thunkApi);
-});
+export const setNewPassword = createAsyncThunk(
+  "user/setNewPassword",
+  async (_form, _thunkApi) => {},
+);
 
 const handleAuthFulfilled = (state: any, action: any) => {
   state.isLoading = false;

--- a/Clients/src/presentation/components/CommandPalette/index.tsx
+++ b/Clients/src/presentation/components/CommandPalette/index.tsx
@@ -353,8 +353,7 @@ export function CommandPalette({ open, onOpenChange }: CommandPaletteProps) {
         onOpenChange(false);
       },
 
-      modal: (modalType: string) => {
-        console.log("Open modal:", modalType);
+      modal: (_modalType: string) => {
         onOpenChange(false);
       },
 
@@ -364,18 +363,16 @@ export function CommandPalette({ open, onOpenChange }: CommandPaletteProps) {
             navigate("/settings", { state: { activeTab: params } });
             break;
           default:
-            console.log("Execute function:", funcName, params);
+            break;
         }
         onOpenChange(false);
       },
 
-      filter: (filterConfig: unknown) => {
-        console.log("Apply filter:", filterConfig);
+      filter: (_filterConfig: unknown) => {
         onOpenChange(false);
       },
 
-      export: (exportType: string) => {
-        console.log("Export:", exportType);
+      export: (_exportType: string) => {
         onOpenChange(false);
       },
     }),

--- a/Clients/src/presentation/components/Modals/Controlpane/NewControlPane.tsx
+++ b/Clients/src/presentation/components/Modals/Controlpane/NewControlPane.tsx
@@ -840,17 +840,6 @@ const NewControlPane = ({
         }
       });
 
-      // Debug logging
-      console.log("Files to upload:", {
-        evidence: Object.values(subcontrolFormData).map((d) => d.uploadEvidenceFiles.length),
-        feedback: Object.values(subcontrolFormData).map((d) => d.uploadFeedbackFiles.length),
-      });
-      console.log("Files to attach:", {
-        evidence: attachedEvidenceFiles,
-        feedback: attachedFeedbackFiles,
-      });
-      console.log("Files to delete:", allDeletedFileIds);
-
       formData.append("delete", JSON.stringify(allDeletedFileIds));
 
       // Add attached file IDs (for linking existing files from File Manager)

--- a/Clients/src/presentation/components/Modals/Controlpane/index.tsx
+++ b/Clients/src/presentation/components/Modals/Controlpane/index.tsx
@@ -199,12 +199,12 @@ const CustomModal: React.FC<ICustomModalProps> = ({
             <AuditorFeedback
               activeSection={activeSection}
               feedback=""
-              onChange={(e) => console.log(e.target.value)}
+              onChange={() => {}}
               files={[]}
               deletedFilesIds={[]}
-              onDeletedFilesChange={(ids) => console.log("Deleted Files:", ids)} // Add a handler
+              onDeletedFilesChange={() => {}}
               uploadFiles={[]}
-              onUploadFilesChange={(files) => console.log("Uploaded Files:", files)} // Add a handler
+              onUploadFilesChange={() => {}}
             />
           )}
         </Box>
@@ -217,20 +217,10 @@ const CustomModal: React.FC<ICustomModalProps> = ({
           }}
         >
           <Stack gap={theme.spacing(4)} sx={{ display: "flex", flexDirection: "row" }}>
-            <Button
-              variant="contained"
-              onClick={() => console.log("Previous Control clicked")}
-              sx={buttonStyle}
-              disableRipple
-            >
+            <Button variant="contained" onClick={() => {}} sx={buttonStyle} disableRipple>
               &lt;- Previous Control
             </Button>
-            <Button
-              variant="contained"
-              onClick={() => console.log("Next Control clicked")}
-              sx={buttonStyle}
-              disableRipple
-            >
+            <Button variant="contained" onClick={() => {}} sx={buttonStyle} disableRipple>
               Next Control -&gt;
             </Button>
           </Stack>

--- a/Clients/src/presentation/components/Modals/EvidenceHub/index.tsx
+++ b/Clients/src/presentation/components/Modals/EvidenceHub/index.tsx
@@ -228,7 +228,6 @@ const NewEvidenceHub: FC<NewEvidenceHubProps> = ({
   }, []);
 
   const handleUploadSuccess = (files: FileResponse[]) => {
-    console.log("[NewEvidenceHub.handleUploadSuccess] received files:", files);
     const mapped = files.map((file) => ({
       id: file.id,
       filename: file.filename,
@@ -237,18 +236,10 @@ const NewEvidenceHub: FC<NewEvidenceHubProps> = ({
       uploaded_by: file.uploaded_by,
       upload_date: file.upload_date,
     }));
-    console.log("[NewEvidenceHub.handleUploadSuccess] mapped into evidence_files shape:", mapped);
-    setValues((prev) => {
-      const next = {
-        ...prev,
-        evidence_files: [...prev.evidence_files, ...mapped],
-      };
-      console.log(
-        "[NewEvidenceHub.handleUploadSuccess] evidence_files after merge:",
-        next.evidence_files,
-      );
-      return next;
-    });
+    setValues((prev) => ({
+      ...prev,
+      evidence_files: [...prev.evidence_files, ...mapped],
+    }));
     setErrors((prev) => ({ ...prev, files: "" }));
     setIsUploadModalOpen(false);
   };
@@ -329,13 +320,6 @@ const NewEvidenceHub: FC<NewEvidenceHubProps> = ({
 
     setIsSubmitting(true);
     try {
-      console.log("[NewEvidenceHub.handleSubmit] submitting evidence values:", values);
-      console.log(
-        "[NewEvidenceHub.handleSubmit] evidence_files count:",
-        values.evidence_files?.length,
-        "files:",
-        values.evidence_files,
-      );
       if (onSuccess) onSuccess(values);
       setIsOpen(false);
     } catch (error) {

--- a/Clients/src/presentation/pages/EvalsDashboard/NewExperimentModal.tsx
+++ b/Clients/src/presentation/pages/EvalsDashboard/NewExperimentModal.tsx
@@ -832,11 +832,8 @@ export default function NewExperimentModal({
         },
       };
 
-      console.log("Creating experiment:", experimentConfig);
-
       // Create experiment via API
       const response = await createExperiment(experimentConfig);
-      console.log("Experiment created:", response);
 
       // Optimistically notify parent so the table shows a pending row immediately
       if (onStarted && response?.experiment?.id) {
@@ -861,11 +858,7 @@ export default function NewExperimentModal({
           model: config.judgeLlm.model,
           endpointUrl: config.judgeLlm.endpointUrl || undefined,
         },
-      }).then((success) => {
-        if (success) {
-          console.log("Model preferences saved for next experiment");
-        }
-      });
+      }).catch(() => {});
 
       // Show success message
       setAlert({

--- a/Clients/src/presentation/pages/FileManager/components/FilePreviewPanel/index.tsx
+++ b/Clients/src/presentation/pages/FileManager/components/FilePreviewPanel/index.tsx
@@ -136,18 +136,6 @@ export const FilePreviewPanel: React.FC<FilePreviewPanelProps> = ({
 
   const previewType = file ? getPreviewType(file.mimetype) : "unsupported";
 
-  // Debug logging
-  useEffect(() => {
-    if (file) {
-      console.log("[FilePreviewPanel] File data:", {
-        id: file.id,
-        filename: file.filename,
-        mimetype: file.mimetype,
-        previewType,
-      });
-    }
-  }, [file, previewType]);
-
   // Load preview when file changes - uses the dedicated preview endpoint
   // which has XSS protections and MIME allowlisting
   useEffect(() => {

--- a/Clients/src/presentation/pages/ModelInventory/index.tsx
+++ b/Clients/src/presentation/pages/ModelInventory/index.tsx
@@ -1751,21 +1751,12 @@ const ModelInventory: React.FC = () => {
 
   const handleEvidenceUploadModalSuccess = async (formData: EvidenceHubModel) => {
     try {
-      console.log("[ModelInventory.handleEvidenceUploadModalSuccess] formData received:", formData);
-      console.log(
-        "[ModelInventory.handleEvidenceUploadModalSuccess] evidence_files in payload:",
-        formData?.evidence_files,
-      );
       if (selectedEvidenceHub) {
         // Update existing Evidence
-        const updateRes = await updateEntityById({
+        await updateEntityById({
           routeUrl: `/evidenceHub/${selectedEvidenceHub.id}`,
           body: formData,
         });
-        console.log(
-          "[ModelInventory.handleEvidenceUploadModalSuccess] PATCH /evidenceHub response:",
-          updateRes,
-        );
 
         setEvidenceHubData((prev) =>
           prev.map((item) => (item.id === selectedEvidenceHub.id ? formData : item)),
@@ -1778,14 +1769,6 @@ const ModelInventory: React.FC = () => {
       } else {
         // Create new Evidence
         const response = await createEvidenceHub("/evidenceHub", formData);
-        console.log(
-          "[ModelInventory.handleEvidenceUploadModalSuccess] POST /evidenceHub response:",
-          response,
-        );
-        console.log(
-          "[ModelInventory.handleEvidenceUploadModalSuccess] response.data.evidence_files:",
-          (response as any)?.data?.evidence_files,
-        );
 
         if (response?.data) {
           setEvidenceHubData((prev) => [...prev, response.data]);

--- a/EvalServer/src/utils/gateway_litellm_client.py
+++ b/EvalServer/src/utils/gateway_litellm_client.py
@@ -35,22 +35,29 @@ def _internal_key() -> str:
 def to_litellm_model(provider: str, model: str) -> str:
     """
     Map eval provider + UI model id to a LiteLLM model string.
-    If the model already looks like a LiteLLM route (contains '/'), return as-is.
+
+    OpenRouter models must be resolved first because their names typically contain
+    a "/" (e.g. "meta-llama/llama-3.1-70b-instruct") which would otherwise trigger
+    the early-return and skip the required "openrouter/" prefix.
     """
     p = (provider or "").lower().strip()
     m = (model or "").strip()
     if not m:
         raise ValueError("model name is required")
+
+    # OpenRouter — must come before the "/" shortcut because OpenRouter slugs
+    # (e.g. "meta-llama/llama-3.1-70b-instruct") contain "/" but still need the
+    # "openrouter/" LiteLLM prefix to be routed correctly.
+    if p == "openrouter":
+        return m if m.startswith("openrouter/") else f"openrouter/{m}"
+
+    # For all other providers, a "/" means the caller already supplied a fully-
+    # qualified LiteLLM model string — pass it through unchanged.
     if "/" in m:
         return m
 
     if p in ("google", "gemini"):
-        if m.startswith("gemini/") or m.startswith("google/"):
-            return m
-        return f"gemini/{m}"
-
-    if p == "openrouter":
-        return m
+        return m if m.startswith("gemini/") or m.startswith("google/") else f"gemini/{m}"
 
     if p == "mistral" and not m.startswith("mistral/"):
         return f"mistral/{m}"

--- a/EvalServer/src/utils/gateway_litellm_client.py
+++ b/EvalServer/src/utils/gateway_litellm_client.py
@@ -35,29 +35,22 @@ def _internal_key() -> str:
 def to_litellm_model(provider: str, model: str) -> str:
     """
     Map eval provider + UI model id to a LiteLLM model string.
-
-    OpenRouter models must be resolved first because their names typically contain
-    a "/" (e.g. "meta-llama/llama-3.1-70b-instruct") which would otherwise trigger
-    the early-return and skip the required "openrouter/" prefix.
+    If the model already looks like a LiteLLM route (contains '/'), return as-is.
     """
     p = (provider or "").lower().strip()
     m = (model or "").strip()
     if not m:
         raise ValueError("model name is required")
-
-    # OpenRouter — must come before the "/" shortcut because OpenRouter slugs
-    # (e.g. "meta-llama/llama-3.1-70b-instruct") contain "/" but still need the
-    # "openrouter/" LiteLLM prefix to be routed correctly.
-    if p == "openrouter":
-        return m if m.startswith("openrouter/") else f"openrouter/{m}"
-
-    # For all other providers, a "/" means the caller already supplied a fully-
-    # qualified LiteLLM model string — pass it through unchanged.
     if "/" in m:
         return m
 
     if p in ("google", "gemini"):
-        return m if m.startswith("gemini/") or m.startswith("google/") else f"gemini/{m}"
+        if m.startswith("gemini/") or m.startswith("google/"):
+            return m
+        return f"gemini/{m}"
+
+    if p == "openrouter":
+        return m
 
     if p == "mistral" and not m.startswith("mistral/"):
         return f"mistral/{m}"

--- a/EvaluationModule/src/deepeval_engine/gateway_litellm_client.py
+++ b/EvaluationModule/src/deepeval_engine/gateway_litellm_client.py
@@ -27,31 +27,18 @@ def _internal_key() -> str:
 
 
 def to_litellm_model(provider: str, model: str) -> str:
-    """
-    Map eval provider + UI model id to a LiteLLM model string.
-
-    OpenRouter models must be resolved first because their names typically contain
-    a "/" (e.g. "meta-llama/llama-3.1-70b-instruct") which would otherwise trigger
-    the early-return and skip the required "openrouter/" prefix.
-    """
     p = (provider or "").lower().strip()
     m = (model or "").strip()
     if not m:
         raise ValueError("model name is required")
-
-    # OpenRouter — must come before the "/" shortcut because OpenRouter slugs
-    # (e.g. "meta-llama/llama-3.1-70b-instruct") contain "/" but still need the
-    # "openrouter/" LiteLLM prefix to be routed correctly.
-    if p == "openrouter":
-        return m if m.startswith("openrouter/") else f"openrouter/{m}"
-
-    # For all other providers, a "/" means the caller already supplied a fully-
-    # qualified LiteLLM model string — pass it through unchanged.
     if "/" in m:
         return m
-
     if p in ("google", "gemini"):
-        return m if m.startswith("gemini/") or m.startswith("google/") else f"gemini/{m}"
+        if m.startswith("gemini/") or m.startswith("google/"):
+            return m
+        return f"gemini/{m}"
+    if p == "openrouter":
+        return m
     if p == "mistral" and not m.startswith("mistral/"):
         return f"mistral/{m}"
     if p == "xai" and not m.startswith("xai/"):

--- a/EvaluationModule/src/deepeval_engine/gateway_litellm_client.py
+++ b/EvaluationModule/src/deepeval_engine/gateway_litellm_client.py
@@ -27,18 +27,31 @@ def _internal_key() -> str:
 
 
 def to_litellm_model(provider: str, model: str) -> str:
+    """
+    Map eval provider + UI model id to a LiteLLM model string.
+
+    OpenRouter models must be resolved first because their names typically contain
+    a "/" (e.g. "meta-llama/llama-3.1-70b-instruct") which would otherwise trigger
+    the early-return and skip the required "openrouter/" prefix.
+    """
     p = (provider or "").lower().strip()
     m = (model or "").strip()
     if not m:
         raise ValueError("model name is required")
+
+    # OpenRouter — must come before the "/" shortcut because OpenRouter slugs
+    # (e.g. "meta-llama/llama-3.1-70b-instruct") contain "/" but still need the
+    # "openrouter/" LiteLLM prefix to be routed correctly.
+    if p == "openrouter":
+        return m if m.startswith("openrouter/") else f"openrouter/{m}"
+
+    # For all other providers, a "/" means the caller already supplied a fully-
+    # qualified LiteLLM model string — pass it through unchanged.
     if "/" in m:
         return m
+
     if p in ("google", "gemini"):
-        if m.startswith("gemini/") or m.startswith("google/"):
-            return m
-        return f"gemini/{m}"
-    if p == "openrouter":
-        return m
+        return m if m.startswith("gemini/") or m.startswith("google/") else f"gemini/{m}"
     if p == "mistral" and not m.startswith("mistral/"):
         return f"mistral/{m}"
     if p == "xai" and not m.startswith("xai/"):


### PR DESCRIPTION
## Describe your changes

- **Fix OpenRouter experiment failures**: `to_litellm_model()` in EvalServer and EvaluationModule had an early-return on `"/" in model` that skipped the `openrouter/` prefix for namespaced model IDs (e.g. `meta-llama/llama-3.1-70b-instruct`). LiteLLM requires `openrouter/meta-llama/llama-3.1-70b-instruct` to route correctly — without it, experiments silently fail. The fix moves the OpenRouter check above the `/` shortcut.
- **Remove debug console.log calls from production**: Clears debug logging that was leaking into the browser console, including `console.log(form)` stubs in `authSlice.ts` that could expose sensitive form data (passwords), governance-score debug logs, and leftover debug logs across 8 other frontend files.


## Write your issue number after "Fixes "

Fixes #3948 

## Please ensure all items are checked off before requesting a review:

- [x] I deployed the code locally.
- [x] I have performed a self-review of my code.
- [x] I have included the issue # in the PR.
- [x] I have labelled the PR correctly.
- [x] The issue I am working on is assigned to me.
- [x] I have avoided using hardcoded values to ensure scalability and maintain consistency across the application.
- [x] I have ensured that font sizes, color choices, and other UI elements are referenced from the theme.
- [x] My pull request is focused and addresses a single, specific feature.
- [x] If there are UI changes, I have attached a screenshot or video to this PR.
