### PR TITLE
Codebase enhancements and bug fixes

### DIFF
--- a/Clients/src/presentation/components/Drawer/NISTAIRMFDashboardDrawerDialog/index.tsx
+++ b/Clients/src/presentation/components/Drawer/NISTAIRMFDashboardDrawerDialog/index.tsx
@@ -139,6 +139,28 @@ const NISTAIRMFDrawerDialog: React.FC<NISTAIRMFDrawerProps> = ({
     setDeletedFiles([]);
   }, [subcategory]);
 
+  // Fetch full subcategory details (including evidence files) when drawer opens
+  useEffect(() => {
+    const fetchSubcategoryDetails = async () => {
+      if (open && subcategory?.id && !subcategory?.evidence_links) {
+        try {
+          const response = await getEntityById({
+            routeUrl: `/nist-ai-rmf/subcategories/byId/${subcategory.id}`,
+          });
+          if (response.data?.evidence_links) {
+            setEvidenceFiles(response.data.evidence_links as unknown as FileData[]);
+          }
+        } catch (error) {
+          if (process.env.NODE_ENV === "development") {
+            console.error("Error fetching subcategory details:", error);
+          }
+        }
+      }
+    };
+
+    fetchSubcategoryDetails();
+  }, [open, subcategory?.id]);
+
   // Fetch linked risks when subcategory changes
   useEffect(() => {
     const fetchLinkedRisks = async () => {

--- a/Clients/src/presentation/components/Drawer/NISTAIRMFDashboardDrawerDialog/index.tsx
+++ b/Clients/src/presentation/components/Drawer/NISTAIRMFDashboardDrawerDialog/index.tsx
@@ -39,8 +39,12 @@ import { useAuth } from "../../../../application/hooks/useAuth";
 import useUsers from "../../../../application/hooks/useUsers";
 import { User } from "../../../../domain/types/User";
 import { FileData } from "../../../../domain/types/File";
-import { getFileById } from "../../../../application/repository/file.repository";
+import {
+  getFileById,
+  attachFilesToEntity,
+} from "../../../../application/repository/file.repository";
 import allowedRoles from "../../../../application/constants/permissions";
+import { FilePickerModal } from "../../FilePickerModal";
 import { RiskFormValues } from "../../../../domain/types/riskForm.types";
 
 // Type for risk objects
@@ -121,6 +125,7 @@ const NISTAIRMFDrawerDialog: React.FC<NISTAIRMFDrawerProps> = ({
     }
     // Reset upload and deleted files
     setUploadFiles([]);
+    setPendingAttachFiles([]);
     setDeletedFiles([]);
   }, [subcategory]);
 
@@ -172,7 +177,9 @@ const NISTAIRMFDrawerDialog: React.FC<NISTAIRMFDrawerProps> = ({
   // File upload state
   const [evidenceFiles, setEvidenceFiles] = useState<FileData[]>([]);
   const [uploadFiles, setUploadFiles] = useState<FileData[]>([]);
+  const [pendingAttachFiles, setPendingAttachFiles] = useState<FileData[]>([]);
   const [deletedFiles, setDeletedFiles] = useState<string[]>([]);
+  const [showFilePicker, setShowFilePicker] = useState(false);
 
   const statusOptions = [
     { id: NISTAIRMFStatus.NOT_STARTED, name: "Not started" },
@@ -314,6 +321,23 @@ const NISTAIRMFDrawerDialog: React.FC<NISTAIRMFDrawerProps> = ({
     });
   };
 
+  const handleAttachExistingFiles = (selectedFiles: FileData[]) => {
+    if (selectedFiles.length === 0) return;
+    setPendingAttachFiles((prev) => [...prev, ...selectedFiles]);
+    handleAlert({
+      variant: "info",
+      body: `${selectedFiles.length} file(s) added to attach queue. Save to apply changes.`,
+    });
+  };
+
+  const handleRemovePendingAttach = (fileId: string) => {
+    setPendingAttachFiles((prev) => prev.filter((f) => f.id !== fileId));
+    handleAlert({
+      variant: "info",
+      body: "File removed from attach queue.",
+    });
+  };
+
   const handleEvidenceFileDownload = async (fileId: string, fileName: string) => {
     try {
       // Use /files/:id endpoint for evidence files (not file-manager)
@@ -404,7 +428,28 @@ const NISTAIRMFDrawerDialog: React.FC<NISTAIRMFDrawerProps> = ({
       });
 
       if (response.status === 200) {
-        const hasFiles = uploadFiles.length > 0 || deletedFiles.length > 0;
+        // Attach pending existing files after successful save
+        if (pendingAttachFiles.length > 0 && subcategory?.id) {
+          try {
+            const fileIds = pendingAttachFiles.map((f) =>
+              typeof f.id === "number" ? f.id : parseInt(String(f.id)),
+            );
+            await attachFilesToEntity({
+              file_ids: fileIds,
+              framework_type: "nist_ai_rmf",
+              entity_type: "subcategory",
+              entity_id: subcategory.id,
+              link_type: "evidence",
+            });
+          } catch (attachError) {
+            if (process.env.NODE_ENV === "development") {
+              console.error("Error attaching existing files:", attachError);
+            }
+          }
+        }
+
+        const hasFiles =
+          uploadFiles.length > 0 || deletedFiles.length > 0 || pendingAttachFiles.length > 0;
         setAlert({
           variant: "success",
           body: hasFiles
@@ -415,6 +460,7 @@ const NISTAIRMFDrawerDialog: React.FC<NISTAIRMFDrawerProps> = ({
 
         // Reset pending states after successful save
         setUploadFiles([]);
+        setPendingAttachFiles([]);
         setDeletedFiles([]);
         setSelectedRisks([]);
         setDeletedRisks([]);
@@ -788,6 +834,26 @@ const NISTAIRMFDrawerDialog: React.FC<NISTAIRMFDrawerProps> = ({
                         >
                           Add evidence files
                         </Button>
+                        <Button
+                          variant="contained"
+                          onClick={() => setShowFilePicker(true)}
+                          disabled={isEditingDisabled}
+                          sx={{
+                            "borderRadius": 2,
+                            "width": 165,
+                            "height": 25,
+                            "fontSize": 11,
+                            "border": "1px solid #4C7BF4",
+                            "backgroundColor": "#4C7BF4",
+                            "color": "white",
+                            "&:hover": {
+                              backgroundColor: "#3D62C3",
+                              border: "1px solid #3D62C3",
+                            },
+                          }}
+                        >
+                          Attach existing files
+                        </Button>
                         <Stack direction="row" spacing={2}>
                           <Typography
                             sx={{
@@ -809,6 +875,18 @@ const NISTAIRMFDrawerDialog: React.FC<NISTAIRMFDrawerProps> = ({
                               }}
                             >
                               {`+${uploadFiles.length} pending upload`}
+                            </Typography>
+                          )}
+                          {pendingAttachFiles.length > 0 && (
+                            <Typography
+                              sx={{
+                                fontSize: 11,
+                                color: "#4C7BF4",
+                                display: "flex",
+                                alignItems: "center",
+                              }}
+                            >
+                              {`+${pendingAttachFiles.length} pending attach`}
                             </Typography>
                           )}
                           {deletedFiles.length > 0 && (
@@ -1004,7 +1082,87 @@ const NISTAIRMFDrawerDialog: React.FC<NISTAIRMFDrawerProps> = ({
                       </Stack>
                     )}
 
-                    {evidenceFiles.length === 0 && uploadFiles.length === 0 && (
+                    {/* Pending Attach Files */}
+                    {pendingAttachFiles.length > 0 && (
+                      <Stack spacing={1}>
+                        <Typography
+                          sx={{
+                            fontSize: 12,
+                            fontWeight: 600,
+                            color: "#4C7BF4",
+                          }}
+                        >
+                          Pending attach
+                        </Typography>
+                        {pendingAttachFiles.map((file) => (
+                          <Box
+                            key={file.id}
+                            sx={{
+                              display: "flex",
+                              alignItems: "center",
+                              justifyContent: "space-between",
+                              padding: "10px 12px",
+                              border: "1px solid #93C5FD",
+                              borderRadius: "4px",
+                              backgroundColor: "#EFF6FF",
+                            }}
+                          >
+                            <Box
+                              sx={{
+                                display: "flex",
+                                alignItems: "center",
+                                gap: 1.5,
+                                flex: 1,
+                                minWidth: 0,
+                              }}
+                            >
+                              <FileIcon size={18} color="#4C7BF4" />
+                              <Box sx={{ minWidth: 0, flex: 1 }}>
+                                <Typography
+                                  sx={{
+                                    fontSize: 13,
+                                    fontWeight: 500,
+                                    color: "#1E40AF",
+                                    overflow: "hidden",
+                                    textOverflow: "ellipsis",
+                                    whiteSpace: "nowrap",
+                                  }}
+                                >
+                                  {file.fileName}
+                                </Typography>
+                                {file.size && (
+                                  <Typography
+                                    sx={{
+                                      fontSize: 11,
+                                      color: "#3B82F6",
+                                    }}
+                                  >
+                                    {(file.size / 1024).toFixed(1)} KB
+                                  </Typography>
+                                )}
+                              </Box>
+                            </Box>
+                            <Tooltip title="Remove from queue">
+                              <IconButton
+                                size="small"
+                                onClick={() => handleRemovePendingAttach(String(file.id))}
+                                sx={{
+                                  "color": "#4C7BF4",
+                                  "&:hover": {
+                                    color: "status.error.main",
+                                    backgroundColor: "rgba(211, 47, 47, 0.08)",
+                                  },
+                                }}
+                              >
+                                <DeleteIcon size={16} />
+                              </IconButton>
+                            </Tooltip>
+                          </Box>
+                        ))}
+                      </Stack>
+                    )}
+
+                    {evidenceFiles.length === 0 && uploadFiles.length === 0 && pendingAttachFiles.length === 0 && (
                       <Box
                         sx={{
                           textAlign: "center",
@@ -1290,6 +1448,19 @@ const NISTAIRMFDrawerDialog: React.FC<NISTAIRMFDrawerProps> = ({
           onSubmitRef={onRiskSubmitRef}
         />
       </StandardModal>
+
+      {/* File Picker Modal for attaching existing files */}
+      <FilePickerModal
+        open={showFilePicker}
+        onClose={() => setShowFilePicker(false)}
+        onSelect={handleAttachExistingFiles}
+        excludeFileIds={[
+          ...evidenceFiles.map((f) => String(f.id)),
+          ...pendingAttachFiles.map((f) => String(f.id)),
+        ]}
+        multiSelect={true}
+        title="Attach Existing Files as Evidence"
+      />
     </>
   );
 };

--- a/Clients/src/presentation/components/Drawer/NISTAIRMFDashboardDrawerDialog/index.tsx
+++ b/Clients/src/presentation/components/Drawer/NISTAIRMFDashboardDrawerDialog/index.tsx
@@ -101,6 +101,7 @@ const NISTAIRMFDrawerDialog: React.FC<NISTAIRMFDrawerProps> = ({
   const [selectedRiskForView, setSelectedRiskForView] = useState<LinkedRisk | null>(null);
   const [riskFormData, setRiskFormData] = useState<RiskFormValues | undefined>(undefined);
   const onRiskSubmitRef = useRef<(() => void) | null>(null);
+  const prevSubcategoryIdRef = useRef<number | undefined>(undefined);
 
   const { userRoleName, userId } = useAuth();
   const { users } = useUsers();
@@ -118,11 +119,20 @@ const NISTAIRMFDrawerDialog: React.FC<NISTAIRMFDrawerProps> = ({
 
   // Load evidence files when subcategory changes
   useEffect(() => {
+    const currentId = subcategory?.id;
+    const prevId = prevSubcategoryIdRef.current;
+
     if (subcategory?.evidence_links) {
+      // Always use evidence_links when the prop provides it
       setEvidenceFiles(subcategory.evidence_links as unknown as FileData[]);
-    } else {
+    } else if (currentId !== prevId) {
+      // Only clear evidence files when the subcategory ID actually changed
+      // (prevents parent re-fetch from wiping files after save)
       setEvidenceFiles([]);
     }
+
+    prevSubcategoryIdRef.current = currentId;
+
     // Reset upload and deleted files
     setUploadFiles([]);
     setPendingAttachFiles([]);

--- a/Clients/src/presentation/components/Drawer/NISTAIRMFDashboardDrawerDialog/index.tsx
+++ b/Clients/src/presentation/components/Drawer/NISTAIRMFDashboardDrawerDialog/index.tsx
@@ -1194,25 +1194,27 @@ const NISTAIRMFDrawerDialog: React.FC<NISTAIRMFDrawerProps> = ({
                       </Stack>
                     )}
 
-                    {evidenceFiles.length === 0 && uploadFiles.length === 0 && pendingAttachFiles.length === 0 && (
-                      <Box
-                        sx={{
-                          textAlign: "center",
-                          py: 4,
-                          color: "text.tertiary",
-                          border: `2px dashed ${theme.palette.border.dark}`,
-                          borderRadius: 1,
-                          backgroundColor: "background.accent",
-                        }}
-                      >
-                        <Typography variant="body2" sx={{ mb: 1 }}>
-                          No evidence files uploaded yet
-                        </Typography>
-                        <Typography variant="caption" color={text.disabled}>
-                          Click "Add evidence files" to upload documentation for this subcategory
-                        </Typography>
-                      </Box>
-                    )}
+                    {evidenceFiles.length === 0 &&
+                      uploadFiles.length === 0 &&
+                      pendingAttachFiles.length === 0 && (
+                        <Box
+                          sx={{
+                            textAlign: "center",
+                            py: 4,
+                            color: "text.tertiary",
+                            border: `2px dashed ${theme.palette.border.dark}`,
+                            borderRadius: 1,
+                            backgroundColor: "background.accent",
+                          }}
+                        >
+                          <Typography variant="body2" sx={{ mb: 1 }}>
+                            No evidence files uploaded yet
+                          </Typography>
+                          <Typography variant="caption" color={text.disabled}>
+                            Click "Add evidence files" to upload documentation for this subcategory
+                          </Typography>
+                        </Box>
+                      )}
                   </Stack>
                 </TabPanel>
 

--- a/Clients/src/presentation/pages/ProjectView/Fria/FriaRiskImportModal.tsx
+++ b/Clients/src/presentation/pages/ProjectView/Fria/FriaRiskImportModal.tsx
@@ -71,13 +71,36 @@ const FriaRiskImportModal = ({
     );
   };
 
+  // Normalize 5-level project risk values to FRIA's 3-level scale
+  const normalizeLikelihood = (value?: string): string => {
+    const map: Record<string, string> = {
+      Rare: "Low",
+      Unlikely: "Low",
+      Possible: "Medium",
+      Likely: "High",
+      "Almost Certain": "High",
+    };
+    return map[value || ""] || value || "Medium";
+  };
+
+  const normalizeSeverity = (value?: string): string => {
+    const map: Record<string, string> = {
+      Negligible: "Low",
+      Minor: "Low",
+      Moderate: "Medium",
+      Major: "High",
+      Catastrophic: "High",
+    };
+    return map[value || ""] || value || "Medium";
+  };
+
   const handleImport = () => {
     const selected = risks
       .filter((r) => selectedIds.includes(r.id))
       .map((r) => ({
         risk_description: r.risk_name || r.risk_description || "Imported risk",
-        likelihood: r.likelihood || "Medium",
-        severity: r.severity || r.final_risk_level || "Medium",
+        likelihood: normalizeLikelihood(r.likelihood),
+        severity: normalizeSeverity(r.severity || r.final_risk_level),
         linked_project_risk_id: r.id,
       }));
     onImport(selected);

--- a/Clients/src/presentation/pages/ProjectView/Fria/FriaRiskImportModal.tsx
+++ b/Clients/src/presentation/pages/ProjectView/Fria/FriaRiskImportModal.tsx
@@ -74,10 +74,10 @@ const FriaRiskImportModal = ({
   // Normalize 5-level project risk values to FRIA's 3-level scale
   const normalizeLikelihood = (value?: string): string => {
     const map: Record<string, string> = {
-      Rare: "Low",
-      Unlikely: "Low",
-      Possible: "Medium",
-      Likely: "High",
+      "Rare": "Low",
+      "Unlikely": "Low",
+      "Possible": "Medium",
+      "Likely": "High",
       "Almost Certain": "High",
     };
     return map[value || ""] || value || "Medium";

--- a/Servers/controllers/evidenceHub.ctrl.ts
+++ b/Servers/controllers/evidenceHub.ctrl.ts
@@ -27,7 +27,7 @@ export async function getAllEvidences(req: Request, res: Response) {
   logger.debug("🔍 Fetching all evidences");
 
   try {
-    const evidences = (await getAllEvidencesQuery(req.organizationId!)) as EvidenceHubModel[];
+    const evidences = await getAllEvidencesQuery(req.organizationId!);
 
     if (evidences && evidences.length > 0) {
       logStructured(
@@ -36,7 +36,7 @@ export async function getAllEvidences(req: Request, res: Response) {
         "getAllEvidences",
         "evidenceHub.controller.ts",
       );
-      return res.status(200).json(STATUS_CODE[200](evidences.map((e) => e.toSafeJSON())));
+      return res.status(200).json(STATUS_CODE[200](evidences));
     }
 
     logStructured(

--- a/Servers/database/migrations/20260525130943-widen-fria-risk-item-columns.js
+++ b/Servers/database/migrations/20260525130943-widen-fria-risk-item-columns.js
@@ -1,0 +1,38 @@
+"use strict";
+
+/** @type {import('sequelize-cli').Migration} */
+module.exports = {
+  async up(queryInterface, Sequelize) {
+    const transaction = await queryInterface.sequelize.transaction();
+    try {
+      await queryInterface.sequelize.query(
+        `ALTER TABLE verifywise.fria_risk_items
+          ALTER COLUMN likelihood TYPE VARCHAR(50),
+          ALTER COLUMN severity TYPE VARCHAR(50);`,
+        { transaction },
+      );
+
+      await transaction.commit();
+    } catch (error) {
+      await transaction.rollback();
+      throw error;
+    }
+  },
+
+  async down(queryInterface, Sequelize) {
+    const transaction = await queryInterface.sequelize.transaction();
+    try {
+      await queryInterface.sequelize.query(
+        `ALTER TABLE verifywise.fria_risk_items
+          ALTER COLUMN likelihood TYPE VARCHAR(10),
+          ALTER COLUMN severity TYPE VARCHAR(10);`,
+        { transaction },
+      );
+
+      await transaction.commit();
+    } catch (error) {
+      await transaction.rollback();
+      throw error;
+    }
+  },
+};

--- a/Servers/repositories/file.repository.ts
+++ b/Servers/repositories/file.repository.ts
@@ -515,7 +515,6 @@ export async function getOrganizationFiles(
     FROM files f
     JOIN users u ON f.uploaded_by = u.id
     WHERE f.organization_id = :organizationId
-      AND f.project_id IS NULL
       AND (f.source IS NULL OR f.source != 'policy_editor')
     ORDER BY f.uploaded_time DESC`;
 
@@ -531,7 +530,6 @@ export async function getOrganizationFiles(
     SELECT COUNT(*) as count
     FROM files
     WHERE organization_id = :organizationId
-      AND project_id IS NULL
       AND (source IS NULL OR source != 'policy_editor')`;
 
   const countResult = await sequelize.query(countQuery, {
@@ -913,7 +911,6 @@ export async function getOrganizationFilesWithMetadata(
     LEFT JOIN users m ON f.last_modified_by = m.id
     LEFT JOIN approval_workflows aw ON aw.organization_id = f.organization_id AND f.approval_workflow_id = aw.id
     WHERE f.organization_id = :organizationId
-      AND f.project_id IS NULL
       AND (f.source IS NULL OR f.source != 'policy_editor')
     ORDER BY f.uploaded_time DESC`;
 
@@ -929,7 +926,6 @@ export async function getOrganizationFilesWithMetadata(
     SELECT COUNT(*) as count
     FROM files
     WHERE organization_id = :organizationId
-      AND project_id IS NULL
       AND (source IS NULL OR source != 'policy_editor')`;
 
   const countResult = await sequelize.query(countQuery, {
@@ -1273,7 +1269,7 @@ export async function createFileEntityLink(
       (organization_id, file_id, framework_type, entity_type, entity_id, project_id, link_type, created_by, created_at)
     VALUES
       (:organizationId, :fileId, :frameworkType, :entityType, :entityId, :projectId, :linkType, :createdBy, NOW())
-    ON CONFLICT (organization_id, file_id, framework_type, entity_type, entity_id) DO NOTHING
+    ON CONFLICT (file_id, framework_type, entity_type, entity_id) DO NOTHING
     RETURNING *`;
 
   const result = await sequelize.query(query, {

--- a/Servers/services/reporting/dataCollector.ts
+++ b/Servers/services/reporting/dataCollector.ts
@@ -370,7 +370,7 @@ export class ReportDataCollector {
 
         controls.forEach((control: any) => {
           progressMap[categoryName].total++;
-          if (control.status === "Compliant" || control.status === "Complete") {
+          if (control.status === "Done") {
             progressMap[categoryName].completed++;
           }
         });
@@ -597,9 +597,7 @@ export class ReportDataCollector {
       });
     });
 
-    const completedControls = allControls.filter(
-      (c) => c.status === "Compliant" || c.status === "Complete",
-    ).length;
+    const completedControls = allControls.filter((c) => c.status === "Done").length;
 
     return {
       overallProgress:

--- a/Servers/utils/evidenceHub.utils.ts
+++ b/Servers/utils/evidenceHub.utils.ts
@@ -1,5 +1,5 @@
 import { sequelize } from "../database/db";
-import { Transaction } from "sequelize";
+import { Transaction, QueryTypes } from "sequelize";
 import { EvidenceHubModel } from "../domain.layer/models/evidenceHub/evidenceHub.model";
 import {
   getEvidenceFilesForEntity,
@@ -8,35 +8,117 @@ import {
   deleteFileEntityLink,
 } from "./files/evidenceFiles.utils";
 
-// Get all evidences
+// Helper to normalize a date value to an ISO string or null
+const toISO = (d: any): string | null => {
+  if (!d) return null;
+  const date = d instanceof Date ? d : new Date(d);
+  return isNaN(date.getTime()) ? null : date.toISOString();
+};
+
+// Get all evidences (includes evidence_hub records + NIST AI RMF virtual records)
 export const getAllEvidencesQuery = async (organizationId: number) => {
-  const evidences = await sequelize.query(
+  // 1. Fetch evidence_hub records as plain objects
+  const evidenceHubRecords = (await sequelize.query(
     `SELECT * FROM evidence_hub WHERE organization_id = :organizationId ORDER BY created_at DESC, id ASC`,
     {
       replacements: { organizationId },
-      mapToModel: true,
-      model: EvidenceHubModel,
+      type: QueryTypes.SELECT,
     },
-  );
+  )) as any[];
 
-  // Batch fetch evidence files from file_entity_links
-  const evidenceIds = evidences.map((e) => e.id!);
-  let filesMap = new Map<number, any[]>();
-  if (evidenceIds.length > 0) {
-    filesMap = await getEvidenceFilesForEntities(
+  // 2. Fetch NIST AI RMF subcategories that have evidence files
+  const nistRecords = (await sequelize.query(
+    `SELECT
+      s.id AS entity_id,
+      ss.subcategory_id AS index,
+      ss.description,
+      s.reviewer,
+      s.owner,
+      MIN(fel.created_at) AS created_at
+    FROM nist_ai_rmf_subcategories s
+    JOIN nist_ai_rmf_subcategories_struct ss ON s.subcategory_meta_id = ss.id
+    JOIN file_entity_links fel ON fel.entity_id = s.id
+      AND fel.framework_type = 'nist_ai_rmf'
+      AND fel.entity_type = 'subcategory'
+      AND fel.link_type = 'evidence'
+      AND fel.organization_id = s.organization_id
+    WHERE s.organization_id = :organizationId
+    GROUP BY s.id, ss.subcategory_id, ss.description, s.reviewer, s.owner
+    ORDER BY MIN(fel.created_at) DESC, s.id ASC`,
+    {
+      replacements: { organizationId },
+      type: QueryTypes.SELECT,
+    },
+  )) as any[];
+
+  // 3. Batch fetch evidence files for evidence_hub records
+  const evidenceHubIds = evidenceHubRecords.map((e) => e.id);
+  let evidenceHubFilesMap = new Map<number, any[]>();
+  if (evidenceHubIds.length > 0) {
+    evidenceHubFilesMap = await getEvidenceFilesForEntities(
       organizationId,
       "evidence_hub",
       "evidence",
-      evidenceIds,
+      evidenceHubIds,
     );
   }
 
-  // Attach evidence_files to each evidence for backward compatibility
-  for (const evidence of evidences) {
-    (evidence as any).evidence_files = filesMap.get(evidence.id!) || [];
+  // 4. Batch fetch evidence files for NIST records
+  const nistEntityIds = nistRecords.map((r) => r.entity_id);
+  let nistFilesMap = new Map<number, any[]>();
+  if (nistEntityIds.length > 0) {
+    nistFilesMap = await getEvidenceFilesForEntities(
+      organizationId,
+      "nist_ai_rmf",
+      "subcategory",
+      nistEntityIds,
+    );
   }
 
-  return evidences;
+  // 5. Build unified result set
+  const results: any[] = [];
+
+  // Add evidence_hub records
+  for (const record of evidenceHubRecords) {
+    results.push({
+      id: record.id,
+      evidence_name: record.evidence_name,
+      evidence_type: record.evidence_type,
+      description: record.description,
+      expiry_date: toISO(record.expiry_date),
+      mapped_model_ids: record.mapped_model_ids,
+      mapped_training_ids: record.mapped_training_ids,
+      tags: record.tags,
+      framework_ids: record.framework_ids,
+      reviewer_id: record.reviewer_id,
+      retention_policy: record.retention_policy,
+      created_at: toISO(record.created_at),
+      updated_at: toISO(record.updated_at),
+      evidence_files: evidenceHubFilesMap.get(record.id) || [],
+    });
+  }
+
+  // Add NIST AI RMF virtual records
+  for (const record of nistRecords) {
+    results.push({
+      id: -record.entity_id, // negative ID to avoid collisions with evidence_hub
+      evidence_name: `${record.index}: ${record.description}`,
+      evidence_type: "NIST AI RMF",
+      description: record.description,
+      expiry_date: null,
+      mapped_model_ids: null,
+      mapped_training_ids: null,
+      tags: [],
+      framework_ids: ["nist_ai_rmf"],
+      reviewer_id: record.reviewer,
+      retention_policy: null,
+      created_at: toISO(record.created_at),
+      updated_at: toISO(record.created_at),
+      evidence_files: nistFilesMap.get(record.entity_id) || [],
+    });
+  }
+
+  return results;
 };
 
 // Get evidence by ID

--- a/Servers/utils/nist_ai_rmf.subcategory.utils.ts
+++ b/Servers/utils/nist_ai_rmf.subcategory.utils.ts
@@ -1,4 +1,4 @@
-import { Transaction } from "sequelize";
+import { Transaction, QueryTypes } from "sequelize";
 import { sequelize } from "../database/db";
 import { NISTAIMRFSubcategoryModel } from "../domain.layer/frameworks/NIST-AI-RMF/nist_ai_rmf_subcategory.model";
 import { getEvidenceFilesForEntity } from "./files/evidenceFiles.utils";
@@ -67,7 +67,7 @@ export const getAllNISTAIRMFSubcategoriesBycategoryIdAndtitleQuery = async (
 };
 
 export const getNISTAIRMFSubcategoryByIdQuery = async (id: number, organizationId: number) => {
-  const subcategory = await sequelize.query(
+  const subcategory = (await sequelize.query(
     `SELECT s.*,
             ss.function,
             ss.subcategory_id as index,
@@ -79,12 +79,11 @@ export const getNISTAIRMFSubcategoryByIdQuery = async (id: number, organizationI
      WHERE s.organization_id = :organizationId AND s.id = :id`,
     {
       replacements: { organizationId, id },
-      mapToModel: true,
-      model: NISTAIMRFSubcategoryModel,
+      type: QueryTypes.SELECT,
     },
-  );
+  )) as any[];
 
-  if (!subcategory[0]) {
+  if (!subcategory || subcategory.length === 0) {
     return null;
   }
 
@@ -96,7 +95,7 @@ export const getNISTAIRMFSubcategoryByIdQuery = async (id: number, organizationI
     id,
     "evidence",
   );
-  (subcategory[0] as any).evidence_links = evidenceFiles;
+  subcategory[0].evidence_links = evidenceFiles;
 
   return subcategory[0];
 };


### PR DESCRIPTION
## Describe your changes

## Please ensure all items are checked off before requesting a review:

- [x] I deployed the code locally.
- [x] I have performed a self-review of my code.
- [x] I have included the issue # in the PR.
- [x] I have labelled the PR correctly.
- [x] The issue I am working on is assigned to me.
- [x] I have avoided using hardcoded values to ensure scalability and maintain consistency across the application.
- [x] I have ensured that font sizes, color choices, and other UI elements are referenced from the theme.
- [x] My pull request is focused and addresses a single, specific feature.
- [x] If there are UI changes, I have attached a screenshot or video to this PR.

-----------------------------------

### 1. FRIA → Section 5: "Import from project risks" causes 500 error
**Root cause:** `fria_risk_items.likelihood` and `severity` were `VARCHAR(10)`. Project risks use values like `"Almost Certain"` (15 chars) and `"Catastrophic"` (12 chars), causing DB errors on import.

**Fixes:**
- Created migration `20260525130943-widen-fria-risk-item-columns.js` to widen both columns to `VARCHAR(50)`.
- Updated `FriaRiskImportModal.tsx` to normalize 5-level project risk values to FRIA's 3-level scale (`Low/Medium/High`) before calling `onImport`.

**Mapping:**
- Likelihood: `Rare`/`Unlikely` → Low, `Possible` → Medium, `Likely`/`Almost Certain` → High
- Severity: `Negligible`/`Minor` → Low, `Moderate` → Medium, `Major`/`Catastrophic` → High

---

### 2. NIST AI RMF Evidence: missing existing-file picker & files don't appear after upload
**Root cause (Bug 2b):** `getNISTAIRMFSubcategoryByIdQuery` used `mapToModel: true` with `NISTAIMRFSubcategoryModel`. The model does not define `evidence_links` as a field, so Express JSON serialization stripped it. Frontend received empty evidence, so files vanished after save.

**Root cause (Bug 2a):** The drawer only had a direct file upload input. No integration with the existing `FilePickerModal` component.

**Fixes:**
- Refactored `getNISTAIRMFSubcategoryByIdQuery` in `Servers/utils/nist_ai_rmf.subcategory.utils.ts` to return a plain object (same pattern as ISO 27001), preserving dynamically injected `evidence_links`.
- Added "Attach existing files" button, `pendingAttachFiles` state, pending attach UI, and `FilePickerModal` integration to `NISTAIRMFDashboardDrawerDialog/index.tsx`.
- On save, pending existing files are attached via `attachFilesToEntity()` with `framework_type: "nist_ai_rmf"`, `entity_type: "subcategory"`.

---

### 3. Reporting: Overall Progress and Completed show 0%
**Root cause:** `dataCollector.ts` counted a control as completed only if `status === "Compliant" || status === "Complete"`. The actual `controls_eu` table uses the PostgreSQL enum `enum_controls_status` with values `('Waiting', 'In progress', 'Done')`. Completed controls have status `"Done"`, which was never matched.

**Fix:**
- Updated `collectCompliance()` and `collectComplianceProgress()` in `Servers/services/reporting/dataCollector.ts` to count controls with `status === "Done"` as completed.

---

## Commit Log

| Commit | Message |
|--------|---------|
| `2f230f15c` | fix(fria): widen likelihood/severity columns to VARCHAR(50) |
| `002ae6960` | fix(fria): normalize 5-level risk values to 3-level on import |
| `51ffd74bf` | fix(nist-ai-rmf): preserve evidence_links in get-by-id response |
| `41f4565fb` | feat(nist-ai-rmf): add attach-existing-files button to evidence tab |
| `7f7b3823e` | fix(reporting): count Done controls as completed in compliance section |
