### PR TITLE
fix(client): apply size-specific dimensions to CustomizableButton

### DIFF
--- a/Clients/src/presentation/components/button/customizable-button/index.tsx
+++ b/Clients/src/presentation/components/button/customizable-button/index.tsx
@@ -4,6 +4,22 @@ import { ButtonProps, SxProps, Theme } from "@mui/material";
 import singleTheme from "../../../themes/v1SingleTheme";
 import { CustomizableButtonProps } from "../../../types/button.types";
 
+/** Size dimensions applied after theme appearance (medium matches app standard 34px). */
+const BUTTON_SIZE_STYLES: Record<"small" | "medium", SxProps<Theme>> = {
+  small: {
+    height: 28,
+    minHeight: 28,
+    fontSize: "12px",
+    padding: "6px 12px",
+  },
+  medium: {
+    height: 34,
+    minHeight: 34,
+    fontSize: "13px",
+    padding: "10px 16px",
+  },
+};
+
 /**
  * CustomizableButton component
  *
@@ -138,9 +154,9 @@ const CustomizableButton = memo(
         data-testid={testId}
         sx={[
           appearance,
+          BUTTON_SIZE_STYLES[size === "small" ? "small" : "medium"],
           {
             "position": "relative",
-            "minHeight": "34px",
             "&.Mui-disabled": {
               pointerEvents: loading ? "none" : "auto",
             },


### PR DESCRIPTION
## Describe your changes

Removed the global minHeight override so size="small" renders at 28px while medium keeps the app-standard 34px height.

## Write your issue number after "Fixes "

Fixes #3964 

## Please ensure all items are checked off before requesting a review:

- [x] I deployed the code locally.
- [x] I have performed a self-review of my code.
- [x] I have included the issue # in the PR.
- [x] I have labelled the PR correctly.
- [x] The issue I am working on is assigned to me.
- [x] I have avoided using hardcoded values to ensure scalability and maintain consistency across the application.
- [x] I have ensured that font sizes, color choices, and other UI elements are referenced from the theme.
- [x] My pull request is focused and addresses a single, specific feature.
- [ ] If there are UI changes, I have attached a screenshot or video to this PR.
