### PR TITLE
fix(evals): align table headers with their centered body cells

### DIFF
--- a/Clients/src/presentation/components/Table/ArenaTable/index.tsx
+++ b/Clients/src/presentation/components/Table/ArenaTable/index.tsx
@@ -33,13 +33,16 @@ export interface ArenaTableProps {
   deleting?: string | null;
 }
 
+// BATTLE NAME body cell is left-aligned (default); every other body cell uses
+// textAlign: "center". StandardTableHead defaults to left when `align` is
+// omitted, so headers must match here or they drift off their column.
 const columns: StandardColumn[] = [
   { id: "name", label: "BATTLE NAME", sortable: true },
-  { id: "contestants", label: "CONTESTANTS", sortable: false },
-  { id: "dataset", label: "DATASET", sortable: true },
-  { id: "winner", label: "WINNER", sortable: true },
-  { id: "createdAt", label: "DATE", sortable: true },
-  { id: "actions", label: "ACTION", sortable: false },
+  { id: "contestants", label: "CONTESTANTS", sortable: false, align: "center" },
+  { id: "dataset", label: "DATASET", sortable: true, align: "center" },
+  { id: "winner", label: "WINNER", sortable: true, align: "center" },
+  { id: "createdAt", label: "DATE", sortable: true, align: "center" },
+  { id: "actions", label: "ACTION", sortable: false, align: "center" },
 ];
 
 const ArenaTable: React.FC<ArenaTableProps> = ({

--- a/Clients/src/presentation/components/Table/DatasetsTable/index.tsx
+++ b/Clients/src/presentation/components/Table/DatasetsTable/index.tsx
@@ -37,14 +37,18 @@ export interface DatasetsTableProps {
   hidePagination?: boolean;
 }
 
+// NAME body cell is left-aligned (default); every other body cell uses
+// textAlign: "center". StandardTableHead defaults to left when `align` is
+// omitted, so any column whose body is centered must declare align: "center"
+// here or the header will visually drift off its column.
 const columns: StandardColumn[] = [
   { id: "name", label: "NAME", sortable: true },
-  { id: "type", label: "TYPE", sortable: true },
-  { id: "useCase", label: "USE CASE", sortable: true },
-  { id: "promptCount", label: "# PROMPTS", sortable: true },
-  { id: "difficulty", label: "DIFFICULTY", sortable: true },
-  { id: "createdAt", label: "DATE", sortable: true },
-  { id: "actions", label: "ACTION", sortable: false },
+  { id: "type", label: "TYPE", sortable: true, align: "center" },
+  { id: "useCase", label: "USE CASE", sortable: true, align: "center" },
+  { id: "promptCount", label: "# PROMPTS", sortable: true, align: "center" },
+  { id: "difficulty", label: "DIFFICULTY", sortable: true, align: "center" },
+  { id: "createdAt", label: "DATE", sortable: true, align: "center" },
+  { id: "actions", label: "ACTION", sortable: false, align: "center" },
 ];
 
 const DatasetsTable: React.FC<DatasetsTableProps> = ({

--- a/Clients/src/presentation/components/Table/EvaluationTable/index.tsx
+++ b/Clients/src/presentation/components/Table/EvaluationTable/index.tsx
@@ -53,6 +53,11 @@ const columnWidths: Record<string, string> = {
   "ACTION": "60px",
 };
 
+// EXPERIMENT NAME body cell is left-aligned (default); every other body cell
+// uses textAlign: "center". StandardTableHead defaults to left when `align`
+// is omitted, so headers must match here or they drift off their column.
+const LEFT_ALIGNED_LABELS = new Set<string>(["EXPERIMENT NAME"]);
+
 const toStandardColumns = (labels: string[]): StandardColumn[] =>
   labels.map((label) => ({
     id: columnSortKeys[label] || label.toLowerCase(),
@@ -60,6 +65,7 @@ const toStandardColumns = (labels: string[]): StandardColumn[] =>
     sortable: !!columnSortKeys[label],
     width: columnWidths[label],
     minWidth: label === "ACTION" ? "60px" : undefined,
+    align: LEFT_ALIGNED_LABELS.has(label) ? "left" : "center",
   }));
 
 const EvaluationTable: React.FC<IEvaluationTableProps> = ({

--- a/Clients/src/presentation/components/Table/ScorersTable/index.tsx
+++ b/Clients/src/presentation/components/Table/ScorersTable/index.tsx
@@ -35,13 +35,16 @@ export interface ScorersTableProps {
   loading?: boolean;
 }
 
+// SCORER body cell is left-aligned (default); every other body cell uses
+// textAlign: "center". StandardTableHead defaults to left when `align` is
+// omitted, so headers must match here or they drift off their column.
 const columns: StandardColumn[] = [
   { id: "name", label: "SCORER", sortable: true },
-  { id: "model", label: "MODEL", sortable: true },
-  { id: "threshold", label: "THRESHOLD", sortable: true },
-  { id: "choiceScores", label: "# CHOICE SCORES", sortable: true },
-  { id: "createdAt", label: "LAST RUN", sortable: true },
-  { id: "actions", label: "ACTION", sortable: false },
+  { id: "model", label: "MODEL", sortable: true, align: "center" },
+  { id: "threshold", label: "THRESHOLD", sortable: true, align: "center" },
+  { id: "choiceScores", label: "# CHOICE SCORES", sortable: true, align: "center" },
+  { id: "createdAt", label: "LAST RUN", sortable: true, align: "center" },
+  { id: "actions", label: "ACTION", sortable: false, align: "center" },
 ];
 
 const getModelName = (scorer: ScorerRow): string => {


### PR DESCRIPTION
## Describe your changes

In four of our evals tables (Datasets, Scorers, Arena, Experiments) the body cells are centered but the headers above them sit on the left, so the columns look misaligned. The cause is just a missing `align: "center"` on the column configs — `StandardTableHead` defaults to left when you don't set it. Adding it lines the headers back up with the data.

## Write your issue number after "Fixes "

Fixes #3971 

## Please ensure all items are checked off before requesting a review:

- [x] I deployed the code locally.
- [x] I have performed a self-review of my code.
- [x] I have included the issue # in the PR.
- [x] I have labelled the PR correctly.
- [x] The issue I am working on is assigned to me.
- [x] I have avoided using hardcoded values to ensure scalability and maintain consistency across the application.
- [x] I have ensured that font sizes, color choices, and other UI elements are referenced from the theme.
- [x] My pull request is focused and addresses a single, specific feature.
- [x] If there are UI changes, I have attached a screenshot or video to this PR.