### PR TITLE
fix(evals): normalize judge model shape so OpenRouter judges run

### DIFF
--- a/Clients/src/application/hooks/useModelPreferences.ts
+++ b/Clients/src/application/hooks/useModelPreferences.ts
@@ -100,9 +100,7 @@ export function useModelPreferences(projectId: string, orgId?: string | null) {
                   latestJudge.config?.provider ||
                   "openai",
                 model:
-                  latestJudge.config?.judgeModel?.name ||
-                  latestJudge.config?.model ||
-                  "gpt-4o",
+                  latestJudge.config?.judgeModel?.name || latestJudge.config?.model || "gpt-4o",
                 endpointUrl:
                   latestJudge.config?.judgeModel?.endpointUrl ||
                   latestJudge.config?.endpointUrl ||

--- a/Clients/src/application/hooks/useModelPreferences.ts
+++ b/Clients/src/application/hooks/useModelPreferences.ts
@@ -56,9 +56,18 @@ export function useModelPreferences(projectId: string, orgId?: string | null) {
         deepEvalScorersService.list({ org_id: currentOrgId || undefined }),
       ]);
 
-      // Find the latest judge scorer (type: "llm" with judge config)
+      // Find the latest judge scorer (type: "llm" with judge config).
+      // Scorers may be persisted in either the flat shape ({provider, model}) used by
+      // this hook historically, or the nested shape ({judgeModel: {name, provider}})
+      // used by the Scorers page. Accept both so we don't lose the latest pick.
       const latestJudge = scorersRes.scorers
-        .filter((s) => s.type === "llm" && s.config?.provider && s.config?.model)
+        .filter((s) => {
+          if (s.type !== "llm") return false;
+          const cfg = s.config;
+          const provider = cfg?.judgeModel?.provider || cfg?.provider;
+          const model = cfg?.judgeModel?.name || cfg?.model;
+          return Boolean(provider && model);
+        })
         .sort((a, b) => {
           const dateA = a.updatedAt ? new Date(a.updatedAt).getTime() : 0;
           const dateB = b.updatedAt ? new Date(b.updatedAt).getTime() : 0;
@@ -80,12 +89,24 @@ export function useModelPreferences(projectId: string, orgId?: string | null) {
                 accessMethod: "",
                 endpointUrl: undefined,
               },
-          // Use latest judge from scorers, or default
+          // Use latest judge from scorers, or default. Read both shapes:
+          // nested config.judgeModel.{name,provider,endpointUrl} takes precedence
+          // (canonical / Scorers-page shape), with fall-through to the flat
+          // {provider, model, endpointUrl} historically written by this hook.
           judgeLlm: latestJudge
             ? {
-                provider: latestJudge.config?.provider || "openai",
-                model: latestJudge.config?.model || "gpt-4o",
-                endpointUrl: latestJudge.config?.endpointUrl || undefined,
+                provider:
+                  latestJudge.config?.judgeModel?.provider ||
+                  latestJudge.config?.provider ||
+                  "openai",
+                model:
+                  latestJudge.config?.judgeModel?.name ||
+                  latestJudge.config?.model ||
+                  "gpt-4o",
+                endpointUrl:
+                  latestJudge.config?.judgeModel?.endpointUrl ||
+                  latestJudge.config?.endpointUrl ||
+                  undefined,
               }
             : {
                 provider: "openai",
@@ -164,9 +185,19 @@ export function useModelPreferences(projectId: string, orgId?: string | null) {
         if (prefs.judgeLlm?.provider && prefs.judgeLlm?.model) {
           const scorersRes = await deepEvalScorersService.list({ org_id: currentOrgId });
           const judgeScorerName = `Judge: ${prefs.judgeLlm.model}`;
+          // Persist BOTH shapes:
+          //  - nested `judgeModel` is what EvalServer's run_custom_scorer reads at
+          //    runtime; omitting it causes "Scorer has no judge model configured".
+          //  - flat `provider` / `model` are kept for backward compatibility with
+          //    older reads elsewhere in the UI.
           const judgeConfig = {
             provider: prefs.judgeLlm.provider,
             model: prefs.judgeLlm.model,
+            judgeModel: {
+              name: prefs.judgeLlm.model,
+              provider: prefs.judgeLlm.provider,
+              ...(prefs.judgeLlm.endpointUrl ? { endpointUrl: prefs.judgeLlm.endpointUrl } : {}),
+            },
             ...(prefs.judgeLlm.endpointUrl ? { endpointUrl: prefs.judgeLlm.endpointUrl } : {}),
           };
 

--- a/EvalServer/src/utils/run_custom_scorer.py
+++ b/EvalServer/src/utils/run_custom_scorer.py
@@ -274,20 +274,52 @@ async def run_custom_scorer(
     scorer_id = scorer_config.get("id", "unknown")
     scorer_name = scorer_config.get("name", "Custom Scorer")
     config = scorer_config.get("config", {})
-    
-    # Get judge model settings - handle both object and string formats
-    judge_model_config = config.get("judgeModel", {})
-    if isinstance(judge_model_config, dict):
-        model_name = judge_model_config.get("name")
-        model_params = judge_model_config.get("params", {})
+
+    # Normalize judge-model shape. Scorers may be persisted in any of three shapes
+    # depending on which write path created them:
+    #   1. Nested (Scorers page / _upsert_judge_scorer):
+    #        config = {"provider": ..., "judgeModel": {"name", "provider", ...}, ...}
+    #   2. Legacy string (very old records):
+    #        config = {"judgeModel": "<model name>"}
+    #   3. Flat (older useModelPreferences.savePreferences output — see PR fix):
+    #        config = {"provider": ..., "model": ..., ...}  # no judgeModel key
+    # We merge them into one canonical nested dict, with nested values taking
+    # precedence over flat ones, so downstream code only has to deal with shape #1.
+    raw_judge_model = config.get("judgeModel")
+    if isinstance(raw_judge_model, dict):
+        judge_model_config: Dict[str, Any] = {
+            "name": raw_judge_model.get("name") or config.get("model"),
+            "provider": raw_judge_model.get("provider") or config.get("provider"),
+            "params": raw_judge_model.get("params") or config.get("modelParams") or {},
+            "endpointUrl": raw_judge_model.get("endpointUrl") or config.get("endpointUrl"),
+            "apiKey": raw_judge_model.get("apiKey") or config.get("apiKey"),
+        }
+    elif isinstance(raw_judge_model, str):
+        judge_model_config = {
+            "name": raw_judge_model,
+            "provider": config.get("provider"),
+            "params": config.get("modelParams") or {},
+            "endpointUrl": config.get("endpointUrl"),
+            "apiKey": config.get("apiKey"),
+        }
     else:
-        # Legacy: judgeModel is just a string
-        model_name = judge_model_config
-        model_params = {}
-    
+        judge_model_config = {
+            "name": config.get("model"),
+            "provider": config.get("provider"),
+            "params": config.get("modelParams") or {},
+            "endpointUrl": config.get("endpointUrl"),
+            "apiKey": config.get("apiKey"),
+        }
+
+    model_name = judge_model_config.get("name")
+    model_params = judge_model_config.get("params") or {}
+
     if not model_name:
-        raise ValueError(f"Scorer {scorer_name} has no judge model configured")
-    
+        raise ValueError(
+            f"Scorer {scorer_name} has no judge model configured "
+            "(checked config.judgeModel.name, config.judgeModel (str), and config.model)"
+        )
+
     # Get the provider from config (user explicitly selects provider + model)
     provider, endpoint_url, config_api_key = get_provider_from_config(judge_model_config)
     print(f"   🔍 Using provider: {provider} for model: {model_name}")


### PR DESCRIPTION
## Describe your changes

When users picked a scorer with an OpenRouter judge LLM, the evaluation crashed with `Scorer X has no judge model configured`. Reason: the New Experiment modal saved the judge config in a flat `{provider, model}` shape, but the EvalServer expected a nested `{judgeModel: {name, provider, ...}}` shape. They were just two slightly different schemas for the same data.

This fixes both sides — the frontend now writes the nested shape (and keeps the flat fields for backward compat reads), and the backend normalizes whatever shape it gets so any older scorer records keep working.

## Write your issue number after "Fixes "

Fixes #3974 

## Please ensure all items are checked off before requesting a review:

- [x] I deployed the code locally.
- [x] I have performed a self-review of my code.
- [x] I have included the issue # in the PR.
- [x] I have labelled the PR correctly.
- [x] The issue I am working on is assigned to me.
- [x] I have avoided using hardcoded values to ensure scalability and maintain consistency across the application.
- [x] I have ensured that font sizes, color choices, and other UI elements are referenced from the theme.
- [x] My pull request is focused and addresses a single, specific feature.
- [x] If there are UI changes, I have attached a screenshot or video to this PR.