### PR TITLE
fix(evals): move Choose Dataset Format actions into modal footer

### DIFF
--- a/Clients/src/presentation/pages/EvalsDashboard/ProjectDatasets.tsx
+++ b/Clients/src/presentation/pages/EvalsDashboard/ProjectDatasets.tsx
@@ -3348,6 +3348,43 @@ export function ProjectDatasets({ projectId, orgId }: ProjectDatasetsProps) {
         title="Choose dataset format"
         description="Select the type and format for your new dataset"
         maxWidth="520px"
+        submitButtonText="Create Dataset"
+        onSubmit={() => {
+          setCreateTypeSelectionOpen(false);
+
+          // Initialize with appropriate format based on selection
+          if (newDatasetTurnType === "single-turn") {
+            const singleTurnPrompt: SingleTurnPrompt = {
+              id: "prompt_1",
+              category: "general",
+              prompt: "",
+              expected_output: "",
+              difficulty: "medium",
+              ...(newDatasetUseCase === "rag" ? { retrieval_context: [] } : {}),
+            };
+            setEditablePrompts([singleTurnPrompt]);
+          } else {
+            const multiTurnConversation: MultiTurnConversation = {
+              id: "conversation_1",
+              scenario: "",
+              expected_outcome: "",
+              turns: [{ role: "user", content: "" }],
+              ...(newDatasetUseCase === "rag" ? { context: [] } : {}),
+            };
+            setEditablePrompts([multiTurnConversation]);
+          }
+
+          setEditDatasetName("");
+          setEditingDataset({
+            key: "new",
+            name: "New Dataset",
+            path: "",
+            use_case: newDatasetUseCase,
+            datasetType: newDatasetUseCase,
+            turnType: newDatasetTurnType,
+          });
+          setEditorOpen(true);
+        }}
       >
         <Stack spacing="20px">
           {/* Use Case Selection */}
@@ -3472,55 +3509,6 @@ export function ProjectDatasets({ projectId, orgId }: ProjectDatasetsProps) {
             </Typography>
           </Box>
 
-          {/* Action Buttons */}
-          <Stack direction="row" spacing={2} justifyContent="flex-end">
-            <CustomizableButton
-              variant="text"
-              text="Cancel"
-              onClick={() => setCreateTypeSelectionOpen(false)}
-              sx={{ color: palette.text.tertiary }}
-            />
-            <CustomizableButton
-              variant="contained"
-              text="Create Dataset"
-              onClick={() => {
-                setCreateTypeSelectionOpen(false);
-
-                // Initialize with appropriate format based on selection
-                if (newDatasetTurnType === "single-turn") {
-                  const singleTurnPrompt: SingleTurnPrompt = {
-                    id: "prompt_1",
-                    category: "general",
-                    prompt: "",
-                    expected_output: "",
-                    difficulty: "medium",
-                    ...(newDatasetUseCase === "rag" ? { retrieval_context: [] } : {}),
-                  };
-                  setEditablePrompts([singleTurnPrompt]);
-                } else {
-                  const multiTurnConversation: MultiTurnConversation = {
-                    id: "conversation_1",
-                    scenario: "",
-                    expected_outcome: "",
-                    turns: [{ role: "user", content: "" }],
-                    ...(newDatasetUseCase === "rag" ? { context: [] } : {}),
-                  };
-                  setEditablePrompts([multiTurnConversation]);
-                }
-
-                setEditDatasetName("");
-                setEditingDataset({
-                  key: "new",
-                  name: "New Dataset",
-                  path: "",
-                  use_case: newDatasetUseCase,
-                  datasetType: newDatasetUseCase,
-                  turnType: newDatasetTurnType,
-                });
-                setEditorOpen(true);
-              }}
-            />
-          </Stack>
         </Stack>
       </ModalStandard>
     </Stack>

--- a/Clients/src/presentation/pages/EvalsDashboard/ProjectDatasets.tsx
+++ b/Clients/src/presentation/pages/EvalsDashboard/ProjectDatasets.tsx
@@ -3508,7 +3508,6 @@ export function ProjectDatasets({ projectId, orgId }: ProjectDatasetsProps) {
                   : "Conversations with scenario, multiple turns (user/assistant), and expected outcome"}
             </Typography>
           </Box>
-
         </Stack>
       </ModalStandard>
     </Stack>


### PR DESCRIPTION
## Describe your changes

The "Choose dataset format" modal had two Cancel buttons and a Create Dataset button floating in the middle of the content. That's because the page was rendering its own action buttons inside the modal body while `StandardModal` was already rendering its own Cancel in the footer. Fix is to drop the inline buttons and use the modal's built-in `onSubmit` + `submitButtonText` props, so Cancel and Create Dataset both land in the gradient footer where they belong.

## Write your issue number after "Fixes "

Fixes #3975 

## Please ensure all items are checked off before requesting a review:

- [x] I deployed the code locally.
- [x] I have performed a self-review of my code.
- [x] I have included the issue # in the PR.
- [x] I have labelled the PR correctly.
- [x] The issue I am working on is assigned to me.
- [x] I have avoided using hardcoded values to ensure scalability and maintain consistency across the application.
- [x] I have ensured that font sizes, color choices, and other UI elements are referenced from the theme.
- [x] My pull request is focused and addresses a single, specific feature.
- [x] If there are UI changes, I have attached a screenshot or video to this PR.