### PR TITLE
Rename Generic Handler Functions

### DIFF
--- a/Clients/.gitattributes
+++ b/Clients/.gitattributes
@@ -1,0 +1,2 @@
+# Force LF line endings for all text files so Prettier "endOfLine: lf" works on Windows
+* text=auto eol=lf

--- a/Clients/src/presentation/components/IconButton/index.tsx
+++ b/Clients/src/presentation/components/IconButton/index.tsx
@@ -70,7 +70,7 @@ function IconButton({
     setAnchorEl(event.currentTarget);
   };
 
-  function closeDropDownMenu(e: React.SyntheticEvent) {
+  function closeActionMenu(e: React.SyntheticEvent) {
     e.stopPropagation();
     setAnchorEl(null);
   }
@@ -82,7 +82,7 @@ function IconButton({
     setIsOpenRemoveModal(false);
 
     if (e) {
-      closeDropDownMenu(e);
+      closeActionMenu(e);
     }
 
     try {
@@ -112,7 +112,7 @@ function IconButton({
       }
       setIsOpenRemoveModal(false);
       if (e) {
-        closeDropDownMenu(e);
+        closeActionMenu(e);
       }
     } else {
       await handleDelete(e);
@@ -132,7 +132,7 @@ function IconButton({
   const handleEdit = (e?: React.SyntheticEvent) => {
     onEdit();
     if (e) {
-      closeDropDownMenu(e);
+      closeActionMenu(e);
       onMouseEvent?.(e);
     }
   };
@@ -141,7 +141,7 @@ function IconButton({
     if (onView) {
       onView();
       if (e) {
-        closeDropDownMenu(e);
+        closeActionMenu(e);
         onMouseEvent?.(e);
       }
     }
@@ -151,7 +151,7 @@ function IconButton({
     if (openLinkedPolicies) {
       openLinkedPolicies();
       if (e) {
-        closeDropDownMenu(e);
+        closeActionMenu(e);
       }
     }
   };
@@ -161,7 +161,7 @@ function IconButton({
       onMakeVisible();
     }
     if (e) {
-      closeDropDownMenu(e);
+      closeActionMenu(e);
     }
   };
 
@@ -179,7 +179,7 @@ function IconButton({
       });
     } finally {
       if (e) {
-        closeDropDownMenu(e);
+        closeActionMenu(e);
       }
     }
   };
@@ -189,7 +189,7 @@ function IconButton({
       await onSendTest();
     }
     if (e) {
-      closeDropDownMenu(e);
+      closeActionMenu(e);
     }
   };
 
@@ -198,7 +198,7 @@ function IconButton({
       await onToggleEnable();
     }
     if (e) {
-      closeDropDownMenu(e);
+      closeActionMenu(e);
     }
   };
 
@@ -207,7 +207,7 @@ function IconButton({
       onRestore();
     }
     if (e) {
-      closeDropDownMenu(e);
+      closeActionMenu(e);
     }
   };
 
@@ -216,7 +216,7 @@ function IconButton({
       onLinkedObjects();
     }
     if (e) {
-      closeDropDownMenu(e);
+      closeActionMenu(e);
     }
   };
 
@@ -226,7 +226,7 @@ function IconButton({
     }
     setIsOpenHardDeleteModal(false);
     if (e) {
-      closeDropDownMenu(e);
+      closeActionMenu(e);
     }
   };
 
@@ -235,7 +235,7 @@ function IconButton({
       await onDownloadPDF();
     }
     if (e) {
-      closeDropDownMenu(e);
+      closeActionMenu(e);
     }
   };
 
@@ -244,14 +244,14 @@ function IconButton({
       await onDownloadDOCX();
     }
     if (e) {
-      closeDropDownMenu(e);
+      closeActionMenu(e);
     }
   };
 
   function handleCancel(e?: React.SyntheticEvent) {
     setIsOpenRemoveModal(false);
     if (e) {
-      closeDropDownMenu(e);
+      closeActionMenu(e);
     }
   }
 
@@ -377,7 +377,7 @@ function IconButton({
     <Menu
       anchorEl={anchorEl}
       open={Boolean(anchorEl)}
-      onClose={(e: React.SyntheticEvent) => closeDropDownMenu(e)}
+      onClose={(e: React.SyntheticEvent) => closeActionMenu(e)}
       slotProps={{
         paper: {
           sx: dropDownStyle,
@@ -438,9 +438,9 @@ function IconButton({
                   if (onAssignToFolder) {
                     onAssignToFolder();
                   }
-                  if (e) closeDropDownMenu(e);
+                  if (e) closeActionMenu(e);
                 } else if (item === "preview") {
-                  if (e) closeDropDownMenu(e);
+                  if (e) closeActionMenu(e);
                   if (onPreview) {
                     try {
                       await onPreview();
@@ -449,7 +449,7 @@ function IconButton({
                     }
                   }
                 } else if (item === "edit_metadata") {
-                  if (e) closeDropDownMenu(e);
+                  if (e) closeActionMenu(e);
                   if (onEditMetadata) {
                     try {
                       await onEditMetadata();
@@ -461,12 +461,12 @@ function IconButton({
                   if (onViewHistory) {
                     onViewHistory();
                   }
-                  if (e) closeDropDownMenu(e);
+                  if (e) closeActionMenu(e);
                 } else if (item === "delete" && (type === "Task" || type === "task")) {
                   // Task hard delete action
                   if (hardDeleteWarningTitle && hardDeleteWarningMessage) {
                     setIsOpenHardDeleteModal(true);
-                    if (e) closeDropDownMenu(e);
+                    if (e) closeActionMenu(e);
                   } else {
                     handleHardDelete(e);
                   }
@@ -474,14 +474,14 @@ function IconButton({
                   // Task archive action (soft delete)
                   if (warningTitle && warningMessage) {
                     setIsOpenRemoveModal(true);
-                    if (e) closeDropDownMenu(e);
+                    if (e) closeActionMenu(e);
                   } else {
                     handleDelete(e);
                   }
                 } else if (item === "remove" || item === "archive") {
                   if (warningTitle && warningMessage) {
                     setIsOpenRemoveModal(true);
-                    if (e) closeDropDownMenu(e);
+                    if (e) closeActionMenu(e);
                   } else {
                     if (checkForRisks && onDeleteWithRisks) {
                       handleDeleteWithRiskCheck(e);

--- a/Clients/src/presentation/components/Modals/AiOrNotScreening/index.tsx
+++ b/Clients/src/presentation/components/Modals/AiOrNotScreening/index.tsx
@@ -117,7 +117,7 @@ const AiOrNotScreening: React.FC<AiOrNotScreeningProps> = ({
     setActiveStep((prev) => prev - 1);
   }, []);
 
-  const handleSubmit = useCallback(() => {
+  const handleRunScreening = useCallback(() => {
     if (result) {
       handleClose();
       onComplete(result.isAi);
@@ -422,7 +422,7 @@ const AiOrNotScreening: React.FC<AiOrNotScreeningProps> = ({
       activeStep={activeStep}
       onNext={handleNext}
       onBack={handleBack}
-      onSubmit={handleSubmit}
+      onSubmit={handleRunScreening}
       canProceed={canProceed}
       submitButtonText={result?.isAi ? "Create use case" : "Proceed with caution"}
       maxWidth="680px"

--- a/Clients/src/presentation/components/Modals/CreateTask/index.tsx
+++ b/Clients/src/presentation/components/Modals/CreateTask/index.tsx
@@ -222,7 +222,7 @@ const CreateTask: FC<ICreateTaskProps> = ({
     setActiveTab("details");
   };
 
-  const handleSubmit = async (event?: React.FormEvent) => {
+  const handleSaveTask = async (event?: React.FormEvent) => {
     if (event) event.preventDefault();
 
     if (validateAll(values)) {
@@ -468,7 +468,7 @@ const CreateTask: FC<ICreateTaskProps> = ({
           ? "Update task details and assign team members."
           : "Create a new task by filling in the following details."
       }
-      onSubmit={activeTab === "details" ? handleSubmit : undefined}
+      onSubmit={activeTab === "details" ? handleSaveTask : undefined}
       submitButtonText={isEditMode ? "Update task" : "Create task"}
       isSubmitting={isSubmitting}
       maxWidth="800px"

--- a/Clients/src/presentation/components/Modals/EvidenceHub/index.tsx
+++ b/Clients/src/presentation/components/Modals/EvidenceHub/index.tsx
@@ -315,7 +315,7 @@ const NewEvidenceHub: FC<NewEvidenceHubProps> = ({
     setActiveStep((prev) => prev - 1);
   };
 
-  const handleSubmit = async () => {
+  const handleSaveEvidence = async () => {
     if (!validateCurrentStep()) return;
 
     setIsSubmitting(true);
@@ -323,7 +323,7 @@ const NewEvidenceHub: FC<NewEvidenceHubProps> = ({
       if (onSuccess) onSuccess(values);
       setIsOpen(false);
     } catch (error) {
-      console.error("[NewEvidenceHub.handleSubmit] error:", error);
+      console.error("[NewEvidenceHub.handleSaveEvidence] error:", error);
       setIsSubmitting(false);
       if (onError) onError(error);
     }
@@ -618,7 +618,7 @@ const NewEvidenceHub: FC<NewEvidenceHubProps> = ({
       activeStep={activeStep}
       onNext={handleNext}
       onBack={handleBack}
-      onSubmit={handleSubmit}
+      onSubmit={handleSaveEvidence}
       canProceed={canProceed()}
       isSubmitting={isSubmitting}
       submitButtonText={isEdit ? "Update" : "Save"}

--- a/Clients/src/presentation/components/Modals/NewDataset/index.tsx
+++ b/Clients/src/presentation/components/Modals/NewDataset/index.tsx
@@ -235,7 +235,7 @@ const NewDataset: FC<NewDatasetProps> = ({
     onClose: handleClose,
   });
 
-  const handleSubmit = async (event?: React.FormEvent) => {
+  const handleSaveDataset = async (event?: React.FormEvent) => {
     if (event) event.preventDefault();
     if (validateAll(values)) {
       setIsSubmitting(true);
@@ -562,7 +562,7 @@ const NewDataset: FC<NewDatasetProps> = ({
           ? "Update dataset details, classification, and metadata"
           : "Register a new dataset with comprehensive metadata for AI governance"
       }
-      onSubmit={activeTab === "details" ? handleSubmit : undefined}
+      onSubmit={activeTab === "details" ? handleSaveDataset : undefined}
       submitButtonText={isEdit ? "Update dataset" : "Save"}
       isSubmitting={isButtonDisabled}
       maxWidth="760px"

--- a/Clients/src/presentation/components/Modals/NewIncident/index.tsx
+++ b/Clients/src/presentation/components/Modals/NewIncident/index.tsx
@@ -259,7 +259,7 @@ const SideDrawerIncident: FC<SideDrawerIncidentProps> = ({
     setActiveTab("details");
   };
 
-  const handleSubmit = (e?: React.FormEvent) => {
+  const handleSaveIncident = (e?: React.FormEvent) => {
     if (e) e.preventDefault();
     if (validateAll(values)) {
       onSuccess?.(values);
@@ -341,7 +341,7 @@ const SideDrawerIncident: FC<SideDrawerIncidentProps> = ({
         {activeTab === "activity" && isEdit && incidentId ? (
           <HistorySidebar inline isOpen={true} entityType="incident" entityId={incidentId} />
         ) : (
-          <form onSubmit={handleSubmit}>
+          <form onSubmit={handleSaveIncident}>
             <Stack spacing={4} width="100%">
               {/* SECTION 1: INCIDENT INFORMATION */}
               <Stack spacing={4}>
@@ -766,7 +766,7 @@ const SideDrawerIncident: FC<SideDrawerIncidentProps> = ({
                     variant="contained"
                     text={isEdit ? "Update incident" : "Save incident"}
                     icon={<SaveIconSVGWhite />}
-                    onClick={handleSubmit as (event: unknown) => void}
+                    onClick={handleSaveIncident as (event: unknown) => void}
                     sx={{
                       backgroundColor: theme.palette.primary.main,
                       border: `1px solid ${theme.palette.primary.main}`,

--- a/Clients/src/presentation/components/Modals/NewModelInventory/index.tsx
+++ b/Clients/src/presentation/components/Modals/NewModelInventory/index.tsx
@@ -428,7 +428,7 @@ const NewModelInventory: FC<NewModelInventoryProps> = ({
     onClose: handleClose,
   });
 
-  const handleSubmit = async (event?: React.FormEvent) => {
+  const handleSaveModelInventory = async (event?: React.FormEvent) => {
     if (event) event.preventDefault();
     if (validateAll(values)) {
       setIsSubmitting(true);
@@ -939,7 +939,7 @@ const NewModelInventory: FC<NewModelInventoryProps> = ({
           ? "Update model details, approval status, and metadata"
           : "Register a new AI model with comprehensive metadata and approval tracking"
       }
-      onSubmit={activeTab === "details" ? handleSubmit : undefined}
+      onSubmit={activeTab === "details" ? handleSaveModelInventory : undefined}
       submitButtonText={isEdit ? "Update model" : "Save"}
       isSubmitting={isButtonDisabled}
       maxWidth="760px"

--- a/Clients/src/presentation/components/Modals/NewModelRisk/index.tsx
+++ b/Clients/src/presentation/components/Modals/NewModelRisk/index.tsx
@@ -241,7 +241,7 @@ const NewModelRisk: FC<NewModelRiskProps> = ({
     onClose: handleClose,
   });
 
-  const handleSubmit = () => {
+  const handleSaveModelRisk = () => {
     if (validateAll(values)) {
       setIsSubmitting(true);
       if (onSuccess) {
@@ -414,7 +414,7 @@ const NewModelRisk: FC<NewModelRiskProps> = ({
           ? "Update risk details, mitigation plan, and tracking information"
           : "Document and track potential risks associated with AI models"
       }
-      onSubmit={activeTab === "details" ? handleSubmit : undefined}
+      onSubmit={activeTab === "details" ? handleSaveModelRisk : undefined}
       submitButtonText={isEdit ? "Update risk" : "Save"}
       isSubmitting={isSubmitting}
       maxWidth="760px"

--- a/Clients/src/presentation/components/Modals/NewTraining/index.tsx
+++ b/Clients/src/presentation/components/Modals/NewTraining/index.tsx
@@ -222,7 +222,7 @@ const NewTraining: FC<NewTrainingProps> = ({
 
   // Submit: With error boundary (Defensive Programming)
   // Await the onSuccess callback and only close modal on success
-  const handleSubmit = useCallback(
+  const handleSaveTraining = useCallback(
     async (event?: React.FormEvent) => {
       if (event) event.preventDefault();
 
@@ -385,7 +385,7 @@ const NewTraining: FC<NewTrainingProps> = ({
       onClose={handleClose}
       title={isEdit ? "Edit training" : "New training"}
       description="Record and manage your organization's AI literacy and compliance trainings. Enter training details such as name, provider, duration, department, participants, and status to keep a clear history of all AI-related education initiatives."
-      onSubmit={activeTab === "details" ? handleSubmit : undefined}
+      onSubmit={activeTab === "details" ? handleSaveTraining : undefined}
       hideSubmitButton={activeTab !== "details"}
       submitButtonText={isEdit ? "Update training" : "Create training"}
       maxWidth="680px"

--- a/Clients/src/presentation/components/Modals/NewTrainingEvidence/index.tsx
+++ b/Clients/src/presentation/components/Modals/NewTrainingEvidence/index.tsx
@@ -148,7 +148,7 @@ const NewTrainingEvidence: FC<NewTrainingEvidenceProps> = ({
     }));
   }, []);
 
-  const handleSubmit = useCallback(async () => {
+  const handleSaveTrainingEvidence = useCallback(async () => {
     const nextErrors: FormErrors = {};
     if (!values.evidence_name.trim()) nextErrors.evidence_name = "Evidence name is required";
     if (!values.evidence_type) nextErrors.evidence_type = "Evidence type is required";
@@ -199,7 +199,7 @@ const NewTrainingEvidence: FC<NewTrainingEvidenceProps> = ({
         onClose={handleClose}
         title={isEdit ? "Edit training evidence" : "Upload training evidence"}
         description="Upload certificates, attendance proofs, or other compliance evidence for this training."
-        onSubmit={handleSubmit}
+        onSubmit={handleSaveTrainingEvidence}
         submitButtonText={isEdit ? "Update evidence" : "Save evidence"}
         isSubmitting={isSubmitting}
         maxWidth="640px"

--- a/Clients/src/presentation/components/Notes/NoteItem.tsx
+++ b/Clients/src/presentation/components/Notes/NoteItem.tsx
@@ -91,22 +91,22 @@ const NoteItem: React.FC<NoteItemProps> = ({ note, onEdit, onDelete, canEdit, ca
     };
   }, [note.author_id, fetchProfilePhotoAsBlobUrl]);
 
-  const handleMenuOpen = (event: React.MouseEvent<HTMLElement>) => {
+  const openNoteMenu = (event: React.MouseEvent<HTMLElement>) => {
     setAnchorEl(event.currentTarget);
   };
 
-  const handleMenuClose = () => {
+  const closeNoteMenu = () => {
     setAnchorEl(null);
   };
 
   const handleEdit = () => {
     onEdit(note.id, note.content);
-    handleMenuClose();
+    closeNoteMenu();
   };
 
-  const handleDeleteClick = () => {
+  const deleteNote = () => {
     setIsDeleteModalOpen(true);
-    handleMenuClose();
+    closeNoteMenu();
   };
 
   const handleConfirmDelete = () => {
@@ -245,7 +245,7 @@ const NoteItem: React.FC<NoteItemProps> = ({ note, onEdit, onDelete, canEdit, ca
             <Box sx={{ ml: theme.spacing(1.5) }}>
               <IconButton
                 size="small"
-                onClick={handleMenuOpen}
+                onClick={openNoteMenu}
                 sx={{
                   "color": theme.palette.text.secondary,
                   "padding": theme.spacing(1),
@@ -260,7 +260,7 @@ const NoteItem: React.FC<NoteItemProps> = ({ note, onEdit, onDelete, canEdit, ca
               <Menu
                 anchorEl={anchorEl}
                 open={Boolean(anchorEl)}
-                onClose={handleMenuClose}
+                onClose={closeNoteMenu}
                 anchorOrigin={{ vertical: "bottom", horizontal: "right" }}
                 transformOrigin={{ vertical: "top", horizontal: "right" }}
               >
@@ -275,7 +275,7 @@ const NoteItem: React.FC<NoteItemProps> = ({ note, onEdit, onDelete, canEdit, ca
                 )}
                 {canDelete && (
                   <MenuItem
-                    onClick={handleDeleteClick}
+                    onClick={deleteNote}
                     sx={{ color: theme.palette.error.main, fontSize: 13 }}
                   >
                     <DeleteIcon size={16} style={{ marginRight: 8 }} />

--- a/Clients/src/presentation/components/PluginCard/index.tsx
+++ b/Clients/src/presentation/components/PluginCard/index.tsx
@@ -48,25 +48,25 @@ const PluginCard: React.FC<PluginCardProps> = ({
   const [isDeleteModalOpen, setIsDeleteModalOpen] = useState(false);
   const menuOpen = Boolean(anchorEl);
 
-  const handleMenuOpen = (event: React.MouseEvent<HTMLElement>) => {
+  const openPluginMenu = (event: React.MouseEvent<HTMLElement>) => {
     event.stopPropagation();
     setAnchorEl(event.currentTarget);
   };
 
-  const handleMenuClose = (event?: React.MouseEvent) => {
+  const closePluginMenu = (event?: React.MouseEvent) => {
     if (event) event.stopPropagation();
     setAnchorEl(null);
   };
 
   const handleManageClick = (event: React.MouseEvent) => {
     event.stopPropagation();
-    handleMenuClose();
+    closePluginMenu();
     if (onManage) onManage(plugin);
   };
 
   const handleUninstallClick = (event: React.MouseEvent) => {
     event.stopPropagation();
-    handleMenuClose();
+    closePluginMenu();
     setIsDeleteModalOpen(true);
   };
 
@@ -319,7 +319,7 @@ const PluginCard: React.FC<PluginCardProps> = ({
             <>
               <IconButton
                 size="small"
-                onClick={handleMenuOpen}
+                onClick={openPluginMenu}
                 sx={{
                   "color": "brand.primary",
                   "opacity": isHovered ? 1 : 0.7,
@@ -334,7 +334,7 @@ const PluginCard: React.FC<PluginCardProps> = ({
               <Menu
                 anchorEl={anchorEl}
                 open={menuOpen}
-                onClose={() => handleMenuClose()}
+                onClose={() => closePluginMenu()}
                 onClick={(e) => e.stopPropagation()}
                 PaperProps={{
                   sx: {

--- a/Clients/src/presentation/components/Table/ArenaTable/ArenaTableBody.tsx
+++ b/Clients/src/presentation/components/Table/ArenaTable/ArenaTableBody.tsx
@@ -83,13 +83,13 @@ const ArenaTableBody: React.FC<ArenaTableBodyProps> = ({
   const [deleteConfirmOpen, setDeleteConfirmOpen] = useState(false);
   const [rowToDelete, setRowToDelete] = useState<ArenaRow | null>(null);
 
-  const handleMenuOpen = (e: React.MouseEvent<HTMLElement>, row: ArenaRow) => {
+  const openArenaMenu = (e: React.MouseEvent<HTMLElement>, row: ArenaRow) => {
     e.stopPropagation();
     setMenuAnchorEl(e.currentTarget);
     setMenuRow(row);
   };
 
-  const handleMenuClose = () => {
+  const closeArenaMenu = () => {
     setMenuAnchorEl(null);
     setMenuRow(null);
   };
@@ -98,29 +98,29 @@ const ArenaTableBody: React.FC<ArenaTableBodyProps> = ({
     if (menuRow && onViewResults) {
       onViewResults(menuRow);
     }
-    handleMenuClose();
+    closeArenaMenu();
   };
 
   const handleDownloadClick = () => {
     if (menuRow && onDownload) {
       onDownload(menuRow);
     }
-    handleMenuClose();
+    closeArenaMenu();
   };
 
   const handleCopyClick = () => {
     if (menuRow && onCopy) {
       onCopy(menuRow);
     }
-    handleMenuClose();
+    closeArenaMenu();
   };
 
-  const handleDeleteClick = () => {
+  const deleteArenaRow = () => {
     if (menuRow) {
       setRowToDelete(menuRow);
       setDeleteConfirmOpen(true);
     }
-    handleMenuClose();
+    closeArenaMenu();
   };
 
   const handleConfirmDelete = () => {
@@ -282,7 +282,7 @@ const ArenaTableBody: React.FC<ArenaTableBodyProps> = ({
             ) : (
               <IconButton
                 disableRipple={theme.components?.MuiIconButton?.defaultProps?.disableRipple}
-                onClick={(e) => handleMenuOpen(e, row)}
+                onClick={(e) => openArenaMenu(e, row)}
                 sx={singleTheme.iconButtons}
               >
                 <MoreVertical size={18} />
@@ -296,7 +296,7 @@ const ArenaTableBody: React.FC<ArenaTableBodyProps> = ({
       <Popover
         open={Boolean(menuAnchorEl)}
         anchorEl={menuAnchorEl}
-        onClose={handleMenuClose}
+        onClose={closeArenaMenu}
         onClick={(e) => e.stopPropagation()}
         anchorOrigin={{ horizontal: "right", vertical: "bottom" }}
         transformOrigin={{ horizontal: "right", vertical: "top" }}
@@ -385,7 +385,7 @@ const ArenaTableBody: React.FC<ArenaTableBodyProps> = ({
           {onDelete && (
             <CustomizableButton
               variant="outlined"
-              onClick={handleDeleteClick}
+              onClick={deleteArenaRow}
               startIcon={<Trash2 size={14} />}
               sx={{
                 "height": "34px",

--- a/Clients/src/presentation/components/Table/DatasetsTable/DatasetsTableBody.tsx
+++ b/Clients/src/presentation/components/Table/DatasetsTable/DatasetsTableBody.tsx
@@ -41,13 +41,13 @@ const DatasetsTableBody: React.FC<DatasetsTableBodyProps> = ({
   const [menuAnchorEl, setMenuAnchorEl] = useState<null | HTMLElement>(null);
   const [menuRow, setMenuRow] = useState<DatasetRow | null>(null);
 
-  const handleMenuOpen = (e: React.MouseEvent<HTMLElement>, row: DatasetRow) => {
+  const openDatasetMenu = (e: React.MouseEvent<HTMLElement>, row: DatasetRow) => {
     e.stopPropagation();
     setMenuAnchorEl(e.currentTarget);
     setMenuRow(row);
   };
 
-  const handleMenuClose = () => {
+  const closeDatasetMenu = () => {
     setMenuAnchorEl(null);
     setMenuRow(null);
   };
@@ -56,28 +56,28 @@ const DatasetsTableBody: React.FC<DatasetsTableBodyProps> = ({
     if (menuRow && onView) {
       onView(menuRow);
     }
-    handleMenuClose();
+    closeDatasetMenu();
   };
 
   const handleEditClick = () => {
     if (menuRow && onEdit) {
       onEdit(menuRow);
     }
-    handleMenuClose();
+    closeDatasetMenu();
   };
 
-  const handleDeleteClick = () => {
+  const deleteDatasetRow = () => {
     if (menuRow && onDelete) {
       onDelete(menuRow);
     }
-    handleMenuClose();
+    closeDatasetMenu();
   };
 
   const handleDownloadClick = () => {
     if (menuRow && onDownload) {
       onDownload(menuRow);
     }
-    handleMenuClose();
+    closeDatasetMenu();
   };
 
   const formatDate = (dateStr?: string | null): string => {
@@ -285,7 +285,7 @@ const DatasetsTableBody: React.FC<DatasetsTableBodyProps> = ({
             >
               <IconButton
                 size="small"
-                onClick={(e) => handleMenuOpen(e, dataset)}
+                onClick={(e) => openDatasetMenu(e, dataset)}
                 sx={{
                   "color": `${text.icon}`,
                   "padding": "6px",
@@ -305,7 +305,7 @@ const DatasetsTableBody: React.FC<DatasetsTableBodyProps> = ({
       <Popover
         open={Boolean(menuAnchorEl)}
         anchorEl={menuAnchorEl}
-        onClose={handleMenuClose}
+        onClose={closeDatasetMenu}
         onClick={(e) => e.stopPropagation()}
         anchorOrigin={{ horizontal: "right", vertical: "bottom" }}
         transformOrigin={{ horizontal: "right", vertical: "top" }}
@@ -394,7 +394,7 @@ const DatasetsTableBody: React.FC<DatasetsTableBodyProps> = ({
           {onDelete && (
             <CustomizableButton
               variant="outlined"
-              onClick={handleDeleteClick}
+              onClick={deleteDatasetRow}
               startIcon={<Trash2 size={14} />}
               sx={{
                 "height": "34px",

--- a/Clients/src/presentation/components/Table/ExperimentTable/ExperimentTableBody.tsx
+++ b/Clients/src/presentation/components/Table/ExperimentTable/ExperimentTableBody.tsx
@@ -50,38 +50,38 @@ const ExperimentTableBody: React.FC<IExperimentTableBodyProps> = ({
   const showActionsColumn = !compact && Boolean(onRerun || onDelete || onDownload || onCopy);
   const showLinkedModelColumn = !compact;
 
-  const handleMenuOpen = (e: React.MouseEvent<HTMLElement>, row: IExperimentRow) => {
+  const openExperimentMenu = (e: React.MouseEvent<HTMLElement>, row: IExperimentRow) => {
     e.stopPropagation();
     setMenuAnchorEl(e.currentTarget);
     setMenuRow(row);
   };
 
-  const handleMenuClose = () => {
+  const closeExperimentMenu = () => {
     setMenuAnchorEl(null);
     setMenuRow(null);
   };
 
   const handleRerunClick = () => {
     if (menuRow && onRerun) onRerun(menuRow);
-    handleMenuClose();
+    closeExperimentMenu();
   };
 
   const handleDownloadClick = () => {
     if (menuRow && onDownload) onDownload(menuRow);
-    handleMenuClose();
+    closeExperimentMenu();
   };
 
   const handleCopyClick = () => {
     if (menuRow && onCopy) onCopy(menuRow);
-    handleMenuClose();
+    closeExperimentMenu();
   };
 
-  const handleDeleteClick = () => {
+  const deleteExperimentRow = () => {
     if (menuRow) {
       setRowToDelete(menuRow);
       setDeleteModalOpen(true);
     }
-    handleMenuClose();
+    closeExperimentMenu();
   };
 
   const handleConfirmDelete = () => {
@@ -250,7 +250,7 @@ const ExperimentTableBody: React.FC<IExperimentTableBodyProps> = ({
               >
                 <IconButton
                   size="small"
-                  onClick={(e) => handleMenuOpen(e, row)}
+                  onClick={(e) => openExperimentMenu(e, row)}
                   sx={{
                     "color": palette.text.tertiary,
                     "padding": "6px",
@@ -271,7 +271,7 @@ const ExperimentTableBody: React.FC<IExperimentTableBodyProps> = ({
       <Popover
         open={Boolean(menuAnchorEl)}
         anchorEl={menuAnchorEl}
-        onClose={handleMenuClose}
+        onClose={closeExperimentMenu}
         onClick={(e) => e.stopPropagation()}
         anchorOrigin={{ horizontal: "right", vertical: "bottom" }}
         transformOrigin={{ horizontal: "right", vertical: "top" }}
@@ -361,7 +361,7 @@ const ExperimentTableBody: React.FC<IExperimentTableBodyProps> = ({
           {onDelete && (
             <CustomizableButton
               variant="outlined"
-              onClick={handleDeleteClick}
+              onClick={deleteExperimentRow}
               startIcon={<Trash2 size={14} />}
               sx={{
                 "height": "34px",

--- a/Clients/src/presentation/components/Table/ModelsTable/ModelsTableBody.tsx
+++ b/Clients/src/presentation/components/Table/ModelsTable/ModelsTableBody.tsx
@@ -183,22 +183,22 @@ const ModelsTableBody: React.FC<ModelsTableBodyProps> = ({
   const [menuAnchorEl, setMenuAnchorEl] = useState<null | HTMLElement>(null);
   const [menuRow, setMenuRow] = useState<ModelRow | null>(null);
 
-  const handleMenuOpen = (e: React.MouseEvent<HTMLElement>, row: ModelRow) => {
+  const openModelMenu = (e: React.MouseEvent<HTMLElement>, row: ModelRow) => {
     e.stopPropagation();
     setMenuAnchorEl(e.currentTarget);
     setMenuRow(row);
   };
 
-  const handleMenuClose = () => {
+  const closeModelMenu = () => {
     setMenuAnchorEl(null);
     setMenuRow(null);
   };
 
-  const handleDeleteClick = () => {
+  const deleteModelRow = () => {
     if (menuRow && onDelete) {
       onDelete(menuRow);
     }
-    handleMenuClose();
+    closeModelMenu();
   };
 
   return (
@@ -305,7 +305,7 @@ const ModelsTableBody: React.FC<ModelsTableBodyProps> = ({
             >
               <IconButton
                 size="small"
-                onClick={(e) => handleMenuOpen(e, model)}
+                onClick={(e) => openModelMenu(e, model)}
                 sx={{
                   "color": `${text.icon}`,
                   "padding": "6px",
@@ -325,7 +325,7 @@ const ModelsTableBody: React.FC<ModelsTableBodyProps> = ({
       <Popover
         open={Boolean(menuAnchorEl)}
         anchorEl={menuAnchorEl}
-        onClose={handleMenuClose}
+        onClose={closeModelMenu}
         onClick={(e) => e.stopPropagation()}
         anchorOrigin={{ horizontal: "right", vertical: "bottom" }}
         transformOrigin={{ horizontal: "right", vertical: "top" }}
@@ -345,7 +345,7 @@ const ModelsTableBody: React.FC<ModelsTableBodyProps> = ({
           {onDelete && (
             <CustomizableButton
               variant="outlined"
-              onClick={handleDeleteClick}
+              onClick={deleteModelRow}
               startIcon={<Trash2 size={14} />}
               sx={{
                 "height": "34px",

--- a/Clients/src/presentation/components/Table/ScorersTable/ScorersTableBody.tsx
+++ b/Clients/src/presentation/components/Table/ScorersTable/ScorersTableBody.tsx
@@ -51,13 +51,13 @@ const ScorersTableBody: React.FC<ScorersTableBodyProps> = ({
   const [menuAnchorEl, setMenuAnchorEl] = useState<null | HTMLElement>(null);
   const [menuRow, setMenuRow] = useState<ScorerRow | null>(null);
 
-  const handleMenuOpen = (e: React.MouseEvent<HTMLElement>, row: ScorerRow) => {
+  const openScorerMenu = (e: React.MouseEvent<HTMLElement>, row: ScorerRow) => {
     e.stopPropagation();
     setMenuAnchorEl(e.currentTarget);
     setMenuRow(row);
   };
 
-  const handleMenuClose = () => {
+  const closeScorerMenu = () => {
     setMenuAnchorEl(null);
     setMenuRow(null);
   };
@@ -66,14 +66,14 @@ const ScorersTableBody: React.FC<ScorersTableBodyProps> = ({
     if (menuRow && onEdit) {
       onEdit(menuRow);
     }
-    handleMenuClose();
+    closeScorerMenu();
   };
 
-  const handleDeleteClick = () => {
+  const deleteScorerRow = () => {
     if (menuRow && onDelete) {
       onDelete(menuRow);
     }
-    handleMenuClose();
+    closeScorerMenu();
   };
 
   // Helper to get model name from scorer
@@ -175,7 +175,7 @@ const ScorersTableBody: React.FC<ScorersTableBodyProps> = ({
           >
             <IconButton
               size="small"
-              onClick={(e) => handleMenuOpen(e, scorer)}
+              onClick={(e) => openScorerMenu(e, scorer)}
               sx={{
                 "color": `${text.icon}`,
                 "padding": "6px",
@@ -194,7 +194,7 @@ const ScorersTableBody: React.FC<ScorersTableBodyProps> = ({
       <Popover
         open={Boolean(menuAnchorEl)}
         anchorEl={menuAnchorEl}
-        onClose={handleMenuClose}
+        onClose={closeScorerMenu}
         onClick={(e) => e.stopPropagation()}
         anchorOrigin={{ horizontal: "right", vertical: "bottom" }}
         transformOrigin={{ horizontal: "right", vertical: "top" }}
@@ -237,7 +237,7 @@ const ScorersTableBody: React.FC<ScorersTableBodyProps> = ({
           {onDelete && (
             <CustomizableButton
               variant="outlined"
-              onClick={handleDeleteClick}
+              onClick={deleteScorerRow}
               startIcon={<Trash2 size={14} />}
               sx={{
                 "height": "34px",

--- a/Clients/src/presentation/pages/Framework/index.tsx
+++ b/Clients/src/presentation/pages/Framework/index.tsx
@@ -159,23 +159,23 @@ const Framework = () => {
     setAnchorEl(event.currentTarget);
   };
 
-  const handleMenuClose = () => {
+  const closeFrameworkMenu = () => {
     setAnchorEl(null);
   };
 
   const handleManageFrameworksClick = () => {
     setIsFrameworkModalOpen(true);
-    handleMenuClose();
+    closeFrameworkMenu();
   };
 
   const handleEditProjectClick = () => {
     setIsEditProjectModalOpen(true);
-    handleMenuClose();
+    closeFrameworkMenu();
   };
 
   const handleDeleteProjectClick = () => {
     setIsDeleteModalOpen(true);
-    handleMenuClose();
+    closeFrameworkMenu();
   };
 
   // Function to handle project deletion
@@ -846,7 +846,7 @@ const Framework = () => {
                 <Popover
                   anchorEl={anchorEl}
                   open={isMenuOpen}
-                  onClose={handleMenuClose}
+                  onClose={closeFrameworkMenu}
                   anchorOrigin={{
                     vertical: "bottom",
                     horizontal: "right",


### PR DESCRIPTION
## Rename Generic Handler Functions

## Please ensure all items are checked off before requesting a review:

- [x] I deployed the code locally.
- [x] I have performed a self-review of my code.
- [x] I have included the issue # in the PR.
- [x] I have labelled the PR correctly.
- [x] The issue I am working on is assigned to me.
- [x] I have avoided using hardcoded values to ensure scalability and maintain consistency across the application.
- [x] I have ensured that font sizes, color choices, and other UI elements are referenced from the theme.
- [x] My pull request is focused and addresses a single, specific feature.
----------

## What We Did

Renamed ambiguous generic handlers to feature-specific names across 18 files in `Clients/src/presentation/`.

**Key changes:**
- `closeDropDownMenu` → `closeActionMenu` (`IconButton/index.tsx`, 25 call sites)
- `handleMenuOpen/Close/DeleteClick` → `open/close/delete{Entity}*` (5 table bodies: Experiment, Dataset, Model, Arena, Scorer)
- `handleSubmit` → `handleSave{Entity}` (9 modals: ModelInventory, Dataset, Task, Incident, Training, ModelRisk, Evidence, AiOrNotScreening, TrainingEvidence)
- `handleMenuOpen/Close` → disambiguated in `NoteItem`, `PluginCard`, `Framework`

## Validation

- **TypeScript:** `tsc --noEmit` passes cleanly
- **Graph impact:** `closeDropDownMenu()` god node (17 edges) eliminated; replaced by `closeActionMenu()` (17 edges) — same structure, unambiguous name
- **Branch:** `mo-353-may-27-rename-generic-handler-functions`
- **Commits:** 8 | **Files:** 18 | **Call sites:** ~120
