### PR TITLE
feat(button): add iconOnly mode to CustomizableButton

### DIFF
--- a/Clients/src/domain/types/button.types.ts
+++ b/Clients/src/domain/types/button.types.ts
@@ -52,6 +52,8 @@ export interface CustomizableButtonCoreProps {
   indicator?: boolean;
   /** Custom inline text color */
   textColor?: string;
+  /** Compact square button for icon-only actions (close, toolbar, etc.) */
+  iconOnly?: boolean;
 }
 
 /**

--- a/Clients/src/presentation/components/button/__tests__/CustomizableButton.test.tsx
+++ b/Clients/src/presentation/components/button/__tests__/CustomizableButton.test.tsx
@@ -1,0 +1,44 @@
+import { screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { renderWithProviders } from "../../../../test/renderWithProviders";
+import { CustomizableButton } from "../customizable-button";
+
+describe("CustomizableButton", () => {
+  it("renders labeled button text", () => {
+    renderWithProviders(<CustomizableButton>Save</CustomizableButton>);
+    expect(screen.getByRole("button", { name: "Save" })).toBeInTheDocument();
+  });
+
+  it("renders icon-only button with ariaLabel and no fallback text", () => {
+    renderWithProviders(
+      <CustomizableButton iconOnly variant="text" size="small" ariaLabel="Close">
+        <span data-testid="close-icon">X</span>
+      </CustomizableButton>,
+    );
+
+    const button = screen.getByRole("button", { name: "Close" });
+    expect(button).toBeInTheDocument();
+    expect(button).toHaveTextContent("X");
+    expect(button).not.toHaveTextContent("CustomizableButton");
+  });
+
+  it("supports icon-only via startIcon", () => {
+    renderWithProviders(
+      <CustomizableButton iconOnly variant="text" ariaLabel="Edit" startIcon={<span>Edit</span>} />,
+    );
+
+    expect(screen.getByRole("button", { name: "Edit" })).toHaveTextContent("Edit");
+  });
+
+  it("handles onClick for icon-only buttons", async () => {
+    const handleClick = vi.fn();
+    renderWithProviders(
+      <CustomizableButton iconOnly ariaLabel="Close" onClick={handleClick}>
+        <span>X</span>
+      </CustomizableButton>,
+    );
+
+    await userEvent.click(screen.getByRole("button", { name: "Close" }));
+    expect(handleClick).toHaveBeenCalledTimes(1);
+  });
+});

--- a/Clients/src/presentation/components/button/customizable-button/index.md
+++ b/Clients/src/presentation/components/button/customizable-button/index.md
@@ -37,6 +37,7 @@ The CustomizableButton component is designed to provide a consistent, accessible
 - ✅ Material-UI Button extension with custom styling
 - ✅ Loading state with spinner indicators
 - ✅ Icon positioning (start, end, or custom)
+- ✅ Icon-only mode for compact actions (close, toolbar)
 - ✅ Theme-based color variants
 - ✅ Full accessibility support
 - ✅ Keyboard navigation
@@ -89,6 +90,29 @@ function MyComponent() {
 }
 ```
 
+### Icon-Only Button
+
+Use `iconOnly` for compact square buttons (close, toolbar actions). `ariaLabel` is required.
+
+```tsx
+import { CustomizableButton } from "./components/button/customizable-button";
+import { X as CloseIcon } from "lucide-react";
+
+function MyComponent() {
+  return (
+    <CustomizableButton
+      iconOnly
+      variant="text"
+      size="small"
+      ariaLabel="Close dialog"
+      onClick={handleClose}
+    >
+      <CloseIcon size={20} />
+    </CustomizableButton>
+  );
+}
+```
+
 ### Loading Button
 
 ```tsx
@@ -118,29 +142,30 @@ function MyComponent() {
 
 ### CustomizableButtonProps
 
-| Prop               | Type                                                                      | Default       | Description                                    |
-| ------------------ | ------------------------------------------------------------------------- | ------------- | ---------------------------------------------- |
-| `variant`          | `"contained" \| "outlined" \| "text"`                                     | `"contained"` | The visual style variant of the button         |
-| `size`             | `"small" \| "medium" \| "large"`                                          | `"medium"`    | The size of the button                         |
-| `isDisabled`       | `boolean`                                                                 | `false`       | Whether the button is disabled                 |
-| `isLink`           | `boolean`                                                                 | `false`       | Whether to style the button as a link          |
-| `color`            | `"primary" \| "secondary" \| "success" \| "warning" \| "error" \| "info"` | `"primary"`   | The color theme of the button                  |
-| `onClick`          | `(event: React.MouseEvent<HTMLButtonElement>) => void`                    | `undefined`   | Click event handler                            |
-| `sx`               | `SxProps<Theme>`                                                          | `undefined`   | Custom styles using MUI's sx prop              |
-| `text`             | `string`                                                                  | `undefined`   | Button text content (deprecated: use children) |
-| `icon`             | `React.ReactNode`                                                         | `undefined`   | Icon element (deprecated: use startIcon)       |
-| `startIcon`        | `React.ReactNode`                                                         | `undefined`   | Icon to display at the start                   |
-| `endIcon`          | `React.ReactNode`                                                         | `undefined`   | Icon to display at the end                     |
-| `children`         | `React.ReactNode`                                                         | `undefined`   | Button content                                 |
-| `loading`          | `boolean`                                                                 | `false`       | Loading state with spinner                     |
-| `loadingIndicator` | `React.ReactNode`                                                         | `undefined`   | Custom loading indicator                       |
-| `ariaLabel`        | `string`                                                                  | `undefined`   | ARIA label for accessibility                   |
-| `ariaDescribedBy`  | `string`                                                                  | `undefined`   | ARIA described by reference                    |
-| `testId`           | `string`                                                                  | `undefined`   | Test identifier for automation                 |
-| `type`             | `"button" \| "submit" \| "reset"`                                         | `"button"`    | HTML button type                               |
-| `fullWidth`        | `boolean`                                                                 | `false`       | Whether button takes full width                |
-| `className`        | `string`                                                                  | `undefined`   | Custom CSS class name                          |
-| `title`            | `string`                                                                  | `undefined`   | Tooltip text                                   |
+| Prop               | Type                                                                      | Default       | Description                                         |
+| ------------------ | ------------------------------------------------------------------------- | ------------- | --------------------------------------------------- |
+| `variant`          | `"contained" \| "outlined" \| "text"`                                     | `"contained"` | The visual style variant of the button              |
+| `size`             | `"small" \| "medium" \| "large"`                                          | `"medium"`    | The size of the button                              |
+| `isDisabled`       | `boolean`                                                                 | `false`       | Whether the button is disabled                      |
+| `isLink`           | `boolean`                                                                 | `false`       | Whether to style the button as a link               |
+| `color`            | `"primary" \| "secondary" \| "success" \| "warning" \| "error" \| "info"` | `"primary"`   | The color theme of the button                       |
+| `onClick`          | `(event: React.MouseEvent<HTMLButtonElement>) => void`                    | `undefined`   | Click event handler                                 |
+| `sx`               | `SxProps<Theme>`                                                          | `undefined`   | Custom styles using MUI's sx prop                   |
+| `text`             | `string`                                                                  | `undefined`   | Button text content (deprecated: use children)      |
+| `icon`             | `React.ReactNode`                                                         | `undefined`   | Icon element (deprecated: use startIcon)            |
+| `startIcon`        | `React.ReactNode`                                                         | `undefined`   | Icon to display at the start                        |
+| `endIcon`          | `React.ReactNode`                                                         | `undefined`   | Icon to display at the end                          |
+| `children`         | `React.ReactNode`                                                         | `undefined`   | Button content                                      |
+| `iconOnly`         | `boolean`                                                                 | `false`       | Compact square icon-only mode; requires `ariaLabel` |
+| `loading`          | `boolean`                                                                 | `false`       | Loading state with spinner                          |
+| `loadingIndicator` | `React.ReactNode`                                                         | `undefined`   | Custom loading indicator                            |
+| `ariaLabel`        | `string`                                                                  | `undefined`   | ARIA label for accessibility                        |
+| `ariaDescribedBy`  | `string`                                                                  | `undefined`   | ARIA described by reference                         |
+| `testId`           | `string`                                                                  | `undefined`   | Test identifier for automation                      |
+| `type`             | `"button" \| "submit" \| "reset"`                                         | `"button"`    | HTML button type                                    |
+| `fullWidth`        | `boolean`                                                                 | `false`       | Whether button takes full width                     |
+| `className`        | `string`                                                                  | `undefined`   | Custom CSS class name                               |
+| `title`            | `string`                                                                  | `undefined`   | Tooltip text                                        |
 
 ### Inherited Props
 

--- a/Clients/src/presentation/components/button/customizable-button/index.tsx
+++ b/Clients/src/presentation/components/button/customizable-button/index.tsx
@@ -20,6 +20,24 @@ const BUTTON_SIZE_STYLES: Record<"small" | "medium", SxProps<Theme>> = {
   },
 };
 
+/** Compact square sizing for icon-only buttons (matches small/medium heights). */
+const ICON_ONLY_SIZE_STYLES: Record<"small" | "medium", SxProps<Theme>> = {
+  small: {
+    minWidth: 0,
+    width: 28,
+    height: 28,
+    minHeight: 28,
+    padding: "5px",
+  },
+  medium: {
+    minWidth: 0,
+    width: 34,
+    height: 34,
+    minHeight: 34,
+    padding: "5px",
+  },
+};
+
 /**
  * CustomizableButton component
  *
@@ -30,6 +48,7 @@ const BUTTON_SIZE_STYLES: Record<"small" | "medium", SxProps<Theme>> = {
  * - Theme-based styling with customizable variants
  * - Loading state with spinner
  * - Icon positioning with proper spacing
+ * - Icon-only mode for compact toolbar/close actions
  * - Full accessibility support with ARIA attributes
  * - Keyboard navigation support
  * - Performance optimized with memoization
@@ -81,6 +100,7 @@ const CustomizableButton = memo(
       title,
       indicator,
       textColor,
+      iconOnly = false,
       ...rest
     },
     ref,
@@ -116,19 +136,24 @@ const CustomizableButton = memo(
       [handleClick, loading, isDisabled],
     );
 
+    const sizeKey = size === "small" ? "small" : "medium";
+
     // Get theme-based appearance - ensure proper typing for MUI sx prop
     const appearance = (singleTheme.buttons?.[color]?.[variant] || {}) as SxProps<Theme>;
 
-    // Determine button content
-    const buttonText = children || text || "CustomizableButton";
-    const resolvedStartIcon = startIcon || icon;
+    const iconContent = children || startIcon || icon;
+    const buttonText = iconOnly ? null : children || text || "CustomizableButton";
+    const resolvedStartIcon = iconOnly ? undefined : startIcon || icon;
+    const resolvedEndIcon = iconOnly ? undefined : endIcon;
+    const showCenteredSpinner =
+      loading && (iconOnly ? !iconContent : !resolvedStartIcon && !resolvedEndIcon);
 
     // Custom loading indicator or default spinner
     const spinner = loadingIndicator || (
       <CircularProgress
         size={16}
         color="inherit"
-        sx={{ mr: resolvedStartIcon || endIcon ? 1 : 0 }}
+        sx={{ mr: !iconOnly && (resolvedStartIcon || resolvedEndIcon) ? 1 : 0 }}
       />
     );
 
@@ -154,9 +179,14 @@ const CustomizableButton = memo(
         data-testid={testId}
         sx={[
           appearance,
-          BUTTON_SIZE_STYLES[size === "small" ? "small" : "medium"],
+          iconOnly ? ICON_ONLY_SIZE_STYLES[sizeKey] : BUTTON_SIZE_STYLES[sizeKey],
           {
             "position": "relative",
+            ...(iconOnly && {
+              display: "inline-flex",
+              alignItems: "center",
+              justifyContent: "center",
+            }),
             "&.Mui-disabled": {
               pointerEvents: loading ? "none" : "auto",
             },
@@ -165,9 +195,7 @@ const CustomizableButton = memo(
         ]}
         disableElevation={variant === "contained" && !isLink}
         startIcon={
-          // Show spinner as startIcon if loading AND (has original startIcon OR has endIcon)
-          // If no icons at all, we'll show a centered spinner instead
-          loading && (resolvedStartIcon || endIcon) ? (
+          iconOnly ? undefined : loading && (resolvedStartIcon || resolvedEndIcon) ? (
             <Box component="span" sx={{ display: "flex", alignItems: "center" }}>
               {spinner}
             </Box>
@@ -175,11 +203,10 @@ const CustomizableButton = memo(
             (resolvedStartIcon as React.ReactNode)
           )
         }
-        endIcon={!loading ? (endIcon as React.ReactNode) : undefined}
+        endIcon={!loading && !iconOnly ? (resolvedEndIcon as React.ReactNode) : undefined}
         {...filteredRest}
       >
-        {/* Show centered spinner only when loading and NO icons at all */}
-        {loading && !resolvedStartIcon && !endIcon && (
+        {showCenteredSpinner && (
           <Box
             component="span"
             sx={{
@@ -195,11 +222,16 @@ const CustomizableButton = memo(
         <Box
           component="span"
           sx={{
-            opacity: loading && !resolvedStartIcon && !endIcon ? 0 : 1,
+            opacity: showCenteredSpinner ? 0 : 1,
             transition: "opacity 0.2s ease",
+            ...(iconOnly && {
+              display: "inline-flex",
+              alignItems: "center",
+              justifyContent: "center",
+            }),
           }}
         >
-          {buttonText as React.ReactNode}
+          {iconOnly ? (iconContent as React.ReactNode) : (buttonText as React.ReactNode)}
         </Box>
       </Button>
     );

--- a/Clients/src/presentation/types/button.types.ts
+++ b/Clients/src/presentation/types/button.types.ts
@@ -5,15 +5,10 @@ import {
   FilterButtonCoreProps,
 } from "../../domain/types/button.types";
 
-/**
- * Presentation adapter for CustomizableButton component
- * Extends domain props with MUI-specific styling
- * Overrides unknown types from domain with React.ReactNode
- */
-export interface CustomizableButtonProps extends Omit<
+type CustomizableButtonSharedProps = Omit<
   CustomizableButtonCoreProps,
-  "icon" | "startIcon" | "endIcon" | "children" | "loadingIndicator" | "onClick"
-> {
+  "icon" | "startIcon" | "endIcon" | "children" | "loadingIndicator" | "onClick" | "iconOnly" | "ariaLabel"
+> & {
   /** Icon element (overrides domain unknown type) */
   icon?: React.ReactNode;
   /** Icon to display at the start of the button */
@@ -28,7 +23,21 @@ export interface CustomizableButtonProps extends Omit<
   onClick?: (event: React.MouseEvent<HTMLButtonElement>) => void;
   /** Custom styles using MUI's sx prop */
   sx?: SxProps<Theme>;
-}
+};
+
+/**
+ * Presentation adapter for CustomizableButton component.
+ * When iconOnly is true, ariaLabel is required for accessibility.
+ */
+export type CustomizableButtonProps =
+  | (CustomizableButtonSharedProps & {
+      iconOnly: true;
+      ariaLabel: string;
+    })
+  | (CustomizableButtonSharedProps & {
+      iconOnly?: false;
+      ariaLabel?: string;
+    });
 
 /**
  * Presentation adapter for FilterButton component

--- a/Clients/src/presentation/types/button.types.ts
+++ b/Clients/src/presentation/types/button.types.ts
@@ -7,7 +7,14 @@ import {
 
 type CustomizableButtonSharedProps = Omit<
   CustomizableButtonCoreProps,
-  "icon" | "startIcon" | "endIcon" | "children" | "loadingIndicator" | "onClick" | "iconOnly" | "ariaLabel"
+  | "icon"
+  | "startIcon"
+  | "endIcon"
+  | "children"
+  | "loadingIndicator"
+  | "onClick"
+  | "iconOnly"
+  | "ariaLabel"
 > & {
   /** Icon element (overrides domain unknown type) */
   icon?: React.ReactNode;


### PR DESCRIPTION
## Describe your changes

Introduce compact square sizing for icon-only actions with required ariaLabel typing, avoiding manual sx overrides and the CustomizableButton text fallback.

## Write your issue number after "Fixes "

Fixes #3989 

## Please ensure all items are checked off before requesting a review:

- [x] I deployed the code locally.
- [x] I have performed a self-review of my code.
- [x] I have included the issue # in the PR.
- [x] I have labelled the PR correctly.
- [x] The issue I am working on is assigned to me.
- [x] I have avoided using hardcoded values to ensure scalability and maintain consistency across the application.
- [x] I have ensured that font sizes, color choices, and other UI elements are referenced from the theme.
- [x] My pull request is focused and addresses a single, specific feature.
- [ ] If there are UI changes, I have attached a screenshot or video to this PR.
