### PR TITLE
fix(dashboard): align chart and legend layout across dashboard cards

### DIFF
--- a/Clients/src/presentation/components/Charts/DashboardChartLayout.tsx
+++ b/Clients/src/presentation/components/Charts/DashboardChartLayout.tsx
@@ -1,0 +1,46 @@
+import { Box, BoxProps } from "@mui/material";
+import { ReactNode } from "react";
+
+export const DASHBOARD_CHART_SIZE = 100;
+/** Fixed column width so donut/gauge centers align across dashboard cards. */
+export const DASHBOARD_CHART_COLUMN_WIDTH = 110;
+/** Fixed legend column width — pinned to the right so left edges align across cards. */
+export const DASHBOARD_LEGEND_MAX_WIDTH = 160;
+
+interface DashboardChartLayoutProps {
+  chart: ReactNode;
+  sideContent: ReactNode;
+  alignItems?: BoxProps["alignItems"];
+}
+
+export function DashboardChartLayout({
+  chart,
+  sideContent,
+  alignItems = "flex-start",
+}: DashboardChartLayoutProps) {
+  return (
+    <Box sx={{ display: "flex", alignItems, width: "100%" }}>
+      <Box
+        sx={{
+          width: DASHBOARD_CHART_COLUMN_WIDTH,
+          flexShrink: 0,
+          display: "flex",
+          justifyContent: "center",
+          pt: "8px",
+        }}
+      >
+        {chart}
+      </Box>
+      <Box sx={{ flex: 1, minWidth: 16 }} />
+      <Box
+        sx={{
+          width: DASHBOARD_LEGEND_MAX_WIDTH,
+          flexShrink: 0,
+          pt: "8px",
+        }}
+      >
+        {sideContent}
+      </Box>
+    </Box>
+  );
+}

--- a/Clients/src/presentation/components/Charts/GovernanceScoreCard.tsx
+++ b/Clients/src/presentation/components/Charts/GovernanceScoreCard.tsx
@@ -1,5 +1,6 @@
 import { Box, Stack, Typography } from "@mui/material";
 import { DASHBOARD_COLORS, TEXT_STYLES } from "../../styles/colors";
+import { DashboardChartLayout, DASHBOARD_CHART_SIZE } from "./DashboardChartLayout";
 
 const C = DASHBOARD_COLORS;
 
@@ -22,7 +23,7 @@ const getScoreColor = (score: number): string => {
 };
 
 // Circular progress component for the main score (includes label)
-function ScoreGauge({ score, size = 100 }: { score: number; size?: number }) {
+function ScoreGauge({ score, size = DASHBOARD_CHART_SIZE }: { score: number; size?: number }) {
   const strokeWidth = 8;
   const radius = (size - strokeWidth) / 2;
   const circumference = 2 * Math.PI * radius;
@@ -75,28 +76,34 @@ function ScoreGauge({ score, size = 100 }: { score: number; size?: number }) {
 
 export function GovernanceScoreCard({ score, modules }: GovernanceScoreProps) {
   return (
-    <Stack direction="row" alignItems="center" justifyContent="space-between">
-      <ScoreGauge score={score} size={100} />
-      <Stack spacing={2} sx={{ minWidth: 160 }}>
-        {modules.map((module) => {
-          const scoreColor = getScoreColor(module.score);
-          return (
-            <Typography
-              key={module.name}
-              sx={{
-                display: "flex",
-                alignItems: "center",
-                justifyContent: "space-between",
-                fontSize: 12,
-                color: C.textSecondary,
-              }}
-            >
-              <span>{module.name}</span>
-              <span style={{ fontWeight: 600, color: scoreColor }}>{module.score}%</span>
-            </Typography>
-          );
-        })}
-      </Stack>
-    </Stack>
+    <DashboardChartLayout
+      alignItems="center"
+      chart={<ScoreGauge score={score} />}
+      sideContent={
+        <Stack spacing={2} sx={{ width: "100%" }}>
+          {modules.map((module) => {
+            const scoreColor = getScoreColor(module.score);
+            return (
+              <Typography
+                key={module.name}
+                sx={{
+                  display: "flex",
+                  alignItems: "center",
+                  justifyContent: "space-between",
+                  fontSize: 12,
+                  color: C.textSecondary,
+                  gap: 1,
+                }}
+              >
+                <span>{module.name}</span>
+                <span style={{ fontWeight: 600, color: scoreColor, flexShrink: 0 }}>
+                  {module.score}%
+                </span>
+              </Typography>
+            );
+          })}
+        </Stack>
+      }
+    />
   );
 }

--- a/Clients/src/presentation/components/Charts/NewMetricsCards.tsx
+++ b/Clients/src/presentation/components/Charts/NewMetricsCards.tsx
@@ -10,6 +10,7 @@ import {
   ResponsiveContainer,
 } from "recharts";
 import { StatusDonutChart } from "./StatusDonutChart";
+import { DashboardChartLayout, DASHBOARD_CHART_SIZE } from "./DashboardChartLayout";
 import { vwTooltipStyle, ChartOutlineWrapper } from "./VWCharts";
 import { DASHBOARD_COLORS, TEXT_STYLES } from "../../styles/colors";
 import { border as borderPalette } from "../../themes/palette";
@@ -107,16 +108,16 @@ export function PolicyStatusCard({ total, distribution }: PolicyStatusProps) {
   ].filter((item) => item.value > 0);
 
   return (
-    <Stack direction="row" alignItems="flex-start" justifyContent="space-around">
-      <Box sx={{ pt: "8px" }}>
-        <StatusDonutChart data={data} total={total} size={100} />
-      </Box>
-      <Stack gap="4px" sx={{ pt: "8px" }}>
-        {data.map((item) => (
-          <LegendItem key={item.label} {...item} />
-        ))}
-      </Stack>
-    </Stack>
+    <DashboardChartLayout
+      chart={<StatusDonutChart data={data} total={total} size={DASHBOARD_CHART_SIZE} />}
+      sideContent={
+        <Stack gap="4px">
+          {data.map((item) => (
+            <LegendItem key={item.label} {...item} />
+          ))}
+        </Stack>
+      }
+    />
   );
 }
 
@@ -205,15 +206,15 @@ export function ModelLifecycleCard({ total, distribution }: ModelLifecycleProps)
   ].filter((item) => item.value > 0);
 
   return (
-    <Stack direction="row" alignItems="flex-start" justifyContent="space-around">
-      <Box sx={{ pt: "8px" }}>
-        <StatusDonutChart data={data} total={total} size={100} />
-      </Box>
-      <Stack gap="4px" sx={{ pt: "8px" }}>
-        {data.map((item) => (
-          <LegendItem key={item.label} {...item} />
-        ))}
-      </Stack>
-    </Stack>
+    <DashboardChartLayout
+      chart={<StatusDonutChart data={data} total={total} size={DASHBOARD_CHART_SIZE} />}
+      sideContent={
+        <Stack gap="4px">
+          {data.map((item) => (
+            <LegendItem key={item.label} {...item} />
+          ))}
+        </Stack>
+      }
+    />
   );
 }

--- a/Clients/src/presentation/components/Charts/RiskDonutWithLegend.tsx
+++ b/Clients/src/presentation/components/Charts/RiskDonutWithLegend.tsx
@@ -1,5 +1,6 @@
 import { Box, Stack, Typography } from "@mui/material";
 import { StatusDonutChart } from "./StatusDonutChart";
+import { DashboardChartLayout, DASHBOARD_CHART_SIZE } from "./DashboardChartLayout";
 import { text } from "../../themes/palette";
 
 export interface RiskDataItem {
@@ -14,30 +15,34 @@ interface RiskDonutWithLegendProps {
   size?: number;
 }
 
-export function RiskDonutWithLegend({ data, total, size = 100 }: RiskDonutWithLegendProps) {
+export function RiskDonutWithLegend({
+  data,
+  total,
+  size = DASHBOARD_CHART_SIZE,
+}: RiskDonutWithLegendProps) {
   return (
-    <Stack direction="row" alignItems="flex-start" justifyContent="space-around">
-      <Box sx={{ pt: "8px" }}>
-        <StatusDonutChart data={data} total={total} size={size} />
-      </Box>
-      <Stack gap={0.5} sx={{ pt: "8px" }}>
-        {data.map((item) => (
-          <Stack key={item.label} direction="row" alignItems="center" gap="8px">
-            <Box
-              sx={{
-                width: 8,
-                height: 8,
-                borderRadius: "50%",
-                backgroundColor: item.color,
-                flexShrink: 0,
-              }}
-            />
-            <Typography sx={{ fontSize: 13, color: `${text.icon}` }}>
-              {item.label}: {item.value}
-            </Typography>
-          </Stack>
-        ))}
-      </Stack>
-    </Stack>
+    <DashboardChartLayout
+      chart={<StatusDonutChart data={data} total={total} size={size} />}
+      sideContent={
+        <Stack gap={0.5}>
+          {data.map((item) => (
+            <Stack key={item.label} direction="row" alignItems="center" gap="8px">
+              <Box
+                sx={{
+                  width: 8,
+                  height: 8,
+                  borderRadius: "50%",
+                  backgroundColor: item.color,
+                  flexShrink: 0,
+                }}
+              />
+              <Typography sx={{ fontSize: 13, color: `${text.icon}` }}>
+                {item.label}: {item.value}
+              </Typography>
+            </Stack>
+          ))}
+        </Stack>
+      }
+    />
   );
 }


### PR DESCRIPTION
## Describe your changes

Introduce shared DashboardChartLayout so donut/gauge charts and legends stay vertically aligned while legends sit on the right side of each card.

## Write your issue number after "Fixes "

Fixes #3986

## Please ensure all items are checked off before requesting a review:

- [ ] I deployed the code locally.
- [ ] I have performed a self-review of my code.
- [ ] I have included the issue # in the PR.
- [ ] I have labelled the PR correctly.
- [ ] The issue I am working on is assigned to me.
- [ ] I have avoided using hardcoded values to ensure scalability and maintain consistency across the application.
- [ ] I have ensured that font sizes, color choices, and other UI elements are referenced from the theme.
- [x] My pull request is focused and addresses a single, specific feature.
- [x] If there are UI changes, I have attached a screenshot or video to this PR.

https://github.com/user-attachments/assets/95d68525-a184-4d16-989e-f2ef3f99ba7f

