### PR TITLE
refactor(drawers): migrate MUI Button to CustomizableButton in clause/annex drawers

### DIFF
--- a/Clients/src/presentation/components/Drawer/AnnexDrawerDialog/index.tsx
+++ b/Clients/src/presentation/components/Drawer/AnnexDrawerDialog/index.tsx
@@ -1,5 +1,4 @@
 import {
-  Button,
   Divider,
   Drawer,
   Stack,
@@ -15,12 +14,14 @@ import {
 import { TabContext, TabPanel } from "@mui/lab";
 import { FileData } from "../../../../domain/types/File";
 import {
-  X as CloseIcon,
+  X,
   Save as SaveIcon,
+  Upload as UploadIcon,
   Download as DownloadIcon,
   Trash2 as DeleteIcon,
   Eye as ViewIcon,
   FileText as FileIcon,
+  PaperclipIcon,
 } from "lucide-react";
 import Checkbox from "../../Inputs/Checkbox";
 import Field from "../../Inputs/Field";
@@ -662,7 +663,15 @@ const VWISO42001AnnexDrawerDialog = ({
           <Typography fontSize={15} fontWeight={700}>
             {title}
           </Typography>
-          <CloseIcon size={20} onClick={onClose} style={{ cursor: "pointer" }} />
+          <CustomizableButton
+            variant="text"
+            iconOnly
+            ariaLabel="Close"
+            size="medium"
+            onClick={onClose}
+          >
+            <X size={20} />
+          </CustomizableButton>
         </Stack>
         <Divider />
         <TabContext value={activeTab}>
@@ -874,7 +883,6 @@ const VWISO42001AnnexDrawerDialog = ({
                 Upload evidence files to document how this requirement is implemented.
               </Typography>
 
-              {/* File Input */}
               <Box>
                 <input
                   type="file"
@@ -892,49 +900,22 @@ const VWISO42001AnnexDrawerDialog = ({
                 />
 
                 <Stack direction="row" spacing={2} alignItems="center">
-                  <Button
-                    variant="contained"
-                    component="label"
-                    htmlFor="evidence-file-input"
-                    disabled={isEditingDisabled}
-                    sx={{
-                      "borderRadius": 2,
-                      "minWidth": 155,
-                      "height": 25,
-                      "fontSize": 11,
-                      "border": `1px solid ${theme.palette.border.dark}`,
-                      "backgroundColor": "background.main",
-                      "color": "text.secondary",
-                      "&:hover": {
-                        backgroundColor: "background.accent",
-                        border: `1px solid ${theme.palette.border.dark}`,
-                      },
-                    }}
-                    disableRipple={theme.components?.MuiButton?.defaultProps?.disableRipple}
-                  >
-                    Upload new files
-                  </Button>
-                  <Button
-                    variant="contained"
+                  <CustomizableButton
+                    variant="outlined"
+                    onClick={() => document.getElementById("evidence-file-input")?.click()}
+                    isDisabled={isEditingDisabled}
+                    text="Upload new files"
+                    size="small"
+                    icon={<UploadIcon size={14} />}
+                  />
+                  <CustomizableButton
+                    variant="outlined"
                     onClick={() => setShowFilePicker(true)}
-                    disabled={isEditingDisabled}
-                    sx={{
-                      "borderRadius": 2,
-                      "minWidth": 165,
-                      "height": 25,
-                      "fontSize": 11,
-                      "border": "1px solid #4C7BF4",
-                      "backgroundColor": "#4C7BF4",
-                      "color": "white",
-                      "&:hover": {
-                        backgroundColor: "#3D62C3",
-                        border: "1px solid #3D62C3",
-                      },
-                    }}
-                    disableRipple={theme.components?.MuiButton?.defaultProps?.disableRipple}
-                  >
-                    Attach existing files
-                  </Button>
+                    isDisabled={isEditingDisabled}
+                    text="Attach existing files"
+                    size="small"
+                    icon={<PaperclipIcon size={14} />}
+                  />
 
                   <Stack direction="row" spacing={2}>
                     <Typography sx={{ fontSize: 11, color: "text.secondary" }}>
@@ -1128,27 +1109,13 @@ const VWISO42001AnnexDrawerDialog = ({
 
               {/* Add/Remove Button */}
               <Stack direction="row" spacing={2} alignItems="center">
-                <Button
-                  variant="contained"
+                <CustomizableButton
+                  variant="outlined"
                   onClick={() => setIsLinkedRisksModalOpen(true)}
-                  disabled={isEditingDisabled}
-                  sx={{
-                    "borderRadius": 2,
-                    "minWidth": 155,
-                    "height": 25,
-                    "fontSize": 11,
-                    "border": `1px solid ${theme.palette.border.dark}`,
-                    "backgroundColor": "background.main",
-                    "color": "text.secondary",
-                    "&:hover": {
-                      backgroundColor: "background.accent",
-                      border: `1px solid ${theme.palette.border.dark}`,
-                    },
-                  }}
-                  disableRipple={theme.components?.MuiButton?.defaultProps?.disableRipple}
-                >
-                  Add/remove risks
-                </Button>
+                  isDisabled={isEditingDisabled}
+                  text="Add/remove risks"
+                  size="small"
+                />
 
                 <Stack direction="row" spacing={2}>
                   <Typography sx={{ fontSize: 11, color: "text.secondary" }}>

--- a/Clients/src/presentation/components/Drawer/ClauseDrawerDialog/index.tsx
+++ b/Clients/src/presentation/components/Drawer/ClauseDrawerDialog/index.tsx
@@ -14,7 +14,6 @@
 import React, { useState, useEffect, useMemo, useRef } from "react";
 import {
   Box,
-  Button,
   CircularProgress,
   Divider,
   Drawer,
@@ -27,12 +26,14 @@ import {
 } from "@mui/material";
 import { TabContext, TabPanel } from "@mui/lab";
 import {
-  X as CloseIcon,
+  X,
   Save as SaveIcon,
   Download as DownloadIcon,
   Trash2 as DeleteIcon,
   Eye as ViewIcon,
   FileText as FileIcon,
+  UploadIcon,
+  PaperclipIcon,
 } from "lucide-react";
 import dayjs, { Dayjs } from "dayjs";
 
@@ -727,15 +728,15 @@ const ISO42001ClauseDrawerDialog: React.FC<ISO42001ClauseDrawerProps> = ({
                   : "Clause")}{" "}
               {subclause?.title}
             </Typography>
-            <Button
+            <CustomizableButton
+              variant="text"
+              iconOnly
+              ariaLabel="Close"
+              size="medium"
               onClick={onClose}
-              sx={{
-                minWidth: "0",
-                padding: "5px",
-              }}
             >
-              <CloseIcon size={20} color={theme.palette.other.icon} />
-            </Button>
+              <X size={20} />
+            </CustomizableButton>
           </Stack>
 
           <Divider />
@@ -952,43 +953,22 @@ const ISO42001ClauseDrawerDialog: React.FC<ISO42001ClauseDrawerProps> = ({
                   />
 
                   <Stack direction="row" spacing={2} alignItems="center">
-                    <Button
-                      variant="contained"
-                      component="label"
-                      htmlFor="evidence-file-input"
-                      disabled={isEditingDisabled}
-                      sx={{
-                        borderRadius: 2,
-                        width: 155,
-                        height: 25,
-                        fontSize: 11,
-                        border: `1px solid ${theme.palette.border.dark}`,
-                        backgroundColor: "background.main",
-                        color: "text.secondary",
-                      }}
-                    >
-                      Upload new files
-                    </Button>
-                    <Button
-                      variant="contained"
+                    <CustomizableButton
+                      variant="outlined"
+                      onClick={() => document.getElementById("evidence-file-input")?.click()}
+                      isDisabled={isEditingDisabled}
+                      text="Upload new files"
+                      size="small"
+                      icon={<UploadIcon size={14} />}
+                    />
+                    <CustomizableButton
+                      variant="outlined"
                       onClick={() => setShowFilePicker(true)}
-                      disabled={isEditingDisabled}
-                      sx={{
-                        "borderRadius": 2,
-                        "width": 165,
-                        "height": 25,
-                        "fontSize": 11,
-                        "border": "1px solid #4C7BF4",
-                        "backgroundColor": "#4C7BF4",
-                        "color": "white",
-                        "&:hover": {
-                          backgroundColor: "#3D62C3",
-                          border: "1px solid #3D62C3",
-                        },
-                      }}
-                    >
-                      Attach existing files
-                    </Button>
+                      isDisabled={isEditingDisabled}
+                      text="Attach existing files"
+                      size="small"
+                      icon={<PaperclipIcon size={14} />}
+                    />
 
                     <Stack direction="row" spacing={2}>
                       <Typography sx={{ fontSize: 11, color: "text.secondary" }}>
@@ -1275,22 +1255,13 @@ const ISO42001ClauseDrawerDialog: React.FC<ISO42001ClauseDrawerProps> = ({
                 </Typography>
 
                 <Stack direction="row" spacing={2} alignItems="center">
-                  <Button
-                    variant="contained"
-                    sx={{
-                      borderRadius: 2,
-                      width: 155,
-                      height: 25,
-                      fontSize: 11,
-                      border: `1px solid ${theme.palette.border.dark}`,
-                      backgroundColor: "background.main",
-                      color: "text.secondary",
-                    }}
+                  <CustomizableButton
+                    variant="outlined"
                     onClick={() => setIsLinkedRisksModalOpen(true)}
-                    disabled={isEditingDisabled}
-                  >
-                    Add/remove risks
-                  </Button>
+                    isDisabled={isEditingDisabled}
+                    text="Add/remove risks"
+                    size="small"
+                  />
 
                   <Stack direction="row" spacing={2}>
                     <Typography sx={{ fontSize: 11, color: "text.secondary" }}>

--- a/Clients/src/presentation/components/Drawer/ISO27001AnnexDrawerDialog/index.tsx
+++ b/Clients/src/presentation/components/Drawer/ISO27001AnnexDrawerDialog/index.tsx
@@ -1,5 +1,4 @@
 import {
-  Button,
   Divider,
   Drawer,
   Stack,
@@ -14,11 +13,13 @@ import {
 import { TabContext, TabPanel } from "@mui/lab";
 import { FileData } from "../../../../domain/types/File";
 import {
-  X as CloseIcon,
+  X,
+  Upload as UploadIcon,
   Trash2 as DeleteIcon,
   Download as DownloadIcon,
   FileText as FileIcon,
   Eye as ViewIcon,
+  PaperclipIcon,
 } from "lucide-react";
 import Field from "../../Inputs/Field";
 import RichTextEditor from "../../RichTextEditor";
@@ -719,7 +720,15 @@ const VWISO27001AnnexDrawerDialog = ({
           <Typography fontSize={15} fontWeight={700}>
             {title}
           </Typography>
-          <CloseIcon size={20} onClick={onClose} style={{ cursor: "pointer" }} />
+          <CustomizableButton
+            variant="text"
+            iconOnly
+            ariaLabel="Close"
+            size="medium"
+            onClick={onClose}
+          >
+            <X size={20} />
+          </CustomizableButton>
         </Stack>
         <Divider />
         <TabContext value={activeTab}>
@@ -913,7 +922,6 @@ const VWISO27001AnnexDrawerDialog = ({
                 Upload evidence files to document compliance with this requirement.
               </Typography>
 
-              {/* File Input */}
               <Box>
                 <input
                   type="file"
@@ -931,48 +939,22 @@ const VWISO27001AnnexDrawerDialog = ({
                 />
                 <Stack spacing={2}>
                   <Stack direction="row" spacing={1}>
-                    <Button
-                      variant="contained"
+                    <CustomizableButton
+                      variant="outlined"
                       onClick={() => document.getElementById("evidence-file-input")?.click()}
-                      disabled={isEditingDisabled}
-                      sx={{
-                        "borderRadius": 2,
-                        "minWidth": 155,
-                        "height": 25,
-                        "fontSize": 11,
-                        "border": "1px solid #d0d5dd",
-                        "backgroundColor": "white",
-                        "color": "text.secondary",
-                        "&:hover": {
-                          backgroundColor: "background.accent",
-                          border: "1px solid #d0d5dd",
-                        },
-                      }}
-                      disableRipple={theme.components?.MuiButton?.defaultProps?.disableRipple}
-                    >
-                      Upload new files
-                    </Button>
-                    <Button
-                      variant="contained"
+                      isDisabled={isEditingDisabled}
+                      text="Upload new files"
+                      size="small"
+                      icon={<UploadIcon size={14} />}
+                    />
+                    <CustomizableButton
+                      variant="outlined"
                       onClick={() => setShowFilePicker(true)}
-                      disabled={isEditingDisabled}
-                      sx={{
-                        "borderRadius": 2,
-                        "minWidth": 165,
-                        "height": 25,
-                        "fontSize": 11,
-                        "border": "1px solid #4C7BF4",
-                        "backgroundColor": "#4C7BF4",
-                        "color": "white",
-                        "&:hover": {
-                          backgroundColor: "#3D62C3",
-                          border: "1px solid #3D62C3",
-                        },
-                      }}
-                      disableRipple={theme.components?.MuiButton?.defaultProps?.disableRipple}
-                    >
-                      Attach existing files
-                    </Button>
+                      isDisabled={isEditingDisabled}
+                      text="Attach existing files"
+                      size="small"
+                      icon={<PaperclipIcon size={14} />}
+                    />
                   </Stack>
 
                   <Stack direction="row" spacing={2}>
@@ -1264,22 +1246,13 @@ const VWISO27001AnnexDrawerDialog = ({
               </Typography>
 
               <Stack direction="row" spacing={2} alignItems="center">
-                <Button
-                  variant="contained"
-                  sx={{
-                    borderRadius: 2,
-                    width: 155,
-                    height: 25,
-                    fontSize: 11,
-                    border: `1px solid ${theme.palette.border.dark}`,
-                    backgroundColor: "background.main",
-                    color: "text.secondary",
-                  }}
+                <CustomizableButton
+                  variant="outlined"
                   onClick={() => setIsLinkedRisksModalOpen(true)}
-                  disabled={isEditingDisabled}
-                >
-                  Add/remove risks
-                </Button>
+                  isDisabled={isEditingDisabled}
+                  text="Add/remove risks"
+                  size="small"
+                />
 
                 <Stack direction="row" spacing={2}>
                   <Typography sx={{ fontSize: 11, color: "text.secondary" }}>

--- a/Clients/src/presentation/components/Drawer/ISO27001ClauseDrawerDialog/index.tsx
+++ b/Clients/src/presentation/components/Drawer/ISO27001ClauseDrawerDialog/index.tsx
@@ -1,5 +1,4 @@
 import {
-  Button,
   Divider,
   Drawer,
   Stack,
@@ -14,8 +13,9 @@ import {
 } from "@mui/material";
 import { TabContext, TabPanel } from "@mui/lab";
 import {
-  X as CloseIcon,
+  X,
   Save as SaveIcon,
+  Upload as UploadIcon,
   Trash2 as DeleteIcon,
   Download as DownloadIcon,
   FileText as FileIcon,
@@ -824,7 +824,15 @@ const VWISO27001ClauseDrawerDialog = ({
             <Typography fontSize={15} fontWeight={700}>
               {clause?.order_no + "." + (index + 1)} {displayData?.title}
             </Typography>
-            <CloseIcon size={20} onClick={onClose} style={{ cursor: "pointer" }} />
+            <CustomizableButton
+              variant="text"
+              iconOnly
+              ariaLabel="Close"
+              size="medium"
+              onClick={onClose}
+            >
+              <X size={20} />
+            </CustomizableButton>
           </Stack>
           <Divider />
           <TabContext value={activeTab}>
@@ -1026,7 +1034,6 @@ const VWISO27001ClauseDrawerDialog = ({
                   Upload evidence files to document compliance with this requirement.
                 </Typography>
 
-                {/* File Input */}
                 <Box>
                   <input
                     type="file"
@@ -1044,48 +1051,20 @@ const VWISO27001ClauseDrawerDialog = ({
                   />
                   <Stack spacing={2}>
                     <Stack direction="row" spacing={1}>
-                      <Button
-                        variant="contained"
+                      <CustomizableButton
+                        variant="outlined"
                         onClick={() => document.getElementById("evidence-file-input")?.click()}
-                        disabled={isEditingDisabled}
-                        sx={{
-                          "borderRadius": 2,
-                          "minWidth": 155,
-                          "height": 25,
-                          "fontSize": 11,
-                          "border": "1px solid #d0d5dd",
-                          "backgroundColor": "white",
-                          "color": "text.secondary",
-                          "&:hover": {
-                            backgroundColor: "background.accent",
-                            border: "1px solid #d0d5dd",
-                          },
-                        }}
-                        disableRipple={theme.components?.MuiButton?.defaultProps?.disableRipple}
-                      >
-                        Upload new files
-                      </Button>
-                      <Button
+                        isDisabled={isEditingDisabled}
+                        text="Upload new files"
+                        size="small"
+                        icon={<UploadIcon size={14} />}
+                      />
+                      <CustomizableButton
                         variant="contained"
                         onClick={() => setShowFilePicker(true)}
-                        disabled={isEditingDisabled}
-                        sx={{
-                          "borderRadius": 2,
-                          "minWidth": 165,
-                          "height": 25,
-                          "fontSize": 11,
-                          "border": "1px solid #4C7BF4",
-                          "backgroundColor": "#4C7BF4",
-                          "color": "white",
-                          "&:hover": {
-                            backgroundColor: "#3D62C3",
-                            border: "1px solid #3D62C3",
-                          },
-                        }}
-                        disableRipple={theme.components?.MuiButton?.defaultProps?.disableRipple}
-                      >
-                        Attach existing files
-                      </Button>
+                        isDisabled={isEditingDisabled}
+                        text="Attach existing files"
+                      />
                     </Stack>
 
                     <Stack direction="row" spacing={2}>
@@ -1370,27 +1349,13 @@ const VWISO27001ClauseDrawerDialog = ({
 
                 {/* Add/Remove Button */}
                 <Stack direction="row" spacing={2} alignItems="center">
-                  <Button
-                    variant="contained"
+                  <CustomizableButton
+                    variant="outlined"
                     onClick={() => setIsLinkedRisksModalOpen(true)}
-                    disabled={isEditingDisabled}
-                    sx={{
-                      "borderRadius": 2,
-                      "minWidth": 155,
-                      "height": 25,
-                      "fontSize": 11,
-                      "border": `1px solid ${theme.palette.border.dark}`,
-                      "backgroundColor": "background.main",
-                      "color": "text.secondary",
-                      "&:hover": {
-                        backgroundColor: "background.accent",
-                        border: `1px solid ${theme.palette.border.dark}`,
-                      },
-                    }}
-                    disableRipple={theme.components?.MuiButton?.defaultProps?.disableRipple}
-                  >
-                    Add/remove risks
-                  </Button>
+                    isDisabled={isEditingDisabled}
+                    text="Add/remove risks"
+                    size="small"
+                  />
 
                   <Stack direction="row" spacing={2}>
                     <Typography sx={{ fontSize: 11, color: "text.secondary" }}>


### PR DESCRIPTION
## Describe your changes

Replace raw MUI Button with CustomizableButton in ClauseDrawerDialog, AnnexDrawerDialog, ISO27001AnnexDrawerDialog, ISO27001ClauseDrawerDialog

## Write your issue number after "Fixes "

Fixes #4009 

## Please ensure all items are checked off before requesting a review:

- [x] I deployed the code locally.
- [x] I have performed a self-review of my code.
- [x] I have included the issue # in the PR.
- [x] I have labelled the PR correctly.
- [x] The issue I am working on is assigned to me.
- [x] I have avoided using hardcoded values to ensure scalability and maintain consistency across the application.
- [x] I have ensured that font sizes, color choices, and other UI elements are referenced from the theme.
- [x] My pull request is focused and addresses a single, specific feature.
- [x] If there are UI changes, I have attached a screenshot or video to this PR.

<img width="834" height="342" alt="Screenshot 2026-06-03 at 1 56 00 PM" src="https://github.com/user-attachments/assets/07f41f4c-4780-4581-acac-5d1d75ee6a1f" />
<img width="834" height="385" alt="Screenshot 2026-06-03 at 1 55 54 PM" src="https://github.com/user-attachments/assets/d363dfe2-117c-4542-8721-ca3c45d9bc97" />
