### PR TITLE
Feat: Deadline Warning Banner

### DIFF
--- a/Clients/src/application/config/deadlineConfig.ts
+++ b/Clients/src/application/config/deadlineConfig.ts
@@ -1,0 +1,27 @@
+export interface DeadlineThresholds {
+  /** Tasks due within this many days (inclusive of today) are considered "due soon". */
+  dueSoonDays: number;
+}
+
+export const DEADLINE_CONFIG: DeadlineThresholds = {
+  dueSoonDays: 7,
+};
+
+/** Snooze durations (in milliseconds) offered in the banner's snooze menu. */
+export const SNOOZE_DURATIONS = {
+  ONE_HOUR: 60 * 60 * 1000,
+  ONE_DAY: 24 * 60 * 60 * 1000,
+  ONE_WEEK: 7 * 24 * 60 * 60 * 1000,
+} as const;
+
+export interface SnoozeOption {
+  label: string;
+  durationMs: number;
+}
+
+/** Options rendered in the snooze dropdown, in display order. */
+export const SNOOZE_OPTIONS: SnoozeOption[] = [
+  { label: "1 hour", durationMs: SNOOZE_DURATIONS.ONE_HOUR },
+  { label: "24 hours", durationMs: SNOOZE_DURATIONS.ONE_DAY },
+  { label: "1 week", durationMs: SNOOZE_DURATIONS.ONE_WEEK },
+];

--- a/Clients/src/application/hooks/useDeadlineWarnings.ts
+++ b/Clients/src/application/hooks/useDeadlineWarnings.ts
@@ -1,0 +1,43 @@
+import { useQuery } from "@tanstack/react-query";
+import { useAuth } from "./useAuth";
+import { getDeadlineSummary, DeadlineSummary } from "../repository/deadline.repository";
+import { DEADLINE_CONFIG } from "../config/deadlineConfig";
+
+const DEADLINE_WARNINGS_QUERY_KEY = ["deadlineWarnings"] as const;
+
+interface UseDeadlineWarningsResult {
+  overdue: number;
+  dueSoon: number;
+  dueSoonDays: number;
+  isLoading: boolean;
+  error: string | null;
+}
+
+/**
+ * Fetches the current organization's deadline summary (overdue + due-soon task
+ * counts) from GET /api/deadlines/summary. Disabled until a user is present.
+ */
+const useDeadlineWarnings = (): UseDeadlineWarningsResult => {
+  const { userId } = useAuth();
+
+  const { data, isLoading, error } = useQuery({
+    queryKey: DEADLINE_WARNINGS_QUERY_KEY,
+    queryFn: async (): Promise<DeadlineSummary> => {
+      const response = await getDeadlineSummary(DEADLINE_CONFIG.dueSoonDays);
+      return response.data;
+    },
+    enabled: !!userId,
+    staleTime: 5 * 60 * 1000, // fresh for 5 minutes
+    gcTime: 10 * 60 * 1000, // cached for 10 minutes
+  });
+
+  return {
+    overdue: data?.overdue ?? 0,
+    dueSoon: data?.dueSoon ?? 0,
+    dueSoonDays: data?.dueSoonDays ?? DEADLINE_CONFIG.dueSoonDays,
+    isLoading,
+    error: error instanceof Error ? error.message : error ? String(error) : null,
+  };
+};
+
+export default useDeadlineWarnings;

--- a/Clients/src/application/repository/deadline.repository.ts
+++ b/Clients/src/application/repository/deadline.repository.ts
@@ -1,0 +1,21 @@
+import { apiServices } from "../../infrastructure/api/networkServices";
+
+export interface DeadlineSummary {
+  overdue: number;
+  dueSoon: number;
+  dueSoonDays: number;
+}
+
+/**
+ * Retrieves the deadline summary (overdue + due-soon task counts) for the
+ * current organization. Org scoping is handled server-side via the auth token.
+ *
+ * @param {number} [days] - Optional due-soon window in days (defaults to backend's 7).
+ * @returns {Promise<{ data: DeadlineSummary }>} The wrapped summary payload.
+ * @throws Will throw an error if the request fails.
+ */
+export async function getDeadlineSummary(days?: number): Promise<{ data: DeadlineSummary }> {
+  const query = typeof days === "number" ? `?days=${days}` : "";
+  const response = await apiServices.get(`/deadlines/summary${query}`);
+  return response.data as { data: DeadlineSummary };
+}

--- a/Clients/src/application/utils/deadlineSnooze.ts
+++ b/Clients/src/application/utils/deadlineSnooze.ts
@@ -1,0 +1,53 @@
+/**
+ * Per-user snooze persistence for the deadline warning banner.
+ *
+ * Stored under `verifywise_deadline_snooze_<userId>` as `{ snoozeUntil: number }`,
+ * where `snoozeUntil` is a Unix epoch (ms) timestamp. The banner is hidden while
+ * `Date.now() < snoozeUntil` and reappears automatically once that time passes.
+ *
+ * All access is wrapped in try/catch so a disabled/full localStorage never breaks
+ * the banner (mirrors the pattern in useTipManager / paginationStorage).
+ */
+
+interface SnoozeState {
+  snoozeUntil: number;
+}
+
+const snoozeKey = (userId: number): string => `verifywise_deadline_snooze_${userId}`;
+
+/** Returns the snooze expiry timestamp (ms), or null if not snoozed / unreadable. */
+export const getSnoozeExpiry = (userId: number): number | null => {
+  try {
+    const raw = localStorage.getItem(snoozeKey(userId));
+    if (!raw) return null;
+    const parsed = JSON.parse(raw) as Partial<SnoozeState>;
+    return typeof parsed?.snoozeUntil === "number" ? parsed.snoozeUntil : null;
+  } catch {
+    return null;
+  }
+};
+
+/** True when the banner is currently snoozed for this user. */
+export const isSnoozed = (userId: number): boolean => {
+  const expiry = getSnoozeExpiry(userId);
+  return expiry !== null && Date.now() < expiry;
+};
+
+/** Snooze the banner for `durationMs` from now. */
+export const setSnooze = (userId: number, durationMs: number): void => {
+  try {
+    const state: SnoozeState = { snoozeUntil: Date.now() + durationMs };
+    localStorage.setItem(snoozeKey(userId), JSON.stringify(state));
+  } catch {
+    // localStorage unavailable (private mode / quota) — snooze is best-effort.
+  }
+};
+
+/** Clear any existing snooze for this user. */
+export const clearSnooze = (userId: number): void => {
+  try {
+    localStorage.removeItem(snoozeKey(userId));
+  } catch {
+    // No-op if storage is unavailable.
+  }
+};

--- a/Clients/src/application/utils/tests/deadlineSnooze.test.ts
+++ b/Clients/src/application/utils/tests/deadlineSnooze.test.ts
@@ -1,10 +1,5 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
-import {
-  getSnoozeExpiry,
-  isSnoozed,
-  setSnooze,
-  clearSnooze,
-} from "../deadlineSnooze";
+import { getSnoozeExpiry, isSnoozed, setSnooze, clearSnooze } from "../deadlineSnooze";
 
 const USER_ID = 42;
 const STORAGE_KEY = `verifywise_deadline_snooze_${USER_ID}`;

--- a/Clients/src/application/utils/tests/deadlineSnooze.test.ts
+++ b/Clients/src/application/utils/tests/deadlineSnooze.test.ts
@@ -1,0 +1,65 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import {
+  getSnoozeExpiry,
+  isSnoozed,
+  setSnooze,
+  clearSnooze,
+} from "../deadlineSnooze";
+
+const USER_ID = 42;
+const STORAGE_KEY = `verifywise_deadline_snooze_${USER_ID}`;
+const ONE_HOUR = 60 * 60 * 1000;
+
+describe("deadlineSnooze", () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("setSnooze persists a future expiry and isSnoozed reports true", () => {
+    setSnooze(USER_ID, ONE_HOUR);
+
+    const expiry = getSnoozeExpiry(USER_ID);
+    expect(expiry).not.toBeNull();
+    expect(expiry!).toBeGreaterThan(Date.now());
+    expect(isSnoozed(USER_ID)).toBe(true);
+  });
+
+  it("getSnoozeExpiry returns null when nothing is stored", () => {
+    expect(getSnoozeExpiry(USER_ID)).toBeNull();
+    expect(isSnoozed(USER_ID)).toBe(false);
+  });
+
+  it("isSnoozed returns false once the snooze has expired", () => {
+    // Write an already-expired snooze directly.
+    localStorage.setItem(STORAGE_KEY, JSON.stringify({ snoozeUntil: Date.now() - 1000 }));
+
+    expect(isSnoozed(USER_ID)).toBe(false);
+    // Expiry value is still readable, it's just in the past.
+    expect(getSnoozeExpiry(USER_ID)).toBeLessThan(Date.now());
+  });
+
+  it("clearSnooze removes the stored snooze", () => {
+    setSnooze(USER_ID, ONE_HOUR);
+    expect(isSnoozed(USER_ID)).toBe(true);
+
+    clearSnooze(USER_ID);
+    expect(getSnoozeExpiry(USER_ID)).toBeNull();
+    expect(isSnoozed(USER_ID)).toBe(false);
+  });
+
+  it("getSnoozeExpiry returns null for corrupted JSON instead of throwing", () => {
+    localStorage.setItem(STORAGE_KEY, "{not json");
+    expect(() => getSnoozeExpiry(USER_ID)).not.toThrow();
+    expect(getSnoozeExpiry(USER_ID)).toBeNull();
+  });
+
+  it("scopes snooze per user id", () => {
+    setSnooze(USER_ID, ONE_HOUR);
+    expect(isSnoozed(USER_ID)).toBe(true);
+    expect(isSnoozed(999)).toBe(false);
+  });
+});

--- a/Clients/src/i18n/translations.ts
+++ b/Clients/src/i18n/translations.ts
@@ -25,6 +25,7 @@ export type Lang = "en" | "de" | "fr";
 
 export const translations: Record<string, Record<string, string>> = {
   de: {
+    "Snooze": "Schlummern",
     // Sidebar / nav
     "Start here": "Hier starten",
     "Dashboard": "Dashboard",
@@ -7949,6 +7950,7 @@ export const translations: Record<string, Record<string, string>> = {
   },
 
   fr: {
+    "Snooze": "Différer",
     // Sidebar / nav
     "Start here": "Commencer ici",
     "Dashboard": "Tableau de bord",

--- a/Clients/src/presentation/components/DeadlineWarningBox/__tests__/DeadlineWarningBox.test.tsx
+++ b/Clients/src/presentation/components/DeadlineWarningBox/__tests__/DeadlineWarningBox.test.tsx
@@ -52,9 +52,7 @@ describe("DeadlineWarningBox", () => {
   it("shows only the due-soon segment when there are no overdue tasks", () => {
     mockWarnings.mockReturnValue({ ...baseWarnings, dueSoon: 1 });
     renderWithProviders(<DeadlineWarningBox />);
-    expect(
-      screen.getByText("You have 1 task due in the next 7 days."),
-    ).toBeInTheDocument();
+    expect(screen.getByText("You have 1 task due in the next 7 days.")).toBeInTheDocument();
   });
 
   it("renders nothing when the banner is already snoozed", () => {

--- a/Clients/src/presentation/components/DeadlineWarningBox/__tests__/DeadlineWarningBox.test.tsx
+++ b/Clients/src/presentation/components/DeadlineWarningBox/__tests__/DeadlineWarningBox.test.tsx
@@ -1,0 +1,84 @@
+import { vi } from "vitest";
+
+const mockWarnings = vi.fn();
+
+vi.mock("../../../../application/hooks/useDeadlineWarnings", () => ({
+  default: () => mockWarnings(),
+}));
+
+vi.mock("../../../../application/hooks/useAuth", () => ({
+  useAuth: () => ({ userId: 1 }),
+}));
+
+import { describe, it, expect, beforeEach } from "vitest";
+import { screen, fireEvent } from "@testing-library/react";
+import { renderWithProviders } from "../../../../test/renderWithProviders";
+import DeadlineWarningBox from "../index";
+
+const baseWarnings = {
+  overdue: 0,
+  dueSoon: 0,
+  dueSoonDays: 7,
+  isLoading: false,
+  error: null,
+};
+
+describe("DeadlineWarningBox", () => {
+  beforeEach(() => {
+    localStorage.clear();
+    mockWarnings.mockReset();
+  });
+
+  it("renders nothing when there are no overdue or due-soon tasks", () => {
+    mockWarnings.mockReturnValue({ ...baseWarnings });
+    const { container } = renderWithProviders(<DeadlineWarningBox />);
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it("renders nothing while loading", () => {
+    mockWarnings.mockReturnValue({ ...baseWarnings, overdue: 3, isLoading: true });
+    const { container } = renderWithProviders(<DeadlineWarningBox />);
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it("shows overdue and due-soon counts with correct pluralization", () => {
+    mockWarnings.mockReturnValue({ ...baseWarnings, overdue: 1, dueSoon: 3 });
+    renderWithProviders(<DeadlineWarningBox />);
+    expect(
+      screen.getByText("You have 1 overdue task and 3 tasks due in the next 7 days."),
+    ).toBeInTheDocument();
+  });
+
+  it("shows only the due-soon segment when there are no overdue tasks", () => {
+    mockWarnings.mockReturnValue({ ...baseWarnings, dueSoon: 1 });
+    renderWithProviders(<DeadlineWarningBox />);
+    expect(
+      screen.getByText("You have 1 task due in the next 7 days."),
+    ).toBeInTheDocument();
+  });
+
+  it("renders nothing when the banner is already snoozed", () => {
+    localStorage.setItem(
+      "verifywise_deadline_snooze_1",
+      JSON.stringify({ snoozeUntil: Date.now() + 60 * 60 * 1000 }),
+    );
+    mockWarnings.mockReturnValue({ ...baseWarnings, overdue: 2 });
+    const { container } = renderWithProviders(<DeadlineWarningBox />);
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it("persists a snooze and hides the banner when a snooze option is chosen", () => {
+    mockWarnings.mockReturnValue({ ...baseWarnings, overdue: 2 });
+    renderWithProviders(<DeadlineWarningBox />);
+
+    fireEvent.click(screen.getByRole("button", { name: /snooze/i }));
+    fireEvent.click(screen.getByText("24 hours"));
+
+    // Persisted to localStorage with a future expiry.
+    const stored = JSON.parse(localStorage.getItem("verifywise_deadline_snooze_1") || "{}");
+    expect(stored.snoozeUntil).toBeGreaterThan(Date.now());
+
+    // Banner is gone.
+    expect(screen.queryByText(/You have/)).not.toBeInTheDocument();
+  });
+});

--- a/Clients/src/presentation/components/DeadlineWarningBox/index.tsx
+++ b/Clients/src/presentation/components/DeadlineWarningBox/index.tsx
@@ -1,0 +1,161 @@
+import { useState, useEffect } from "react";
+import { Stack, Typography, Button, Menu, MenuItem, ListItemText } from "@mui/material";
+import { AlertTriangle, Clock, ChevronDown } from "lucide-react";
+import { useAuth } from "../../../application/hooks/useAuth";
+import useDeadlineWarnings from "../../../application/hooks/useDeadlineWarnings";
+import { SNOOZE_OPTIONS } from "../../../application/config/deadlineConfig";
+import { getSnoozeExpiry, setSnooze } from "../../../application/utils/deadlineSnooze";
+import { status, background, text } from "../../themes/palette";
+
+/**
+ * Banner shown on the Tasks page when the organization has overdue or
+ * soon-due tasks. Hidden while snoozed (per-user, persisted) and re-appears
+ * automatically once the snooze expires. Renders nothing when there is
+ * nothing to warn about.
+ */
+const DeadlineWarningBox = () => {
+  const { userId } = useAuth();
+  const { overdue, dueSoon, dueSoonDays, isLoading } = useDeadlineWarnings();
+
+  const [snoozeUntil, setSnoozeUntil] = useState<number | null>(() =>
+    userId ? getSnoozeExpiry(userId) : null,
+  );
+  const [anchorEl, setAnchorEl] = useState<null | HTMLElement>(null);
+
+  // Re-read persisted snooze once the user id becomes available.
+  useEffect(() => {
+    if (userId) setSnoozeUntil(getSnoozeExpiry(userId));
+  }, [userId]);
+
+  // Clear the snooze automatically when it expires so the banner re-appears.
+  useEffect(() => {
+    if (!snoozeUntil) return;
+    const remaining = snoozeUntil - Date.now();
+    if (remaining <= 0) {
+      setSnoozeUntil(null);
+      return;
+    }
+    const timer = setTimeout(() => setSnoozeUntil(null), remaining);
+    return () => clearTimeout(timer);
+  }, [snoozeUntil]);
+
+  const handleSnooze = (durationMs: number) => {
+    if (userId) {
+      setSnooze(userId, durationMs);
+      setSnoozeUntil(Date.now() + durationMs);
+    }
+    setAnchorEl(null);
+  };
+
+  // Guards: no user, still loading, currently snoozed, or nothing to warn about.
+  if (!userId || isLoading) return null;
+  if (snoozeUntil !== null && Date.now() < snoozeUntil) return null;
+  if (overdue === 0 && dueSoon === 0) return null;
+
+  const isCritical = overdue > 0;
+  const palette = isCritical ? status.error : status.warning;
+
+  const parts: string[] = [];
+  if (overdue > 0) {
+    parts.push(`${overdue} overdue ${overdue === 1 ? "task" : "tasks"}`);
+  }
+  if (dueSoon > 0) {
+    parts.push(
+      `${dueSoon} ${dueSoon === 1 ? "task" : "tasks"} due in the next ${dueSoonDays} days`,
+    );
+  }
+  const message = `You have ${parts.join(" and ")}.`;
+
+  return (
+    <Stack
+      direction={{ xs: "column", sm: "row" }}
+      alignItems={{ xs: "flex-start", sm: "center" }}
+      justifyContent="space-between"
+      spacing={1.5}
+      role="alert"
+      sx={{
+        py: "10px",
+        px: 2,
+        backgroundColor: palette.bg,
+        border: `1px solid ${palette.border}`,
+        borderRadius: 2,
+      }}
+    >
+      <Stack direction="row" alignItems="center" spacing={1.5} sx={{ minWidth: 0 }}>
+        {isCritical ? (
+          <AlertTriangle size={16} color={palette.text} style={{ flexShrink: 0 }} />
+        ) : (
+          <Clock size={16} color={palette.text} style={{ flexShrink: 0 }} />
+        )}
+        <Typography sx={{ fontSize: 13, fontWeight: 500, color: palette.text }}>
+          {message}
+        </Typography>
+      </Stack>
+
+      <Button
+        size="small"
+        variant="outlined"
+        endIcon={<ChevronDown size={14} />}
+        onClick={(e) => setAnchorEl(e.currentTarget)}
+        aria-haspopup="true"
+        aria-expanded={Boolean(anchorEl)}
+        sx={{
+          "textTransform": "none",
+          "fontSize": 12,
+          "fontWeight": 600,
+          "minWidth": "auto",
+          "flexShrink": 0,
+          "px": 1.5,
+          "py": 0.25,
+          "color": palette.text,
+          "borderColor": palette.border,
+          "&:hover": {
+            color: palette.text,
+            borderColor: palette.text,
+            backgroundColor: "transparent",
+          },
+        }}
+      >
+        Snooze
+      </Button>
+
+      <Menu
+        anchorEl={anchorEl}
+        open={Boolean(anchorEl)}
+        onClose={() => setAnchorEl(null)}
+        anchorOrigin={{ vertical: "bottom", horizontal: "right" }}
+        transformOrigin={{ vertical: "top", horizontal: "right" }}
+        slotProps={{
+          paper: {
+            sx: {
+              minWidth: "160px",
+              boxShadow: "0px 4px 12px rgba(0, 0, 0, 0.1)",
+              borderRadius: "8px",
+              mt: 1,
+            },
+          },
+        }}
+      >
+        {SNOOZE_OPTIONS.map((option) => (
+          <MenuItem
+            key={option.durationMs}
+            onClick={() => handleSnooze(option.durationMs)}
+            sx={{
+              "fontSize": "13px",
+              "padding": "8px 12px",
+              "color": text.primary,
+              "&:hover": { backgroundColor: `${background.accent} !important` },
+            }}
+          >
+            <ListItemText
+              primary={option.label}
+              primaryTypographyProps={{ fontSize: "13px" }}
+            />
+          </MenuItem>
+        ))}
+      </Menu>
+    </Stack>
+  );
+};
+
+export default DeadlineWarningBox;

--- a/Clients/src/presentation/components/DeadlineWarningBox/index.tsx
+++ b/Clients/src/presentation/components/DeadlineWarningBox/index.tsx
@@ -147,10 +147,7 @@ const DeadlineWarningBox = () => {
               "&:hover": { backgroundColor: `${background.accent} !important` },
             }}
           >
-            <ListItemText
-              primary={option.label}
-              primaryTypographyProps={{ fontSize: "13px" }}
-            />
+            <ListItemText primary={option.label} primaryTypographyProps={{ fontSize: "13px" }} />
           </MenuItem>
         ))}
       </Menu>

--- a/Clients/src/presentation/components/Layout/PageHeaderExtended.tsx
+++ b/Clients/src/presentation/components/Layout/PageHeaderExtended.tsx
@@ -12,6 +12,7 @@ export function PageHeaderExtended({
   title,
   description,
   helpArticlePath,
+  warningBanner,
   tipBoxEntity,
   summaryCards,
   summaryCardsJoyrideId,
@@ -65,6 +66,8 @@ export function PageHeaderExtended({
           {/* Alerts/toasts rendered outside the gap Stack so they don't affect layout */}
           {alert}
           {loadingToast}
+
+          {warningBanner && <Box sx={{ mt: "18px" }}>{warningBanner}</Box>}
 
           {(tipBoxEntity || summaryCards) && (
             <Stack gap="18px" sx={{ mt: "18px" }}>

--- a/Clients/src/presentation/pages/Tasks/index.tsx
+++ b/Clients/src/presentation/pages/Tasks/index.tsx
@@ -8,6 +8,7 @@ import { SearchBox } from "../../components/Search";
 import TasksTable from "../../components/Table/TasksTable";
 import { CustomizableButton } from "../../components/button/customizable-button";
 import { PageHeaderExtended } from "../../components/Layout/PageHeaderExtended";
+import DeadlineWarningBox from "../../components/DeadlineWarningBox";
 import { VerifyWiseContext } from "../../../application/contexts/VerifyWise.context";
 import { ITask, TaskSummary } from "../../../domain/interfaces/i.task";
 import {
@@ -779,6 +780,7 @@ const Tasks: React.FC = () => {
           : "Showing tasks you created or are assigned to. You can create and manage your tasks here."
       }
       helpArticlePath="ai-governance/task-management"
+      warningBanner={<DeadlineWarningBox />}
       tipBoxEntity="tasks"
       summaryCards={
         <TaskSummaryCards

--- a/Clients/src/presentation/types/interfaces/i.header.ts
+++ b/Clients/src/presentation/types/interfaces/i.header.ts
@@ -5,6 +5,8 @@ export interface PageHeaderExtendedProps {
   title: string;
   description?: string;
   helpArticlePath?: string;
+  /** Banner rendered above the TipBox (e.g. deadline warnings). */
+  warningBanner?: ReactNode;
   tipBoxEntity?: string;
   summaryCards?: ReactNode;
   summaryCardsJoyrideId?: string;

--- a/Servers/app.ts
+++ b/Servers/app.ts
@@ -37,6 +37,7 @@ import tiersRoutes from "./routes/tiers.route";
 import subscriptionRoutes from "./routes/subscription.route";
 import autoDriverRoutes from "./routes/autoDriver.route";
 import taskRoutes from "./routes/task.route";
+import deadlineRoutes from "./routes/deadline.route";
 import slackWebhookRoutes from "./routes/slackWebhook.route";
 import pluginRoutes from "./routes/plugin.route";
 import tokenRoutes from "./routes/tokens.route";
@@ -239,6 +240,7 @@ export function createApp(preRoutesMiddleware?: RequestHandler[]): express.Appli
   app.use("/api/tiers", tiersRoutes);
   app.use("/api/subscriptions", subscriptionRoutes);
   app.use("/api/tasks", taskRoutes);
+  app.use("/api/deadlines", deadlineRoutes);
   app.use("/api/docs", swaggerUi.serve, swaggerUi.setup(swaggerDoc));
   app.use("/api/policies", policyRoutes);
   app.use("/api/policies", policyFolderRoutes);

--- a/Servers/controllers/deadline.ctrl.ts
+++ b/Servers/controllers/deadline.ctrl.ts
@@ -17,8 +17,7 @@ export async function getDeadlinesSummary(req: Request, res: Response) {
 
   try {
     const parsedDays = parseInt(req.query.days as string);
-    const days =
-      Number.isFinite(parsedDays) && parsedDays > 0 ? parsedDays : DEFAULT_DUE_SOON_DAYS;
+    const days = Number.isFinite(parsedDays) && parsedDays > 0 ? parsedDays : DEFAULT_DUE_SOON_DAYS;
 
     const summary = await getDeadlineSummaryQuery(req.organizationId!, days);
 

--- a/Servers/controllers/deadline.ctrl.ts
+++ b/Servers/controllers/deadline.ctrl.ts
@@ -1,0 +1,48 @@
+import { Request, Response } from "express";
+import { logFailure, logProcessing, logSuccess } from "../utils/logger/logHelper";
+import { STATUS_CODE } from "../utils/statusCode.utils";
+import { getDeadlineSummaryQuery } from "../utils/deadline.utils";
+import { translateError } from "../utils/i18n.utils";
+
+const DEFAULT_DUE_SOON_DAYS = 7;
+
+export async function getDeadlinesSummary(req: Request, res: Response) {
+  logProcessing({
+    description: "starting getDeadlinesSummary",
+    functionName: "getDeadlinesSummary",
+    fileName: "deadline.ctrl.ts",
+    userId: req.userId!,
+    tenantId: req.organizationId!,
+  });
+
+  try {
+    const parsedDays = parseInt(req.query.days as string);
+    const days =
+      Number.isFinite(parsedDays) && parsedDays > 0 ? parsedDays : DEFAULT_DUE_SOON_DAYS;
+
+    const summary = await getDeadlineSummaryQuery(req.organizationId!, days);
+
+    await logSuccess({
+      eventType: "Read",
+      description: "Retrieved deadline summary successfully",
+      functionName: "getDeadlinesSummary",
+      fileName: "deadline.ctrl.ts",
+      userId: req.userId!,
+      tenantId: req.organizationId!,
+    });
+
+    return res.status(200).json(STATUS_CODE[200](summary));
+  } catch (error) {
+    await logFailure({
+      eventType: "Read",
+      description: "Failed to retrieve deadline summary",
+      functionName: "getDeadlinesSummary",
+      fileName: "deadline.ctrl.ts",
+      error: error as Error,
+      userId: req.userId!,
+      tenantId: req.organizationId!,
+    });
+
+    return res.status(500).json(STATUS_CODE[500](translateError(req, error)));
+  }
+}

--- a/Servers/routes/deadline.route.ts
+++ b/Servers/routes/deadline.route.ts
@@ -1,0 +1,11 @@
+import express from "express";
+const router = express.Router();
+
+import { getDeadlinesSummary } from "../controllers/deadline.ctrl";
+
+import authenticateJWT from "../middleware/auth.middleware";
+
+// GET requests
+router.get("/summary", authenticateJWT, getDeadlinesSummary);
+
+export default router;

--- a/Servers/utils/deadline.utils.ts
+++ b/Servers/utils/deadline.utils.ts
@@ -1,0 +1,42 @@
+import { sequelize } from "../database/db";
+
+export interface IDeadlineSummary {
+  overdue: number;
+  dueSoon: number;
+  dueSoonDays: number;
+}
+
+/**
+ * Returns counts of overdue and due-soon tasks for an organization.
+ * - overdue: due_date < today, not Completed/Deleted
+ * - dueSoon: due_date within the next `days` days (inclusive of today), not Completed/Deleted
+ *
+ * NULL due_date rows are naturally excluded by the date comparisons.
+ */
+export const getDeadlineSummaryQuery = async (
+  organizationId: number,
+  days: number = 7,
+): Promise<IDeadlineSummary> => {
+  const overdueResult = (await sequelize.query(
+    `SELECT COUNT(*) FROM tasks
+     WHERE due_date < CURRENT_DATE
+     AND status NOT IN ('Completed', 'Deleted')
+     AND organization_id = :organizationId`,
+    { replacements: { organizationId } },
+  )) as [{ count: string }[], number];
+
+  const dueSoonResult = (await sequelize.query(
+    `SELECT COUNT(*) FROM tasks
+     WHERE due_date >= CURRENT_DATE
+     AND due_date <= CURRENT_DATE + (:days || ' days')::INTERVAL
+     AND status NOT IN ('Completed', 'Deleted')
+     AND organization_id = :organizationId`,
+    { replacements: { organizationId, days } },
+  )) as [{ count: string }[], number];
+
+  return {
+    overdue: parseInt(overdueResult[0][0].count),
+    dueSoon: parseInt(dueSoonResult[0][0].count),
+    dueSoonDays: days,
+  };
+};


### PR DESCRIPTION
## Describe your changes

Adds a Deadline Warning banner to the Tasks page that surfaces overdue and due-soon task counts, backed by a new `GET /api/deadlines/summary` endpoint (org-scoped, reuses the dashboard's deadline SQL). The banner is severity-aware (red for overdue, amber for due-soon), self-hides when there's nothing to warn about, and supports per-user snoozing (1h/24h/1w) persisted in localStorage that auto-expires. Includes config, a React Query hook, a reusable `warningBanner` slot in `PageHeaderExtended`, and unit/component tests.

Fixes part of #4018 

## Please ensure all items are checked off before requesting a review:

- [x] I deployed the code locally.
- [x] I have performed a self-review of my code.
- [x] I have included the issue # in the PR.
- [x] I have labelled the PR correctly.
- [x] The issue I am working on is assigned to me.
- [x] I have avoided using hardcoded values to ensure scalability and maintain consistency across the application.
- [x] I have ensured that font sizes, color choices, and other UI elements are referenced from the theme.
- [x] My pull request is focused and addresses a single, specific feature.
- [x] If there are UI changes, I have attached a screenshot or video to this PR.
<img width="1099" height="395" alt="Screenshot 2026-06-09 at 21 36 52" src="https://github.com/user-attachments/assets/f5ac7378-b8e3-424a-8f1a-3e48db2c7b92" />
