### PR TITLE
feat(ui): unify table loading states with CustomizableSkeleton

### DIFF
--- a/Clients/src/presentation/pages/AgentDiscovery/AgentTable.tsx
+++ b/Clients/src/presentation/pages/AgentDiscovery/AgentTable.tsx
@@ -28,6 +28,7 @@ import {
 import IconButton from "../../components/IconButton";
 import { ReactComponent as SelectorVertical } from "../../assets/icons/selector-vertical.svg";
 import { EmptyState } from "../../components/EmptyState";
+import CustomizableSkeleton from "../../components/Skeletons";
 import { CustomizableButton } from "../../components/button/customizable-button";
 import EmptyStateTip from "../../components/EmptyState/EmptyStateTip";
 import { getInstalledPlugins } from "../../../application/repository/plugin.repository";
@@ -179,7 +180,11 @@ const AgentTable: React.FC<AgentTableProps> = ({
   }, [page, rowsPerPage, sortedData.length]);
 
   if (isLoading) {
-    return <EmptyState icon={Bot} message="Loading agents..." />;
+    return (
+      <Stack spacing={2}>
+        <CustomizableSkeleton variant="rectangular" width="100%" height={400} />
+      </Stack>
+    );
   }
 
   if (!sortedData || sortedData.length === 0) {

--- a/Clients/src/presentation/pages/AgentDiscovery/index.tsx
+++ b/Clients/src/presentation/pages/AgentDiscovery/index.tsx
@@ -384,8 +384,8 @@ const AgentDiscovery: React.FC = () => {
         ) : undefined
       }
     >
-      {/* Controls row - only show when agents exist */}
-      {hasAgents && (
+      {/* Controls row - show while loading or when agents exist */}
+      {(hasAgents || isLoading) && (
         <Stack spacing={2}>
           <Stack direction="row" justifyContent="space-between" alignItems="center">
             <Stack direction="row" gap={2} alignItems="center">

--- a/Clients/src/presentation/pages/FileManager/index.tsx
+++ b/Clients/src/presentation/pages/FileManager/index.tsx
@@ -18,7 +18,7 @@ import {
   UpdateFileMetadataInput,
 } from "../../../application/repository/file.repository";
 import { transformFilesData } from "../../../application/utils/fileTransform.utils";
-import { filesTableFrame, filesTablePlaceholder } from "./styles";
+import { filesTableFrame } from "./styles";
 import { FileModel } from "../../../domain/models/Common/file/file.model";
 import { CustomizableButton } from "../../components/button/customizable-button";
 import FileManagerUploadModal from "../../components/Modals/FileManagerUpload";
@@ -935,13 +935,7 @@ const FileManager: React.FC = (): JSX.Element => {
             }}
           >
             {isLoading ? (
-              <Box sx={{ padding: "24px", textAlign: "center" }}>
-                <Typography sx={{ color: "text.icon" }}>Loading files...</Typography>
-                <CustomizableSkeleton
-                  variant="rectangular"
-                  sx={{ ...filesTablePlaceholder, marginTop: 2 }}
-                />
-              </Box>
+              <CustomizableSkeleton variant="rectangular" height={400} />
             ) : filesError ? (
               <Box
                 sx={{

--- a/Clients/src/presentation/pages/ModelInventory/DatasetTable.tsx
+++ b/Clients/src/presentation/pages/ModelInventory/DatasetTable.tsx
@@ -10,12 +10,11 @@ import {
   TableRow,
   useTheme,
   Stack,
-  Typography,
   TableFooter,
   Tooltip,
-  Box,
 } from "@mui/material";
 import TablePaginationActions from "../../components/TablePagination";
+import CustomizableSkeleton from "../../components/Skeletons";
 import "../../components/Table/index.css";
 import singleTheme from "../../themes/v1SingleTheme";
 import CustomIconButton from "../../components/IconButton";
@@ -40,7 +39,6 @@ import {
 import {
   tableRowHoverStyle,
   tableRowDeletingStyle,
-  loadingContainerStyle,
   tableFooterRowStyle,
   showingTextCellStyle,
   paginationMenuProps,
@@ -257,9 +255,9 @@ const DatasetTable: React.FC<DatasetTableProps> = ({
 
   if (isLoading) {
     return (
-      <Box sx={loadingContainerStyle}>
-        <Typography>Loading datasets...</Typography>
-      </Box>
+      <Stack spacing={2}>
+        <CustomizableSkeleton variant="rectangular" width="100%" height={400} />
+      </Stack>
     );
   }
 

--- a/Clients/src/presentation/pages/ModelInventory/ModelEvaluationsTab.tsx
+++ b/Clients/src/presentation/pages/ModelInventory/ModelEvaluationsTab.tsx
@@ -2,6 +2,7 @@ import { useState, useEffect, useMemo } from "react";
 import { Box, Stack, Typography, Alert as MuiAlert } from "@mui/material";
 import { FlaskConical, AlertTriangle } from "lucide-react";
 import Chip from "../../components/Chip";
+import CustomizableSkeleton from "../../components/Skeletons";
 import { palette } from "../../themes/palette";
 import {
   getAllModelEvaluations,
@@ -92,11 +93,9 @@ export default function ModelEvaluationsTab() {
 
   if (loading) {
     return (
-      <Box sx={{ p: "24px", textAlign: "center" }}>
-        <Typography sx={{ fontSize: "13px", color: palette.text.secondary }}>
-          Loading evaluations...
-        </Typography>
-      </Box>
+      <Stack spacing={2} sx={{ p: "24px" }}>
+        <CustomizableSkeleton variant="rectangular" width="100%" height={400} />
+      </Stack>
     );
   }
 

--- a/Clients/src/presentation/pages/ModelInventory/ModelRisksTable.tsx
+++ b/Clients/src/presentation/pages/ModelInventory/ModelRisksTable.tsx
@@ -14,6 +14,7 @@ import {
 } from "@mui/material";
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { EmptyState } from "../../components/EmptyState";
+import CustomizableSkeleton from "../../components/Skeletons";
 import singleTheme from "../../themes/v1SingleTheme";
 import IconButton from "../../components/IconButton";
 import TablePaginationActions from "../../components/TablePagination";
@@ -495,24 +496,10 @@ const ModelRisksTable: React.FC<ModelRisksTableProps> = ({
     ],
   );
 
-  // Show loading state
   if (isLoading) {
     return (
-      <Stack
-        alignItems="center"
-        justifyContent="center"
-        sx={{
-          border: `1px solid ${palette.border.light}`,
-          borderRadius: "4px",
-          padding: theme.spacing(15, 5),
-          paddingBottom: theme.spacing(20),
-          gap: theme.spacing(10),
-          minHeight: 200,
-        }}
-      >
-        <Typography sx={{ fontSize: "13px", color: palette.text.tertiary }}>
-          Loading model risks...
-        </Typography>
+      <Stack spacing={2}>
+        <CustomizableSkeleton variant="rectangular" width="100%" height={400} />
       </Stack>
     );
   }

--- a/Clients/src/presentation/pages/ModelInventory/evidenceHubTable.tsx
+++ b/Clients/src/presentation/pages/ModelInventory/evidenceHubTable.tsx
@@ -21,6 +21,7 @@ import {
   IconButton as MuiIconButton,
 } from "@mui/material";
 import TablePaginationActions from "../../components/TablePagination";
+import CustomizableSkeleton from "../../components/Skeletons";
 import CustomIconButton from "../../components/IconButton";
 import {
   ChevronsUpDown,
@@ -46,7 +47,6 @@ import EvidenceAnalysisPanel from "../../components/EvidenceAnalysisPanel";
 import { useQualityScores, useTriggerAnalysis } from "../../../application/hooks/useEvidenceAi";
 import { text as textColors, border as borderPalette } from "../../themes/palette";
 import {
-  loadingContainerStyle,
   paginationMenuProps,
   paginationStyle,
   showingTextCellStyle,
@@ -730,8 +730,8 @@ const EvidenceHubTable: React.FC<EvidenceHubTableProps> = ({
 
   if (isLoading) {
     return (
-      <Stack alignItems="center" justifyContent="center" sx={loadingContainerStyle(theme)}>
-        <Typography>Loading...</Typography>
+      <Stack spacing={2}>
+        <CustomizableSkeleton variant="rectangular" width="100%" height={400} />
       </Stack>
     );
   }

--- a/Clients/src/presentation/pages/ModelInventory/index.tsx
+++ b/Clients/src/presentation/pages/ModelInventory/index.tsx
@@ -2452,7 +2452,7 @@ const ModelInventory: React.FC = () => {
               renderTable={(data, options) => (
                 <EvidenceHubTable
                   key={tableKey}
-                  isLoading={isLoading}
+                  isLoading={isEvidenceLoading}
                   data={data}
                   onEdit={handleEditEvidence}
                   onDelete={handleDeleteEvidence}

--- a/Clients/src/presentation/pages/ModelInventory/modelInventoryTable.tsx
+++ b/Clients/src/presentation/pages/ModelInventory/modelInventoryTable.tsx
@@ -20,6 +20,7 @@ import allowedRoles from "../../../application/constants/permissions";
 import { useAuth } from "../../../application/hooks/useAuth";
 import { Cpu, Layers, BarChart3, Link2 } from "lucide-react";
 import { EmptyState } from "../../components/EmptyState";
+import CustomizableSkeleton from "../../components/Skeletons";
 import EmptyStateTip from "../../components/EmptyState/EmptyStateTip";
 import {
   ModelInventoryTableProps,
@@ -27,7 +28,7 @@ import {
 } from "../../../domain/interfaces/i.modelInventory";
 import { getAllEntities } from "../../../application/repository/entity.repository";
 import { User } from "../../../domain/types/User";
-import { tableRowHoverStyle, tableRowDeletingStyle, loadingContainerStyle } from "./style";
+import { tableRowHoverStyle, tableRowDeletingStyle } from "./style";
 import dayjs from "dayjs";
 import utc from "dayjs/plugin/utc";
 import { displayFormattedDate } from "../../tools/isoDateToString";
@@ -532,8 +533,8 @@ const ModelInventoryTable: React.FC<ModelInventoryTableProps> = ({
 
   if (isLoading) {
     return (
-      <Stack alignItems="center" justifyContent="center" sx={loadingContainerStyle(theme)}>
-        <Typography>Loading...</Typography>
+      <Stack spacing={2}>
+        <CustomizableSkeleton variant="rectangular" width="100%" height={400} />
       </Stack>
     );
   }

--- a/Clients/src/presentation/pages/ModelInventory/modelInventoryTable.tsx
+++ b/Clients/src/presentation/pages/ModelInventory/modelInventoryTable.tsx
@@ -5,7 +5,6 @@ import {
   TableCell,
   TableContainer,
   TableRow,
-  useTheme,
   Stack,
   Typography,
   Tooltip,
@@ -94,7 +93,6 @@ const ModelInventoryTable: React.FC<ModelInventoryTableProps> = ({
   flashRowId,
   visibleColumns,
 }) => {
-  const theme = useTheme();
   const { userRoleName } = useAuth();
   const [users, setUsers] = useState<User[]>([]);
 

--- a/Clients/src/presentation/pages/RiskManagement/index.tsx
+++ b/Clients/src/presentation/pages/RiskManagement/index.tsx
@@ -993,7 +993,9 @@ const RiskManagement = () => {
 
         {/* Table Section */}
         {showCustomizableSkeleton ? (
-          <CustomizableSkeleton />
+          <Stack spacing={1} sx={{ width: "100%" }}>
+            <CustomizableSkeleton variant="rectangular" width="100%" height={400} />
+          </Stack>
         ) : (
           <GroupedTableView
             groupedData={groupedRisks}

--- a/Clients/src/presentation/pages/Tasks/__tests__/Tasks.test.tsx
+++ b/Clients/src/presentation/pages/Tasks/__tests__/Tasks.test.tsx
@@ -157,6 +157,6 @@ describe("Tasks", () => {
 
   it("shows loading state initially", () => {
     renderWithProviders(<Tasks />, { route: "/tasks" });
-    expect(screen.getByText("Loading tasks...")).toBeInTheDocument();
+    expect(document.querySelectorAll(".MuiSkeleton-root").length).toBeGreaterThan(0);
   });
 });

--- a/Clients/src/presentation/pages/Tasks/index.tsx
+++ b/Clients/src/presentation/pages/Tasks/index.tsx
@@ -48,6 +48,7 @@ import { useFilterBy } from "../../../application/hooks/useFilterBy";
 import { useColumnVisibility, ColumnConfig } from "../../../application/hooks/useColumnVisibility";
 import { displayFormattedDate } from "../../tools/isoDateToString";
 import Alert from "../../components/Alert";
+import CustomizableSkeleton from "../../components/Skeletons";
 import TabBar from "../../components/TabBar";
 import DeadlineView from "./DeadlineView";
 import { toggleLabelStyle, toggleContainerStyle } from "./style";
@@ -953,9 +954,9 @@ const Tasks: React.FC = () => {
       {/* Content Area */}
       <Box>
         {isLoading && (
-          <Box sx={{ display: "flex", justifyContent: "center", py: 4 }}>
-            <Typography>Loading tasks...</Typography>
-          </Box>
+          <Stack spacing={2}>
+            <CustomizableSkeleton variant="rectangular" width="100%" height={400} />
+          </Stack>
         )}
 
         {error && (

--- a/Clients/src/presentation/pages/TrainingRegistar/trainingTable.tsx
+++ b/Clients/src/presentation/pages/TrainingRegistar/trainingTable.tsx
@@ -1,20 +1,12 @@
 import React, { useCallback, useMemo } from "react";
-import {
-  Table,
-  TableBody,
-  TableCell,
-  TableContainer,
-  TableRow,
-  useTheme,
-  Stack,
-  Typography,
-} from "@mui/material";
+import { Table, TableBody, TableCell, TableContainer, TableRow, Stack } from "@mui/material";
 import "../../components/Table/index.css";
 import singleTheme from "../../themes/v1SingleTheme";
 import CustomIconButton from "../../components/IconButton";
 import allowedRoles from "../../../application/constants/permissions";
 import { GraduationCap, Users, Calendar, Award } from "lucide-react";
 import { EmptyState } from "../../components/EmptyState";
+import CustomizableSkeleton from "../../components/Skeletons";
 import EmptyStateTip from "../../components/EmptyState/EmptyStateTip";
 import { useAuth } from "../../../application/hooks/useAuth";
 import { TrainingRegistarModel } from "../../../domain/models/Common/trainingRegistar/trainingRegistar.model";
@@ -67,7 +59,6 @@ const TrainingTable: React.FC<TrainingTableProps> = ({
   hidePagination = false,
   visibleColumns,
 }) => {
-  const theme = useTheme();
   const { userRoleName } = useAuth();
 
   const isVisible = useCallback(
@@ -315,17 +306,8 @@ const TrainingTable: React.FC<TrainingTableProps> = ({
 
   if (isLoading) {
     return (
-      <Stack
-        alignItems="center"
-        justifyContent="center"
-        sx={{
-          border: "1px solid #EEEEEE",
-          borderRadius: "4px",
-          padding: theme.spacing(15, 5),
-          minHeight: 200,
-        }}
-      >
-        <Typography>Loading...</Typography>
+      <Stack spacing={2} sx={{ width: "100%" }}>
+        <CustomizableSkeleton variant="rectangular" width="100%" height={400} />
       </Stack>
     );
   }


### PR DESCRIPTION
## Describe your changes

Replace text-based loaders with rectangular skeletons on priority list pages so filters stay visible during load
Pages:
 - Task management
 - Model Inventory
 - Datasets
 - Agent discovery
 - Risk Management
 - AI Training Registry
 - Evidence & documents

## Write your issue number after "Fixes "

Fixes #4058 

## Please ensure all items are checked off before requesting a review:

- [x] I deployed the code locally.
- [x] I have performed a self-review of my code.
- [x] I have included the issue # in the PR.
- [x] I have labelled the PR correctly.
- [x] The issue I am working on is assigned to me.
- [x] I have avoided using hardcoded values to ensure scalability and maintain consistency across the application.
- [x] I have ensured that font sizes, color choices, and other UI elements are referenced from the theme.
- [x] My pull request is focused and addresses a single, specific feature.
- [x] If there are UI changes, I have attached a screenshot or video to this PR.


https://github.com/user-attachments/assets/4036a882-a747-41e0-9f1f-5cf9a734b721

