### PR TITLE
Separate token-refresh rate limit from brute-force limiter

### DIFF
--- a/Clients/src/i18n/translations.ts
+++ b/Clients/src/i18n/translations.ts
@@ -8509,6 +8509,9 @@ export const translations: Record<string, Record<string, string>> = {
     "e.g., Article 9 or A.5.1": "z. B. Article 9 oder A.5.1",
     "e.g., risk_management": "z. B. risk_management",
     "unmapped controls": "nicht zugeordnete Kontrollen",
+    "Too many attempts": "Zu viele Versuche",
+    "Too many requests in a short time. Please wait a moment and refresh the page.":
+      "Zu viele Anfragen in kurzer Zeit. Bitte warten Sie einen Moment und laden Sie die Seite neu.",
   },
 
   fr: {
@@ -16949,6 +16952,9 @@ export const translations: Record<string, Record<string, string>> = {
     "e.g., Article 9 or A.5.1": "p. ex., Article 9 ou A.5.1",
     "e.g., risk_management": "p. ex., risk_management",
     "unmapped controls": "contrôles sans correspondance",
+    "Too many attempts": "Trop de tentatives",
+    "Too many requests in a short time. Please wait a moment and refresh the page.":
+      "Trop de requêtes en peu de temps. Veuillez patienter un instant et actualiser la page.",
   },
   es: {
     "Start here": "Empieza aquí",
@@ -25307,5 +25313,8 @@ export const translations: Record<string, Record<string, string>> = {
     "e.g., Article 9 or A.5.1": "p. ej., Article 9 o A.5.1",
     "e.g., risk_management": "p. ej., risk_management",
     "unmapped controls": "controles sin mapear",
+    "Too many attempts": "Demasiados intentos",
+    "Too many requests in a short time. Please wait a moment and refresh the page.":
+      "Demasiadas solicitudes en poco tiempo. Espera un momento y actualiza la página.",
   },
 };

--- a/Clients/src/infrastructure/api/customAxios.ts
+++ b/Clients/src/infrastructure/api/customAxios.ts
@@ -150,6 +150,22 @@ CustomAxios.interceptors.response.use(
       return Promise.reject(new Error(responseData?.message || "Forbidden"));
     }
 
+    // If the auth/refresh limiter has been tripped (429), stop the retry
+    // cascade and surface a clear message instead of letting calls keep
+    // hammering the refresh endpoint.
+    if (error.response?.status === 429 && originalRequest.url === "/users/refresh-token") {
+      isRefreshing = false;
+      processQueue(error, null);
+      if (showAlertCallback) {
+        showAlertCallback({
+          variant: "warning",
+          title: "Too many attempts",
+          body: "Too many requests in a short time. Please wait a moment and refresh the page.",
+        });
+      }
+      return Promise.reject(error);
+    }
+
     // If error is 406 (Token Expired) and we haven't tried to refresh yet
     if (error.response?.status === 406 && !originalRequest._retry) {
       // If this is the refresh token request itself returning 406

--- a/Servers/middleware/rateLimit.middleware.ts
+++ b/Servers/middleware/rateLimit.middleware.ts
@@ -7,7 +7,13 @@
  * Rate Limiters:
  * - fileOperationsLimiter: 50 requests/15min (for file uploads, downloads, deletions)
  * - generalApiLimiter: 100 requests/15min (for standard API endpoints)
- * - authLimiter: 5 requests/15min (for authentication to prevent brute force)
+ * - authLimiter: 5 requests/15min (for login/register/reset to prevent brute force)
+ * - tokenRefreshLimiter: 60 requests/15min (for automatic access-token refresh)
+ *
+ * The strict auth/refresh limits apply by default. They are relaxed ONLY when
+ * NODE_ENV is an explicit dev/test value, so a single developer hammering
+ * localhost from one IP is not locked out. A missing or unknown NODE_ENV keeps
+ * the strict production limits (fail closed).
  *
  * @module middleware/rateLimit
  */
@@ -15,6 +21,13 @@
 import rateLimit, { Options } from "express-rate-limit";
 import { Request, Response } from "express";
 import logger from "../utils/logger/fileLogger";
+
+// Fail closed: the strict (production) limits apply unless NODE_ENV is
+// EXPLICITLY a known non-production value. A missing or misspelled NODE_ENV in
+// production must NOT silently relax brute-force protection, so anything we
+// don't recognise as dev/test is treated as production.
+const nodeEnv = (process.env.NODE_ENV ?? "").trim().toLowerCase();
+const isNonProduction = nodeEnv === "development" || nodeEnv === "test" || nodeEnv === "local";
 
 /**
  * Rate limit configuration with time window and request limits
@@ -41,8 +54,18 @@ const RATE_LIMIT_CONFIGS: Record<string, RateLimitConfig> = {
   },
   auth: {
     windowMinutes: 15,
-    maxRequests: 5,
+    // Strict by default to prevent brute force; relaxed only in explicit
+    // dev/test so a single developer on one localhost IP is not locked out.
+    maxRequests: isNonProduction ? 1000 : 5,
     message: "Too many authentication attempts from this IP, please try again after 15 minutes",
+  },
+  // Token refresh happens automatically and legitimately many times in a normal
+  // session, so it gets its own generous limit rather than sharing the strict
+  // brute-force limiter. It still requires a valid refresh-token cookie.
+  tokenRefresh: {
+    windowMinutes: 15,
+    maxRequests: isNonProduction ? 1000 : 60,
+    message: "Too many token refresh attempts from this IP, please try again after 15 minutes",
   },
   aiDetectionScan: {
     windowMinutes: 60,
@@ -94,10 +117,17 @@ export const fileOperationsLimiter = createRateLimiter(RATE_LIMIT_CONFIGS.fileOp
 export const generalApiLimiter = createRateLimiter(RATE_LIMIT_CONFIGS.generalApi);
 
 /**
- * Strict rate limiter for authentication endpoints
+ * Strict rate limiter for authentication endpoints (login, register, reset)
  * Very restrictive to prevent brute force attacks
  */
 export const authLimiter = createRateLimiter(RATE_LIMIT_CONFIGS.auth);
+
+/**
+ * Rate limiter for the automatic access-token refresh endpoint
+ * More generous than authLimiter because refresh is a routine, non-credential
+ * operation that happens repeatedly during a normal session
+ */
+export const tokenRefreshLimiter = createRateLimiter(RATE_LIMIT_CONFIGS.tokenRefresh);
 
 /**
  * Rate limiter for AI Detection scan operations

--- a/Servers/routes/__tests__/integration/user.route.test.ts
+++ b/Servers/routes/__tests__/integration/user.route.test.ts
@@ -38,6 +38,7 @@ jest.mock("../../../middleware/selfOnly.middleware", () => ({
 
 jest.mock("../../../middleware/rateLimit.middleware", () => ({
   authLimiter: jest.fn((_req: any, _res: any, next: any) => next()),
+  tokenRefreshLimiter: jest.fn((_req: any, _res: any, next: any) => next()),
 }));
 
 jest.mock("express-rate-limit", () =>

--- a/Servers/routes/user.route.ts
+++ b/Servers/routes/user.route.ts
@@ -33,7 +33,7 @@ const multer = require("multer");
 const upload = multer({ storage: multer.memoryStorage() });
 
 import rateLimit from "express-rate-limit";
-import { authLimiter } from "../middleware/rateLimit.middleware";
+import { authLimiter, tokenRefreshLimiter } from "../middleware/rateLimit.middleware";
 
 import {
   checkUserExists,
@@ -134,7 +134,7 @@ const loginLimiter = rateLimit({
 router.post("/login", loginLimiter, loginUser);
 router.post("/login-microsoft", loginLimiter, loginUserWithMicrosoft);
 
-router.post("/refresh-token", authLimiter, refreshAccessToken);
+router.post("/refresh-token", tokenRefreshLimiter, refreshAccessToken);
 
 /**
  * POST /users/reset-password


### PR DESCRIPTION
## Problem

The `/refresh-token` endpoint shared the strict `authLimiter` (5 requests / 15 min) with login, register and password reset. Token refresh happens automatically and repeatedly during a normal session, so a user whose access token expired could exhaust the 5-request budget and get locked out for 15 minutes. Every authenticated call then returned 406 (token expired), the frontend kept retrying refresh, and the dashboard rendered empty until the window reset.

## Changes

- Add a dedicated `tokenRefreshLimiter` (60 requests / 15 min in production) for `/refresh-token`, instead of the strict `authLimiter`. Refresh requires a valid signed refresh-token cookie, so it is not a credential-guessing vector.
- Make the auth and refresh limits environment-aware, relaxed only when `NODE_ENV` is an explicit dev/test value. The check fails closed: a missing or unknown `NODE_ENV` keeps the strict production limits, so brute-force protection on register and reset-password is never silently disabled.
- Frontend: when `/refresh-token` returns 429, stop the retry cascade and show a clear 'too many attempts' message instead of hammering the endpoint.
- Update the user.route integration test mock to include `tokenRefreshLimiter` (the new import would otherwise leave it undefined and break route registration).

## Review notes

A multi-agent review surfaced and this PR fixes: (1) the broken test mock, and (2) a fail-open env default that could have disabled brute-force protection in production. One pre-existing item is left as a follow-up: queued requests in the single-flight refresh path in `customAxios.ts` are re-issued without setting `_retry`, so a second-round 406 can re-enter the refresh logic.

## Verification

- `cd Servers && npm run build` and `cd Clients && npm run build` pass
- `npm run format-check` clean on both
- `user.route` and `rateLimit` test suites pass (6/6 each)