### PR TITLE
Guard null date_format on the preferences page

### DIFF
--- a/Clients/src/presentation/pages/SettingsPage/Preferences/index.tsx
+++ b/Clients/src/presentation/pages/SettingsPage/Preferences/index.tsx
@@ -60,7 +60,9 @@ const Preferences: React.FC = () => {
 
   useEffect(() => {
     if (userPreferences) {
-      setDateFormat(userPreferences.date_format);
+      // Guard against a null/undefined date_format from the server so the
+      // Select stays controlled (avoids the controlled->uncontrolled warning).
+      setDateFormat(userPreferences.date_format ?? UserDateFormat.DD_MM_YYYY_DASH);
       const serverLang = (userPreferences.language ?? "en") as Lang;
       setLang(serverLang);
       // Server is the source of truth — apply it locally if it differs.


### PR DESCRIPTION
## Problem

On Settings → Preferences, the date-format `Select` set its `value` directly from `userPreferences.date_format`. When the server returns a preferences row with a null `date_format`, the Select received `value={null}`, and React warned that a controlled input was changing to uncontrolled.

## Fix

Fall back to the default format (`DD_MM_YYYY_DASH`) when `date_format` is null/undefined, matching how `language` already falls back to `en` on the same page.

## Notes

Pre-existing issue, surfaced while testing the settings page locally. One-line change.