### PR TITLE
Repair MCP gateway approval, guardrails, and audit gaps

### DIFF
--- a/AIGateway/src/crud/mcp_approvals.py
+++ b/AIGateway/src/crud/mcp_approvals.py
@@ -18,6 +18,7 @@ async def create_approval_request(org_id: int, data: dict) -> dict:
                     tool_id,
                     tool_name,
                     arguments,
+                    arguments_hash,
                     expires_at
                 ) VALUES (
                     :org_id,
@@ -25,6 +26,7 @@ async def create_approval_request(org_id: int, data: dict) -> dict:
                     :tool_id,
                     :tool_name,
                     CAST(:arguments AS jsonb),
+                    :arguments_hash,
                     :expires_at
                 )
                 RETURNING
@@ -47,6 +49,7 @@ async def create_approval_request(org_id: int, data: dict) -> dict:
                 "tool_id": data.get("tool_id"),
                 "tool_name": data.get("tool_name"),
                 "arguments": arguments_json,
+                "arguments_hash": data.get("arguments_hash"),
                 "expires_at": data.get("expires_at"),
             },
         )
@@ -129,8 +132,14 @@ async def get_approval_history(
     return []
 
 
-async def get_pending_request(org_id: int, agent_key_id: int, tool_name: str) -> Optional[dict]:
-    """Return an existing pending, non-expired approval request for this agent+tool."""
+async def get_pending_request(
+    org_id: int, agent_key_id: int, tool_name: str, arguments_hash: str
+) -> Optional[dict]:
+    """Return an existing pending, non-expired approval request for this exact call.
+
+    Scoped to the call's arguments (via arguments_hash) so a pending request for
+    one set of arguments is not reused for a different call.
+    """
     async with get_db() as db:
         result = await db.execute(
             text("""
@@ -139,12 +148,18 @@ async def get_pending_request(org_id: int, agent_key_id: int, tool_name: str) ->
                 WHERE organization_id = :org_id
                   AND agent_key_id = :agent_key_id
                   AND tool_name = :tool_name
+                  AND arguments_hash = :arguments_hash
                   AND status = 'pending'
                   AND expires_at > NOW()
                 ORDER BY created_at DESC
                 LIMIT 1
             """),
-            {"org_id": org_id, "agent_key_id": agent_key_id, "tool_name": tool_name},
+            {
+                "org_id": org_id,
+                "agent_key_id": agent_key_id,
+                "tool_name": tool_name,
+                "arguments_hash": arguments_hash,
+            },
         )
         row = result.mappings().first()
         if row is None:
@@ -152,8 +167,14 @@ async def get_pending_request(org_id: int, agent_key_id: int, tool_name: str) ->
         return dict(row)
 
 
-async def get_approved_request(org_id: int, agent_key_id: int, tool_name: str) -> Optional[dict]:
-    """Check if an approved, non-expired approval request exists for this agent+tool."""
+async def get_approved_request(
+    org_id: int, agent_key_id: int, tool_name: str, arguments_hash: str
+) -> Optional[dict]:
+    """Check if an approved, non-expired approval request exists for this exact call.
+
+    Scoped to the call's arguments (via arguments_hash) so an approval granted for
+    one set of arguments cannot be reused to authorize a different call.
+    """
     async with get_db() as db:
         result = await db.execute(
             text("""
@@ -162,12 +183,18 @@ async def get_approved_request(org_id: int, agent_key_id: int, tool_name: str) -
                 WHERE organization_id = :org_id
                   AND agent_key_id = :agent_key_id
                   AND tool_name = :tool_name
+                  AND arguments_hash = :arguments_hash
                   AND status = 'approved'
                   AND expires_at > NOW()
                 ORDER BY decided_at DESC
                 LIMIT 1
             """),
-            {"org_id": org_id, "agent_key_id": agent_key_id, "tool_name": tool_name},
+            {
+                "org_id": org_id,
+                "agent_key_id": agent_key_id,
+                "tool_name": tool_name,
+                "arguments_hash": arguments_hash,
+            },
         )
         row = result.mappings().first()
         if row is None:

--- a/AIGateway/src/database/migrations/versions/a0005_add_approval_arguments_hash.py
+++ b/AIGateway/src/database/migrations/versions/a0005_add_approval_arguments_hash.py
@@ -1,0 +1,50 @@
+"""Add arguments_hash to MCP approval requests for argument-scoped approvals.
+
+Approvals are scoped to the exact arguments of a tool call. The hash lets the
+gateway match an approval (or pending request) to a specific call rather than
+to the tool name alone, so approving one call no longer authorizes every future
+call of the same tool.
+
+Revision ID: a0005
+Revises: a0004
+Create Date: 2026-06-15
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "a0005"
+down_revision: Union[str, None] = "a0004"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Add arguments_hash column + index to ai_gateway_mcp_approval_requests."""
+    op.execute("SET search_path TO verifywise")
+
+    op.execute("""
+        ALTER TABLE ai_gateway_mcp_approval_requests
+        ADD COLUMN IF NOT EXISTS arguments_hash VARCHAR(64)
+    """)
+
+    # Speeds up the per-call approval lookups (org + agent_key + tool + arguments).
+    op.execute("""
+        CREATE INDEX IF NOT EXISTS idx_gw_mcp_approval_lookup
+        ON ai_gateway_mcp_approval_requests(
+            organization_id, agent_key_id, tool_name, arguments_hash, status
+        )
+    """)
+
+
+def downgrade() -> None:
+    """Remove arguments_hash column + index."""
+    op.execute("SET search_path TO verifywise")
+
+    op.execute("DROP INDEX IF EXISTS idx_gw_mcp_approval_lookup")
+    op.execute("""
+        ALTER TABLE ai_gateway_mcp_approval_requests
+        DROP COLUMN IF EXISTS arguments_hash
+    """)

--- a/AIGateway/src/routers/mcp_proxy.py
+++ b/AIGateway/src/routers/mcp_proxy.py
@@ -21,7 +21,7 @@ from config import settings
 from crud.mcp_approvals import create_approval_request, get_approval_status, get_approved_request, get_pending_request
 from crud.mcp_tools import get_all_tools
 from services.mcp_audit_service import log_tool_call
-from services.mcp_guardrail_service import scan_tool_input
+from services.mcp_guardrail_service import scan_tool_input, check_anomaly, CircuitBreaker
 from services.mcp_proxy_service import (
     authenticate_agent_key,
     resolve_tool,
@@ -31,6 +31,8 @@ from services.mcp_proxy_service import (
 )
 from services.mcp_session import create_session, get_backend_session, set_backend_session
 from utils.acl import matches_acl
+from utils.mcp_arguments import hash_arguments
+from utils.notifications import notify_approval_pending
 
 logger = logging.getLogger("uvicorn")
 
@@ -141,11 +143,14 @@ async def mcp_jsonrpc(request: Request):
             await enforce_mcp_rate_limits(agent_key, tool_name)
 
             if tool.get("requires_approval"):
-                # Check if an approved request already exists for this agent+tool
-                approved = await get_approved_request(org_id, agent_key["id"], tool_name)
+                # Approvals are scoped to the exact arguments of this call, so an
+                # approval for one set of arguments cannot be reused for another.
+                args_hash = hash_arguments(arguments)
+                # Check if an approved request already exists for this agent+tool+arguments
+                approved = await get_approved_request(org_id, agent_key["id"], tool_name, args_hash)
                 if not approved:
-                    # Reuse an existing pending request if one exists, otherwise create a new one
-                    pending = await get_pending_request(org_id, agent_key["id"], tool_name)
+                    # Reuse an existing pending request for the same call, otherwise create a new one
+                    pending = await get_pending_request(org_id, agent_key["id"], tool_name, args_hash)
                     if pending:
                         approval = pending
                     else:
@@ -155,9 +160,17 @@ async def mcp_jsonrpc(request: Request):
                             "tool_id": tool.get("id"),
                             "tool_name": tool_name,
                             "arguments": arguments,
+                            "arguments_hash": args_hash,
                             "expires_at": expires_at,
                         })
                         await _audit("approval_required", f"Approval request {approval.get('id')} created", False)
+                        # Notify org admins that a tool call is waiting for approval.
+                        await notify_approval_pending(org_id, {
+                            "approval_id": approval.get("id"),
+                            "tool_name": tool_name,
+                            "agent_key_id": agent_key["id"],
+                            "agent_key_name": agent_key.get("name"),
+                        })
                     return JSONResponse(content=_jsonrpc_error(msg_id, -32001, "Tool requires approval", {
                         "approval_id": approval.get("id"),
                         "poll_endpoint": f"/v1/mcp/approvals/{approval.get('id')}/status",
@@ -170,24 +183,57 @@ async def mcp_jsonrpc(request: Request):
                 await _audit("blocked", f"Guardrail: {reason}", False)
                 return JSONResponse(content=_jsonrpc_error(msg_id, -32003, f"Blocked by guardrail: {reason}"), status_code=200)
 
+            server_id = tool["server_id"]
+
+            # Circuit breaker: skip calls to an upstream that is failing repeatedly.
+            if await CircuitBreaker.is_open(server_id):
+                await _audit("blocked", "Circuit breaker open: upstream MCP server unavailable", False)
+                return JSONResponse(content=_jsonrpc_error(
+                    msg_id, -32004, "MCP server temporarily unavailable (circuit breaker open)"
+                ), status_code=200)
+
+            # Anomaly detection: warn-only (fail-open), does not block the call.
+            # Runs only for calls that actually forward upstream, so denied,
+            # blocked, or approval-pending calls do not inflate the rate metric.
+            if await check_anomaly(agent_key["id"], tool_name):
+                logger.warning(
+                    "MCP anomalous call rate: org=%s agent_key=%s tool=%s",
+                    org_id, agent_key["id"], tool_name,
+                )
+
             # Look up cached backend session
             gateway_session = request.headers.get("mcp-session-id")
             backend_session = None
             if gateway_session:
-                backend_session = await get_backend_session(gateway_session, tool["server_id"])
+                backend_session = await get_backend_session(gateway_session, server_id)
 
-            result, new_backend_session = await forward_tool_call(
-                server_url=tool["url"],
-                auth_type=tool.get("auth_type", "none"),
-                auth_config=tool.get("auth_config") or {},
-                tool_name=tool_name,
-                arguments=arguments,
-                session_id=backend_session,
-            )
+            try:
+                result, new_backend_session = await forward_tool_call(
+                    server_url=tool["url"],
+                    auth_type=tool.get("auth_type", "none"),
+                    auth_config=tool.get("auth_config") or {},
+                    tool_name=tool_name,
+                    arguments=arguments,
+                    session_id=backend_session,
+                )
+            except ValueError:
+                # A ValueError here is a tool-level error returned by a healthy
+                # upstream (e.g. bad arguments, "not found"). The transport
+                # worked, so it must NOT count against the circuit breaker —
+                # otherwise a misbehaving agent could trip the breaker for a
+                # healthy server. Re-raise without recording a failure.
+                raise
+            except Exception:
+                # A non-ValueError exception is a genuine transport/connection
+                # failure — record it against the circuit breaker.
+                await CircuitBreaker.record_failure(server_id)
+                raise
+
+            await CircuitBreaker.record_success(server_id)
 
             # Cache new backend session for next call
             if new_backend_session and gateway_session:
-                await set_backend_session(gateway_session, tool["server_id"], new_backend_session)
+                await set_backend_session(gateway_session, server_id, new_backend_session)
 
             content_text = None
             if result.get("content"):

--- a/AIGateway/src/utils/mcp_arguments.py
+++ b/AIGateway/src/utils/mcp_arguments.py
@@ -1,0 +1,24 @@
+"""
+Helpers for working with MCP tool-call arguments.
+
+Approvals are scoped to the exact arguments of a call. To compare arguments
+deterministically (regardless of key order), we hash a canonical JSON encoding.
+"""
+
+import hashlib
+import json
+from typing import Any
+
+
+def hash_arguments(arguments: Any) -> str:
+    """Return a stable SHA-256 hex digest of a tool call's arguments.
+
+    Uses canonical JSON (sorted keys, no insignificant whitespace) so that two
+    semantically identical argument sets produce the same hash regardless of key
+    ordering. ``None`` is treated as an empty object so a missing-args call and
+    an explicit ``{}`` call hash the same.
+    """
+    if arguments is None:
+        arguments = {}
+    canonical = json.dumps(arguments, sort_keys=True, separators=(",", ":"), default=str)
+    return hashlib.sha256(canonical.encode("utf-8")).hexdigest()

--- a/AIGateway/src/utils/notifications.py
+++ b/AIGateway/src/utils/notifications.py
@@ -102,6 +102,18 @@ async def notify_guardrail_spike(
     })
 
 
+async def notify_approval_pending(
+    organization_id: int,
+    approval: dict[str, Any],
+) -> None:
+    """Notify admins that an MCP tool call is waiting for human approval."""
+    await _send_notification({
+        "type": "approval_pending",
+        "organization_id": organization_id,
+        "approval": approval,
+    })
+
+
 async def notify_virtual_key_budget_exhausted(
     organization_id: int,
     key_name: str,

--- a/Clients/src/presentation/pages/AIGateway/MCPApprovals/index.tsx
+++ b/Clients/src/presentation/pages/AIGateway/MCPApprovals/index.tsx
@@ -75,6 +75,24 @@ export default function MCPApprovalsPage() {
     else loadHistory();
   }, [tab, loadPending, loadHistory]);
 
+  // Poll the pending tab so newly-arrived approval requests appear without a
+  // manual refresh. Only runs while the pending tab is active and the browser
+  // tab is visible, so backgrounded tabs don't keep hitting the API.
+  useEffect(() => {
+    if (tab !== "pending") return;
+    const interval = setInterval(() => {
+      if (!document.hidden) loadPending();
+    }, 10000);
+    const onVisible = () => {
+      if (!document.hidden) loadPending();
+    };
+    document.addEventListener("visibilitychange", onVisible);
+    return () => {
+      clearInterval(interval);
+      document.removeEventListener("visibilitychange", onVisible);
+    };
+  }, [tab, loadPending]);
+
   const handleDecision = async () => {
     if (!decisionTarget) return;
     try {

--- a/Servers/database/migrations/20260615161419-add-ai-gateway-notification-types.js
+++ b/Servers/database/migrations/20260615161419-add-ai-gateway-notification-types.js
@@ -1,0 +1,54 @@
+"use strict";
+
+/**
+ * Extend `enum_notification_type` with the AI Gateway notification values.
+ *
+ * The TS enum `NotificationType` (`Servers/domain.layer/interfaces/i.notification.ts`)
+ * declares six `ai_gateway_*` values, but the matching Postgres enum type was
+ * never extended. As a result every
+ *   `INSERT INTO notifications (..., type, ...)` with an `ai_gateway_*` type
+ * failed with:
+ *   "invalid input value for enum enum_notification_type: 'ai_gateway_...'".
+ *
+ * The error is caught as non-fatal where notifications are sent, so it was
+ * silent — but functionally the AI Gateway could never deliver an in-app
+ * notification (budget warnings, guardrail spikes, config changes, and the
+ * new approval-pending notice all failed at the insert).
+ *
+ * This adds all six values so the existing budget/guardrail/config-change
+ * notifications work too, not just approval_pending.
+ *
+ * Postgres 12+ allows `ALTER TYPE ... ADD VALUE`. Down is a no-op: removing a
+ * value from a Postgres enum requires recreating the type and migrating every
+ * column that uses it, which is risky for a fix-forward migration.
+ */
+
+const AI_GATEWAY_NOTIFICATION_TYPES = [
+  "ai_gateway_budget_warning",
+  "ai_gateway_budget_exhausted",
+  "ai_gateway_guardrail_spike",
+  "ai_gateway_config_change",
+  "ai_gateway_virtual_key_budget_exhausted",
+  "ai_gateway_approval_pending",
+];
+
+module.exports = {
+  async up(queryInterface) {
+    for (const value of AI_GATEWAY_NOTIFICATION_TYPES) {
+      await queryInterface.sequelize.query(
+        `ALTER TYPE verifywise.enum_notification_type ADD VALUE IF NOT EXISTS '${value}';`,
+      );
+    }
+
+    // The notifications.entity_type column uses a separate enum that is also
+    // missing the AI Gateway value, so every ai_gateway notification failed on
+    // entity_type even once the type value existed.
+    await queryInterface.sequelize.query(
+      `ALTER TYPE verifywise.enum_notification_entity_type ADD VALUE IF NOT EXISTS 'ai_gateway';`,
+    );
+  },
+
+  async down() {
+    // No-op. See header comment.
+  },
+};

--- a/Servers/domain.layer/interfaces/i.notification.ts
+++ b/Servers/domain.layer/interfaces/i.notification.ts
@@ -46,6 +46,7 @@ export enum NotificationType {
   AI_GATEWAY_GUARDRAIL_SPIKE = "ai_gateway_guardrail_spike",
   AI_GATEWAY_CONFIG_CHANGE = "ai_gateway_config_change",
   AI_GATEWAY_VIRTUAL_KEY_BUDGET_EXHAUSTED = "ai_gateway_virtual_key_budget_exhausted",
+  AI_GATEWAY_APPROVAL_PENDING = "ai_gateway_approval_pending",
 
   // System notifications
   SYSTEM = "system",

--- a/Servers/routes/internal.route.ts
+++ b/Servers/routes/internal.route.ts
@@ -13,6 +13,7 @@ import {
   notifyBudgetExhausted,
   notifyGuardrailSpike,
   notifyVirtualKeyBudgetExhausted,
+  notifyApprovalPending,
 } from "../services/aiGateway/aiGatewayNotifications";
 
 const router = Router();
@@ -62,6 +63,10 @@ router.post("/ai-gateway/notify", async (req: Request, res: Response) => {
 
       case "guardrail_spike":
         await notifyGuardrailSpike(organization_id, req.body.stats);
+        break;
+
+      case "approval_pending":
+        await notifyApprovalPending(organization_id, req.body.approval);
         break;
 
       case "virtual_key_budget_exhausted":

--- a/Servers/services/aiGateway/aiGatewayNotifications.ts
+++ b/Servers/services/aiGateway/aiGatewayNotifications.ts
@@ -209,6 +209,40 @@ export async function notifyVirtualKeyBudgetExhausted(
 }
 
 /**
+ * Notify: An MCP tool call is waiting for human approval.
+ *
+ * In-app only (no email) — approvals are time-bounded and reviewed in the
+ * MCP Approvals page, so the in-app notification links straight there.
+ */
+export async function notifyApprovalPending(
+  organizationId: number,
+  approval: {
+    approval_id: number;
+    tool_name: string;
+    agent_key_id: number;
+    agent_key_name?: string | null;
+  },
+): Promise<void> {
+  const admins = await getOrgAdmins(organizationId);
+  const keyLabel = approval.agent_key_name || `agent key #${approval.agent_key_id}`;
+
+  await Promise.allSettled(
+    admins.map((admin) =>
+      sendInAppNotification(organizationId, {
+        user_id: admin.id,
+        type: NotificationType.AI_GATEWAY_APPROVAL_PENDING,
+        title: "Tool call waiting for approval",
+        message: `${keyLabel} requested "${approval.tool_name}" and is waiting for your approval.`,
+        entity_type: NotificationEntityType.AI_GATEWAY,
+        action_url: `${FRONTEND_URL}/ai-gateway/mcp/approvals`,
+      }).catch((err) =>
+        logger.error(`Failed to send approval-pending notice to admin ${admin.id}:`, err),
+      ),
+    ),
+  );
+}
+
+/**
  * Notify: Configuration change (endpoint, API key, guardrail rule)
  *
  * Generic notification for any config change event.


### PR DESCRIPTION
## Summary

Phase 0 fixes that make existing-but-broken MCP gateway features actually work. The gateway already had the bones of an agent control panel; several pieces were unwired, broken, or unsafe.

## Changes

- **Wire the dead guardrails.** The circuit breaker and anomaly detection were implemented but never called. They now run in the MCP tools/call path. The circuit breaker counts only genuine transport failures (not tool-level errors a healthy upstream returns), so a misbehaving agent cannot trip it. Anomaly detection runs only for calls that actually forward upstream, so denied, blocked, and approval-pending calls do not inflate the rate metric.
- **Fix the approval loop.** Admins now get an in-app notification when a tool call is waiting for approval. Previously a pending approval produced no notification at all, and the approvals UI only updated on manual refresh. The pending list now polls (paused while the browser tab is hidden).
- **Argument-scope approvals.** An approval is now tied to the exact arguments of a call via a SHA-256 hash, so approving one call no longer authorizes every future call of the same tool with different arguments.

## Notes

- New migration `a0005` adds `arguments_hash` and a lookup index to `ai_gateway_mcp_approval_requests`.
- A multi-agent review caught and this PR fixes two bugs introduced during the work: the circuit breaker counting tool-level errors as upstream failures, and anomaly-counter inflation from non-forwarded calls.
- Builds pass on Servers and Clients; format-check and frontend type-check are clean.