### PR TITLE
feat(ai-gateway): rename MCP Gateway section to Agent Control

### DIFF
--- a/Clients/src/i18n/translations.ts
+++ b/Clients/src/i18n/translations.ts
@@ -1900,11 +1900,8 @@ export const translations: Record<string, Record<string, string>> = {
     "Masked": "Maskiert",
     "Masked preview:": "Maskierte Vorschau:",
     "Match type": "Abgleichstyp",
-    "MCP Approvals": "MCP-Genehmigungen",
-    "MCP Audit Log": "MCP-Prüfprotokoll",
-    "MCP Guardrails": "MCP-Guardrails",
     "MCP Servers": "MCP-Server",
-    "MCP Tool Catalog": "MCP-Tool-Katalog",
+    "MCP Tools": "MCP-Tools",
     "Medium confidence": "Mittlere Konfidenz",
     "Messages": "Nachrichten",
     "Minimum risk score": "Minimale Risikobewertung",
@@ -2460,8 +2457,8 @@ export const translations: Record<string, Record<string, string>> = {
     "Configure API keys first": "Zuerst API-Schlüssel konfigurieren",
     "Configure endpoints to start tracking":
       "Endpunkte konfigurieren, um mit der Verfolgung zu beginnen",
-    "Configure guardrail rules for MCP tool invocations.":
-      "Guardrail-Regeln für MCP-Tool-Aufrufe konfigurieren.",
+    "Scan agent tool calls for PII, prohibited content, or prompt injection — block or mask matches.":
+      "Durchsuchen Sie Agent-Tool-Aufrufe nach PII, unzulässigen Inhalten oder Prompt-Injection — Treffer blockieren oder maskieren.",
     "Configure integrations and tokens for AI detection scanning.":
       "Integrationen und Token für KI-Erkennungsscans konfigurieren.",
     "Configure LLM provider API keys for running evaluations across your organization":
@@ -2742,13 +2739,13 @@ export const translations: Record<string, Record<string, string>> = {
     "Review and edit the AI-suggested risk before saving.":
       "Prüfen und bearbeiten Sie das von der KI vorgeschlagene Risiko vor dem Speichern.",
     "Review and manage approval requests": "Genehmigungsanfragen prüfen und verwalten",
-    "Review and manage tool invocation approval requests.":
-      "Anfragen zur Genehmigung von Tool-Aufrufen prüfen und verwalten.",
+    "Review and decide on agent tool calls that require human approval before they run.":
+      "Agent-Tool-Aufrufe prüfen und entscheiden, die vor der Ausführung eine menschliche Genehmigung erfordern.",
     "Review and rank": "Prüfen und einstufen",
     "Review the overall assessment and record the deployment decision.":
       "Die Gesamtbewertung prüfen und die Bereitstellungsentscheidung erfassen.",
-    "Review tool invocation history and audit trail.":
-      "Verlauf und Prüfpfad der Tool-Aufrufe prüfen.",
+    "Every tool call your AI agents make, with outcome, latency, and which agent.":
+      "Jeder Tool-Aufruf Ihrer KI-Agenten, mit Ergebnis, Latenz und ausführendem Agenten.",
     "Route alerts to security teams, managers, or compliance officers. Each rule can have different notification recipients.":
       "Benachrichtigungen an Sicherheitsteams, Manager oder Compliance-Beauftragte weiterleiten. Jede Regel kann unterschiedliche Empfänger haben.",
     "Run a test request through the gateway to complete setup":
@@ -3028,8 +3025,8 @@ export const translations: Record<string, Record<string, string>> = {
     "Model / system version": "Modell- / Systemversion",
     "Model/system version": "Modell-/Systemversion",
     "Neutral / Inactive": "Neutral / Inaktiv",
-    "No MCP guardrail rules configured yet. Add rules to scan tool inputs for PII, prohibited content, or prompt injection attempts.":
-      "Noch keine MCP-Guardrail-Regeln konfiguriert. Fügen Sie Regeln hinzu, um Tool-Eingaben auf PII, verbotene Inhalte oder Prompt-Injection-Versuche zu prüfen.",
+    "No guardrail rules configured yet. Add rules to scan agent tool calls for PII, prohibited content, or prompt injection attempts.":
+      "Noch keine Guardrail-Regeln konfiguriert. Fügen Sie Regeln hinzu, um Agent-Tool-Aufrufe auf PII, verbotene Inhalte oder Prompt-Injection-Versuche zu prüfen.",
     "No Organizational Project Found. Create a new organizational project to manage ISO 27001, ISO 42001, and NIST AI RMF frameworks for your organization.":
       "Kein Organisationsprojekt gefunden. Erstellen Sie ein neues Organisationsprojekt, um die Rahmenwerke ISO 27001, ISO 42001 und NIST AI RMF für Ihre Organisation zu verwalten.",
     "Note whether the dataset has been reviewed for bias, completeness, and accuracy. Track any known quality issues or limitations.":
@@ -3891,7 +3888,7 @@ export const translations: Record<string, Record<string, string>> = {
 
     // AI Gateway sidebar — flat items and MCP group
     "Playground": "Playground",
-    "MCP Gateway": "MCP-Gateway",
+    "Agent Control": "Agentensteuerung",
     "Agent Keys": "Agentenschlüssel",
     "Servers": "Server",
     "Tools": "Tools",
@@ -9158,7 +9155,7 @@ export const translations: Record<string, Record<string, string>> = {
     "Playground": "Playground",
     "Prompts": "Prompts",
     "Logs": "Journaux",
-    "MCP Gateway": "Passerelle MCP",
+    "Agent Control": "Contrôle des agents",
     "Agent Keys": "Clés d'agent",
     "Servers": "Serveurs",
     "Tools": "Outils",
@@ -10489,11 +10486,8 @@ export const translations: Record<string, Record<string, string>> = {
     "Masked": "Masqué",
     "Masked preview:": "Aperçu masqué :",
     "Match type": "Type de correspondance",
-    "MCP Approvals": "Approbations MCP",
-    "MCP Audit Log": "Journal d'audit MCP",
-    "MCP Guardrails": "Garde-fous MCP",
     "MCP Servers": "Serveurs MCP",
-    "MCP Tool Catalog": "Catalogue d'outils MCP",
+    "MCP Tools": "Outils MCP",
     "Medium confidence": "Confiance moyenne",
     "Messages": "Messages",
     "Minimum risk score": "Score de risque minimum",
@@ -11043,8 +11037,8 @@ export const translations: Record<string, Record<string, string>> = {
     "Configure API keys first": "Configurez d'abord les clés API",
     "Configure endpoints to start tracking":
       "Configurez des points de terminaison pour commencer le suivi",
-    "Configure guardrail rules for MCP tool invocations.":
-      "Configurer les règles de garde-fous pour les invocations d'outils MCP.",
+    "Scan agent tool calls for PII, prohibited content, or prompt injection — block or mask matches.":
+      "Analysez les appels d'outils des agents à la recherche de données personnelles, de contenu interdit ou d'injection de prompt — bloquez ou masquez les correspondances.",
     "Configure integrations and tokens for AI detection scanning.":
       "Configurer les intégrations et les jetons pour l'analyse de détection IA.",
     "Configure LLM provider API keys for running evaluations across your organization":
@@ -11329,13 +11323,13 @@ export const translations: Record<string, Record<string, string>> = {
     "Review and edit the AI-suggested risk before saving.":
       "Examinez et modifiez le risque suggéré par l'IA avant d'enregistrer.",
     "Review and manage approval requests": "Examiner et gérer les demandes d'approbation",
-    "Review and manage tool invocation approval requests.":
-      "Examiner et gérer les demandes d'approbation d'invocation d'outils.",
+    "Review and decide on agent tool calls that require human approval before they run.":
+      "Examinez et décidez des appels d'outils d'agents qui nécessitent une approbation humaine avant leur exécution.",
     "Review and rank": "Examiner et classer",
     "Review the overall assessment and record the deployment decision.":
       "Examinez l'évaluation globale et enregistrez la décision de déploiement.",
-    "Review tool invocation history and audit trail.":
-      "Examinez l'historique d'invocation des outils et la piste d'audit.",
+    "Every tool call your AI agents make, with outcome, latency, and which agent.":
+      "Chaque appel d'outil effectué par vos agents IA, avec le résultat, la latence et l'agent concerné.",
     "Route alerts to security teams, managers, or compliance officers. Each rule can have different notification recipients.":
       "Acheminez les alertes vers les équipes de sécurité, les managers ou les responsables de la conformité. Chaque règle peut avoir des destinataires de notification différents.",
     "Run a test request through the gateway to complete setup":
@@ -11616,8 +11610,8 @@ export const translations: Record<string, Record<string, string>> = {
     "Model / system version": "Version du modèle / système",
     "Model/system version": "Version du modèle/système",
     "Neutral / Inactive": "Neutre / Inactif",
-    "No MCP guardrail rules configured yet. Add rules to scan tool inputs for PII, prohibited content, or prompt injection attempts.":
-      "Aucune règle de garde-fou MCP configurée pour le moment. Ajoutez des règles pour analyser les entrées d'outils à la recherche de données personnelles, de contenu interdit ou de tentatives d'injection de prompt.",
+    "No guardrail rules configured yet. Add rules to scan agent tool calls for PII, prohibited content, or prompt injection attempts.":
+      "Aucune règle de garde-fou configurée pour le moment. Ajoutez des règles pour analyser les appels d'outils des agents à la recherche de données personnelles, de contenu interdit ou de tentatives d'injection de prompt.",
     "No Organizational Project Found. Create a new organizational project to manage ISO 27001, ISO 42001, and NIST AI RMF frameworks for your organization.":
       "Aucun projet organisationnel trouvé. Créez un nouveau projet organisationnel pour gérer les référentiels ISO 27001, ISO 42001 et NIST AI RMF de votre organisation.",
     "Note whether the dataset has been reviewed for bias, completeness, and accuracy. Track any known quality issues or limitations.":
@@ -18345,11 +18339,8 @@ export const translations: Record<string, Record<string, string>> = {
     "Masked": "Enmascarado",
     "Masked preview:": "Vista previa enmascarada:",
     "Match type": "Tipo de coincidencia",
-    "MCP Approvals": "Aprobaciones de MCP",
-    "MCP Audit Log": "Registro de auditoría de MCP",
-    "MCP Guardrails": "Barreras de protección de MCP",
     "MCP Servers": "Servidores MCP",
-    "MCP Tool Catalog": "Catálogo de herramientas MCP",
+    "MCP Tools": "Herramientas MCP",
     "Medium confidence": "Confianza media",
     "Messages": "Mensajes",
     "Minimum risk score": "Puntuación de riesgo mínima",
@@ -19321,7 +19312,7 @@ export const translations: Record<string, Record<string, string>> = {
     "No API keys configured": "No hay claves de API configuradas",
     "before you can create an endpoint.": "antes de poder crear un endpoint.",
     "Playground": "Playground",
-    "MCP Gateway": "MCP Gateway",
+    "Agent Control": "Control de agentes",
     "Agent Keys": "Claves de agente",
     "Servers": "Servidores",
     "Tools": "Herramientas",
@@ -21990,8 +21981,8 @@ export const translations: Record<string, Record<string, string>> = {
     "Configure a local model provider. No API key required.":
       "Configure un proveedor de modelos local. No se requiere clave de API.",
     "Configure endpoints to start tracking": "Configure endpoints para empezar a hacer seguimiento",
-    "Configure guardrail rules for MCP tool invocations.":
-      "Configure reglas de barreras de protección para las invocaciones de herramientas MCP.",
+    "Scan agent tool calls for PII, prohibited content, or prompt injection — block or mask matches.":
+      "Analice las llamadas a herramientas de los agentes en busca de PII, contenido prohibido o inyección de prompts — bloquee o enmascare las coincidencias.",
     "Configure integrations and tokens for AI detection scanning.":
       "Configure integraciones y tokens para el análisis de detección de IA.",
     "Configure LLM provider API keys for running evaluations across your organization":
@@ -22142,12 +22133,12 @@ export const translations: Record<string, Record<string, string>> = {
       "Registre repositorios y configure programaciones de análisis automatizados.",
     "Review and edit the AI-suggested risk before saving.":
       "Revise y edite el riesgo sugerido por la IA antes de guardar.",
-    "Review and manage tool invocation approval requests.":
-      "Revise y gestione las solicitudes de aprobación de invocación de herramientas.",
+    "Review and decide on agent tool calls that require human approval before they run.":
+      "Revise y decida sobre las llamadas a herramientas de los agentes que requieren aprobación humana antes de ejecutarse.",
     "Review the overall assessment and record the deployment decision.":
       "Revise la evaluación general y registre la decisión de despliegue.",
-    "Review tool invocation history and audit trail.":
-      "Revise el historial de invocaciones de herramientas y el registro de auditoría.",
+    "Every tool call your AI agents make, with outcome, latency, and which agent.":
+      "Cada llamada a herramienta que hacen sus agentes de IA, con el resultado, la latencia y qué agente.",
     "Route alerts to security teams, managers, or compliance officers. Each rule can have different notification recipients.":
       "Dirija las alertas a los equipos de seguridad, los responsables o los responsables de cumplimiento. Cada regla puede tener diferentes destinatarios de notificaciones.",
     "Run a test request through the gateway to complete setup":
@@ -22306,8 +22297,8 @@ export const translations: Record<string, Record<string, string>> = {
       "Realice llamadas a herramientas a través de MCP Gateway utilizando una clave de agente en POST /v1/mcp con el método tools/call.",
     "Manage API keys for syslog integration and configure syslog sources to feed network traffic data into Shadow AI detection.":
       "Gestione las claves de API para la integración con syslog y configure las fuentes de syslog para alimentar la detección de Shadow AI con datos de tráfico de red.",
-    "No MCP guardrail rules configured yet. Add rules to scan tool inputs for PII, prohibited content, or prompt injection attempts.":
-      "Aún no hay reglas de barreras de protección de MCP configuradas. Añada reglas para analizar las entradas de las herramientas en busca de PII, contenido prohibido o intentos de inyección de prompts.",
+    "No guardrail rules configured yet. Add rules to scan agent tool calls for PII, prohibited content, or prompt injection attempts.":
+      "Aún no hay reglas de barreras de protección configuradas. Añada reglas para analizar las llamadas a herramientas de los agentes en busca de PII, contenido prohibido o intentos de inyección de prompts.",
     "No Organizational Project Found. Create a new organizational project to manage ISO 27001, ISO 42001, and NIST AI RMF frameworks for your organization.":
       "No se ha encontrado ningún proyecto organizativo. Cree un nuevo proyecto organizativo para gestionar los marcos ISO 27001, ISO 42001 y NIST AI RMF de su organización.",
     "Note whether the dataset has been reviewed for bias, completeness, and accuracy. Track any known quality issues or limitations.":

--- a/Clients/src/i18n/translations.ts
+++ b/Clients/src/i18n/translations.ts
@@ -1131,6 +1131,7 @@ export const translations: Record<string, Record<string, string>> = {
     "Avg Latency": "Durchschnittliche Latenz",
     "Avg input tokens": "Durchschnittliche Eingabe-Tokens",
     "Avg latency": "Durchschnittliche Latenz",
+    "Avg latency, top 10 tools": "Durchschnittliche Latenz, Top 10 Tools",
     "Avg output tokens": "Durchschnittliche Ausgabe-Tokens",
     "Avg score": "Durchschnittliche Bewertung",
     "Bias (per-turn)": "Verzerrung (pro Runde)",
@@ -2457,8 +2458,8 @@ export const translations: Record<string, Record<string, string>> = {
     "Configure API keys first": "Zuerst API-Schlüssel konfigurieren",
     "Configure endpoints to start tracking":
       "Endpunkte konfigurieren, um mit der Verfolgung zu beginnen",
-    "Scan agent tool calls for PII, prohibited content or prompt injection, then block or mask what matches.":
-      "Durchsuchen Sie Agent-Tool-Aufrufe nach PII, unzulässigen Inhalten oder Prompt-Injection und blockieren oder maskieren Sie dann die Treffer.",
+    "Scan agent tool calls, MCP and native tools like Bash, for PII, prohibited content or prompt injection, then block or mask what matches.":
+      "Durchsuchen Sie Agent-Tool-Aufrufe, MCP- und native Tools wie Bash, nach PII, unzulässigen Inhalten oder Prompt-Injection und blockieren oder maskieren Sie dann die Treffer.",
     "Configure integrations and tokens for AI detection scanning.":
       "Integrationen und Token für KI-Erkennungsscans konfigurieren.",
     "Configure LLM provider API keys for running evaluations across your organization":
@@ -2744,8 +2745,8 @@ export const translations: Record<string, Record<string, string>> = {
     "Review and rank": "Prüfen und einstufen",
     "Review the overall assessment and record the deployment decision.":
       "Die Gesamtbewertung prüfen und die Bereitstellungsentscheidung erfassen.",
-    "Every tool call your AI agents make, with outcome, latency, and which agent.":
-      "Jeder Tool-Aufruf Ihrer KI-Agenten, mit Ergebnis, Latenz und ausführendem Agenten.",
+    "Every tool call your AI agents make, MCP tools and native tools like Bash, with outcome, latency and which agent.":
+      "Jeder Tool-Aufruf Ihrer KI-Agenten, MCP-Tools und native Tools wie Bash, mit Ergebnis, Latenz und ausführendem Agenten.",
     "Route alerts to security teams, managers, or compliance officers. Each rule can have different notification recipients.":
       "Benachrichtigungen an Sicherheitsteams, Manager oder Compliance-Beauftragte weiterleiten. Jede Regel kann unterschiedliche Empfänger haben.",
     "Run a test request through the gateway to complete setup":
@@ -9745,6 +9746,7 @@ export const translations: Record<string, Record<string, string>> = {
     "Avg Latency": "Latence moyenne",
     "Avg input tokens": "Tokens d'entrée moyens",
     "Avg latency": "Latence moyenne",
+    "Avg latency, top 10 tools": "Latence moyenne, top 10 outils",
     "Avg output tokens": "Tokens de sortie moyens",
     "Avg score": "Score moyen",
     "Bias (per-turn)": "Biais (par tour)",
@@ -11037,8 +11039,8 @@ export const translations: Record<string, Record<string, string>> = {
     "Configure API keys first": "Configurez d'abord les clés API",
     "Configure endpoints to start tracking":
       "Configurez des points de terminaison pour commencer le suivi",
-    "Scan agent tool calls for PII, prohibited content or prompt injection, then block or mask what matches.":
-      "Analysez les appels d'outils des agents à la recherche de données personnelles, de contenu interdit ou d'injection de prompt, puis bloquez ou masquez les correspondances.",
+    "Scan agent tool calls, MCP and native tools like Bash, for PII, prohibited content or prompt injection, then block or mask what matches.":
+      "Analysez les appels d'outils des agents, MCP et outils natifs comme Bash, à la recherche de données personnelles, de contenu interdit ou d'injection de prompt, puis bloquez ou masquez les correspondances.",
     "Configure integrations and tokens for AI detection scanning.":
       "Configurer les intégrations et les jetons pour l'analyse de détection IA.",
     "Configure LLM provider API keys for running evaluations across your organization":
@@ -11328,8 +11330,8 @@ export const translations: Record<string, Record<string, string>> = {
     "Review and rank": "Examiner et classer",
     "Review the overall assessment and record the deployment decision.":
       "Examinez l'évaluation globale et enregistrez la décision de déploiement.",
-    "Every tool call your AI agents make, with outcome, latency, and which agent.":
-      "Chaque appel d'outil effectué par vos agents IA, avec le résultat, la latence et l'agent concerné.",
+    "Every tool call your AI agents make, MCP tools and native tools like Bash, with outcome, latency and which agent.":
+      "Chaque appel d'outil effectué par vos agents IA, outils MCP et outils natifs comme Bash, avec le résultat, la latence et l'agent concerné.",
     "Route alerts to security teams, managers, or compliance officers. Each rule can have different notification recipients.":
       "Acheminez les alertes vers les équipes de sécurité, les managers ou les responsables de la conformité. Chaque règle peut avoir des destinataires de notification différents.",
     "Run a test request through the gateway to complete setup":
@@ -17652,6 +17654,7 @@ export const translations: Record<string, Record<string, string>> = {
     "Avg Latency": "Latencia media",
     "Avg input tokens": "Tokens de entrada medios",
     "Avg latency": "Latencia media",
+    "Avg latency, top 10 tools": "Latencia media, 10 herramientas principales",
     "Avg output tokens": "Tokens de salida medios",
     "Avg score": "Puntuación media",
     "Bias (per-turn)": "Sesgo (por turno)",
@@ -21981,8 +21984,8 @@ export const translations: Record<string, Record<string, string>> = {
     "Configure a local model provider. No API key required.":
       "Configure un proveedor de modelos local. No se requiere clave de API.",
     "Configure endpoints to start tracking": "Configure endpoints para empezar a hacer seguimiento",
-    "Scan agent tool calls for PII, prohibited content or prompt injection, then block or mask what matches.":
-      "Analice las llamadas a herramientas de los agentes en busca de PII, contenido prohibido o inyección de prompts y luego bloquee o enmascare las coincidencias.",
+    "Scan agent tool calls, MCP and native tools like Bash, for PII, prohibited content or prompt injection, then block or mask what matches.":
+      "Analice las llamadas a herramientas de los agentes, MCP y herramientas nativas como Bash, en busca de PII, contenido prohibido o inyección de prompts y luego bloquee o enmascare las coincidencias.",
     "Configure integrations and tokens for AI detection scanning.":
       "Configure integraciones y tokens para el análisis de detección de IA.",
     "Configure LLM provider API keys for running evaluations across your organization":
@@ -22137,8 +22140,8 @@ export const translations: Record<string, Record<string, string>> = {
       "Revise y decida sobre las llamadas a herramientas de los agentes que requieren aprobación humana antes de ejecutarse.",
     "Review the overall assessment and record the deployment decision.":
       "Revise la evaluación general y registre la decisión de despliegue.",
-    "Every tool call your AI agents make, with outcome, latency, and which agent.":
-      "Cada llamada a herramienta que hacen sus agentes de IA, con el resultado, la latencia y qué agente.",
+    "Every tool call your AI agents make, MCP tools and native tools like Bash, with outcome, latency and which agent.":
+      "Cada llamada a herramienta que hacen sus agentes de IA, herramientas MCP y herramientas nativas como Bash, con el resultado, la latencia y qué agente.",
     "Route alerts to security teams, managers, or compliance officers. Each rule can have different notification recipients.":
       "Dirija las alertas a los equipos de seguridad, los responsables o los responsables de cumplimiento. Cada regla puede tener diferentes destinatarios de notificaciones.",
     "Run a test request through the gateway to complete setup":

--- a/Clients/src/i18n/translations.ts
+++ b/Clients/src/i18n/translations.ts
@@ -19321,6 +19321,7 @@ export const translations: Record<string, Record<string, string>> = {
     "Tools": "Herramientas",
     "Audit Log": "Registro de auditoría",
     "Approvals": "Aprobaciones",
+    "Require approval": "Aprobación requerida",
     "No pending approvals": "No hay aprobaciones pendientes",
     "Pending approvals": "Aprobaciones pendientes",
     "Approved requests": "Solicitudes aprobadas",

--- a/Clients/src/i18n/translations.ts
+++ b/Clients/src/i18n/translations.ts
@@ -1652,8 +1652,8 @@ export const translations: Record<string, Record<string, string>> = {
     "Average round-trip time for tool calls": "Durchschnittliche Antwortzeit für Tool-Aufrufe",
     "Average round-trip time from request to complete response":
       "Durchschnittliche Antwortzeit von der Anfrage bis zur vollständigen Antwort",
-    "Average round-trip time per tool call, helping identify slow or bottlenecked tools":
-      "Durchschnittliche Antwortzeit pro Tool-Aufruf, hilft bei der Identifizierung langsamer Tools",
+    "Average round-trip time per tool call, useful for spotting slow tools":
+      "Durchschnittliche Antwortzeit pro Tool-Aufruf, nützlich um langsame Tools zu erkennen",
     "Background colors": "Hintergrundfarben",
     "Battle name": "Vergleichsname",
     "Bearer token": "Bearer-Token",
@@ -2457,8 +2457,8 @@ export const translations: Record<string, Record<string, string>> = {
     "Configure API keys first": "Zuerst API-Schlüssel konfigurieren",
     "Configure endpoints to start tracking":
       "Endpunkte konfigurieren, um mit der Verfolgung zu beginnen",
-    "Scan agent tool calls for PII, prohibited content, or prompt injection — block or mask matches.":
-      "Durchsuchen Sie Agent-Tool-Aufrufe nach PII, unzulässigen Inhalten oder Prompt-Injection — Treffer blockieren oder maskieren.",
+    "Scan agent tool calls for PII, prohibited content or prompt injection, then block or mask what matches.":
+      "Durchsuchen Sie Agent-Tool-Aufrufe nach PII, unzulässigen Inhalten oder Prompt-Injection und blockieren oder maskieren Sie dann die Treffer.",
     "Configure integrations and tokens for AI detection scanning.":
       "Integrationen und Token für KI-Erkennungsscans konfigurieren.",
     "Configure LLM provider API keys for running evaluations across your organization":
@@ -2523,8 +2523,8 @@ export const translations: Record<string, Record<string, string>> = {
       "Jeder Protokolleintrag zeigt den vollständigen Prompt, der an das LLM gesendet wurde, das Modell",
     "Each task can be assigned to a workspace member with a priority and due date. They":
       "Jede Aufgabe kann einem Mitglied des Arbeitsbereichs mit einer Priorität und einem Fälligkeitsdatum zugewiesen werden. Sie",
-    "Enable approval requirements on sensitive tools to ensure human review before the AI agent can execute them.":
-      "Genehmigungsanforderungen für sensible Tools aktivieren, um eine menschliche Prüfung vor der Ausführung durch den KI-Agenten zu gewährleisten.",
+    "Require approval on sensitive tools so a person reviews them before the agent runs them.":
+      "Verlangen Sie für sensible Tools eine Genehmigung, damit eine Person sie prüft, bevor der Agent sie ausführt.",
     "Enter a descriptive name for this dataset":
       "Geben Sie einen aussagekräftigen Namen für diesen Datensatz ein",
     "Enter a name for the new organization": "Namen für die neue Organisation eingeben",
@@ -10237,8 +10237,8 @@ export const translations: Record<string, Record<string, string>> = {
     "Average round-trip time for tool calls": "Temps aller-retour moyen pour les appels d'outils",
     "Average round-trip time from request to complete response":
       "Temps aller-retour moyen de la requête à la réponse complète",
-    "Average round-trip time per tool call, helping identify slow or bottlenecked tools":
-      "Temps aller-retour moyen par appel d'outil, aidant à identifier les outils lents ou saturés",
+    "Average round-trip time per tool call, useful for spotting slow tools":
+      "Temps aller-retour moyen par appel d'outil, utile pour repérer les outils lents",
     "Background colors": "Couleurs d'arrière-plan",
     "Battle name": "Nom de la comparaison",
     "Bearer token": "Jeton bearer",
@@ -11037,8 +11037,8 @@ export const translations: Record<string, Record<string, string>> = {
     "Configure API keys first": "Configurez d'abord les clés API",
     "Configure endpoints to start tracking":
       "Configurez des points de terminaison pour commencer le suivi",
-    "Scan agent tool calls for PII, prohibited content, or prompt injection — block or mask matches.":
-      "Analysez les appels d'outils des agents à la recherche de données personnelles, de contenu interdit ou d'injection de prompt — bloquez ou masquez les correspondances.",
+    "Scan agent tool calls for PII, prohibited content or prompt injection, then block or mask what matches.":
+      "Analysez les appels d'outils des agents à la recherche de données personnelles, de contenu interdit ou d'injection de prompt, puis bloquez ou masquez les correspondances.",
     "Configure integrations and tokens for AI detection scanning.":
       "Configurer les intégrations et les jetons pour l'analyse de détection IA.",
     "Configure LLM provider API keys for running evaluations across your organization":
@@ -11106,8 +11106,8 @@ export const translations: Record<string, Record<string, string>> = {
       "Chaque tâche peut être assignée à un membre de l'espace de travail avec une priorité et une date d'échéance. Elles",
 
     // Batch 06
-    "Enable approval requirements on sensitive tools to ensure human review before the AI agent can execute them.":
-      "Activez les exigences d'approbation sur les outils sensibles pour garantir une relecture humaine avant que l'agent IA puisse les exécuter.",
+    "Require approval on sensitive tools so a person reviews them before the agent runs them.":
+      "Exigez une approbation sur les outils sensibles pour qu'une personne les relise avant que l'agent ne les exécute.",
     "Enter a descriptive name for this dataset":
       "Saisissez un nom descriptif pour ce jeu de données",
     "Enter a name for the new organization": "Saisissez un nom pour la nouvelle organisation",
@@ -21840,8 +21840,8 @@ export const translations: Record<string, Record<string, string>> = {
       "Genere datos de muestra para explorar las funciones de VerifyWise",
     "Average round-trip time from request to complete response":
       "Tiempo medio de ida y vuelta desde la solicitud hasta la respuesta completa",
-    "Average round-trip time per tool call, helping identify slow or bottlenecked tools":
-      "Tiempo medio de ida y vuelta por llamada a herramienta, lo que ayuda a identificar herramientas lentas o con cuellos de botella",
+    "Average round-trip time per tool call, useful for spotting slow tools":
+      "Tiempo medio de ida y vuelta por llamada a herramienta, útil para detectar herramientas lentas",
     "Browse pre-built guardrails and enable them with one click":
       "Explore barreras de protección predefinidas y actívelas con un solo clic",
     "Combined prompt and completion tokens across all requests":
@@ -21981,8 +21981,8 @@ export const translations: Record<string, Record<string, string>> = {
     "Configure a local model provider. No API key required.":
       "Configure un proveedor de modelos local. No se requiere clave de API.",
     "Configure endpoints to start tracking": "Configure endpoints para empezar a hacer seguimiento",
-    "Scan agent tool calls for PII, prohibited content, or prompt injection — block or mask matches.":
-      "Analice las llamadas a herramientas de los agentes en busca de PII, contenido prohibido o inyección de prompts — bloquee o enmascare las coincidencias.",
+    "Scan agent tool calls for PII, prohibited content or prompt injection, then block or mask what matches.":
+      "Analice las llamadas a herramientas de los agentes en busca de PII, contenido prohibido o inyección de prompts y luego bloquee o enmascare las coincidencias.",
     "Configure integrations and tokens for AI detection scanning.":
       "Configure integraciones y tokens para el análisis de detección de IA.",
     "Configure LLM provider API keys for running evaluations across your organization":
@@ -22021,8 +22021,8 @@ export const translations: Record<string, Record<string, string>> = {
       "Cada entrada de registro muestra el prompt completo enviado al LLM, el modelo",
     "Each task can be assigned to a workspace member with a priority and due date. They":
       "Cada tarea puede asignarse a un miembro del espacio de trabajo con una prioridad y una fecha de vencimiento. Estos",
-    "Enable approval requirements on sensitive tools to ensure human review before the AI agent can execute them.":
-      "Active los requisitos de aprobación en las herramientas sensibles para garantizar la revisión humana antes de que el agente de IA pueda ejecutarlas.",
+    "Require approval on sensitive tools so a person reviews them before the agent runs them.":
+      "Exige aprobación en las herramientas sensibles para que una persona las revise antes de que el agente las ejecute.",
     "Enter a descriptive name for this dataset":
       "Introduzca un nombre descriptivo para este conjunto de datos",
     "Enter a name for your organization to get started.":

--- a/Clients/src/presentation/components/breadcrumbs/routeMapping.ts
+++ b/Clients/src/presentation/components/breadcrumbs/routeMapping.ts
@@ -150,12 +150,12 @@ export const routeMapping: Record<string, string> = {
   "/ai-gateway/settings/guardrails": "Guardrail settings",
   "/ai-gateway/settings/risks": "Suggested risks",
 
-  // MCP Gateway
-  "/ai-gateway/mcp": "MCP Gateway",
+  // Agent Control
+  "/ai-gateway/mcp": "Agent Control",
   "/ai-gateway/mcp/agent-keys": "Agent keys",
-  "/ai-gateway/mcp/servers": "Servers",
-  "/ai-gateway/mcp/tools": "Tool catalog",
-  "/ai-gateway/mcp/audit": "Audit log",
+  "/ai-gateway/mcp/servers": "MCP Servers",
+  "/ai-gateway/mcp/tools": "MCP Tools",
+  "/ai-gateway/mcp/audit": "Activity",
   "/ai-gateway/mcp/approvals": "Approvals",
   "/ai-gateway/mcp/guardrails": "Guardrails",
 

--- a/Clients/src/presentation/pages/AIGateway/AIGatewaySidebar.tsx
+++ b/Clients/src/presentation/pages/AIGateway/AIGatewaySidebar.tsx
@@ -95,7 +95,7 @@ export default function AIGatewaySidebar({
 
   const mcpGroups: SidebarMenuGroup[] = [
     {
-      name: "MCP Gateway",
+      name: "Agent Control",
       collapsible: true,
       defaultCollapsed: true,
       items: [
@@ -107,19 +107,19 @@ export default function AIGatewaySidebar({
         },
         {
           id: "mcp-servers",
-          label: "Servers",
+          label: "MCP Servers",
           value: "mcp/servers",
           icon: <Server size={16} strokeWidth={1.5} />,
         },
         {
           id: "mcp-tools",
-          label: "Tools",
+          label: "MCP Tools",
           value: "mcp/tools",
           icon: <Wrench size={16} strokeWidth={1.5} />,
         },
         {
           id: "mcp-audit",
-          label: "Audit Log",
+          label: "Activity",
           value: "mcp/audit",
           icon: <ClipboardList size={16} strokeWidth={1.5} />,
         },

--- a/Clients/src/presentation/pages/AIGateway/MCPApprovals/index.tsx
+++ b/Clients/src/presentation/pages/AIGateway/MCPApprovals/index.tsx
@@ -124,8 +124,8 @@ export default function MCPApprovalsPage() {
 
   return (
     <PageHeaderExtended
-      title="MCP Approvals"
-      description="Review and manage tool invocation approval requests."
+      title="Approvals"
+      description="Review and decide on agent tool calls that require human approval before they run."
     >
       {/* Tab bar */}
       <Box sx={{ px: 3, pt: 1 }}>

--- a/Clients/src/presentation/pages/AIGateway/MCPAuditLog/index.tsx
+++ b/Clients/src/presentation/pages/AIGateway/MCPAuditLog/index.tsx
@@ -126,8 +126,8 @@ export default function MCPAuditLogPage() {
 
   return (
     <PageHeaderExtended
-      title="MCP Audit Log"
-      description="Review tool invocation history and audit trail."
+      title="Activity"
+      description="Every tool call your AI agents make, with outcome, latency, and which agent."
       actionButton={
         <Box sx={{ width: 160 }}>
           <Select

--- a/Clients/src/presentation/pages/AIGateway/MCPAuditLog/index.tsx
+++ b/Clients/src/presentation/pages/AIGateway/MCPAuditLog/index.tsx
@@ -127,7 +127,7 @@ export default function MCPAuditLogPage() {
   return (
     <PageHeaderExtended
       title="Activity"
-      description="Every tool call your AI agents make, with outcome, latency, and which agent."
+      description="Every tool call your AI agents make, MCP tools and native tools like Bash, with outcome, latency and which agent."
       actionButton={
         <Box sx={{ width: 160 }}>
           <Select

--- a/Clients/src/presentation/pages/AIGateway/MCPAuditLog/index.tsx
+++ b/Clients/src/presentation/pages/AIGateway/MCPAuditLog/index.tsx
@@ -222,9 +222,9 @@ export default function MCPAuditLogPage() {
               </Box>
               <Box sx={{ ...cardSx, flex: 1 }}>
                 <Stack direction="row" alignItems="center" gap={1} sx={{ mb: 1 }}>
-                  <Typography sx={sectionTitleSx}>Avg latency — top 10 tools</Typography>
+                  <Typography sx={sectionTitleSx}>Avg latency, top 10 tools</Typography>
                   <MuiTooltip
-                    title="Average round-trip time per tool call, helping identify slow or bottlenecked tools"
+                    title="Average round-trip time per tool call, useful for spotting slow tools"
                     arrow
                     placement="top"
                   >

--- a/Clients/src/presentation/pages/AIGateway/MCPGuardrails/index.tsx
+++ b/Clients/src/presentation/pages/AIGateway/MCPGuardrails/index.tsx
@@ -306,7 +306,7 @@ export default function MCPGuardrailsPage() {
   return (
     <PageHeaderExtended
       title="Guardrails"
-      description="Scan agent tool calls for PII, prohibited content, or prompt injection — block or mask matches."
+      description="Scan agent tool calls for PII, prohibited content or prompt injection, then block or mask what matches."
       tipBoxEntity="ai-gateway-mcp-guardrails"
       helpArticlePath="ai-gateway/mcp-guardrails"
       actionButton={

--- a/Clients/src/presentation/pages/AIGateway/MCPGuardrails/index.tsx
+++ b/Clients/src/presentation/pages/AIGateway/MCPGuardrails/index.tsx
@@ -306,7 +306,7 @@ export default function MCPGuardrailsPage() {
   return (
     <PageHeaderExtended
       title="Guardrails"
-      description="Scan agent tool calls for PII, prohibited content or prompt injection, then block or mask what matches."
+      description="Scan agent tool calls, MCP and native tools like Bash, for PII, prohibited content or prompt injection, then block or mask what matches."
       tipBoxEntity="ai-gateway-mcp-guardrails"
       helpArticlePath="ai-gateway/mcp-guardrails"
       actionButton={
@@ -407,7 +407,7 @@ export default function MCPGuardrailsPage() {
               }}
             >
               Matching tool calls will be paused and routed to a human approver before execution. No
-              block or mask action is needed — approval is enforced automatically.
+              block or mask action is needed. Approval is enforced automatically.
             </Typography>
           ) : (
             <Select
@@ -496,8 +496,8 @@ export default function MCPGuardrailsPage() {
       >
         <Stack gap="8px">
           <Typography sx={{ fontSize: 13, color: palette.text.secondary }}>
-            This action takes effect immediately. Agent tool calls will no longer be checked
-            against this rule.
+            This action takes effect immediately. Agent tool calls will no longer be checked against
+            this rule.
           </Typography>
           <Typography sx={{ fontSize: 13, color: palette.text.tertiary }}>
             You can re-create this guardrail at any time.

--- a/Clients/src/presentation/pages/AIGateway/MCPGuardrails/index.tsx
+++ b/Clients/src/presentation/pages/AIGateway/MCPGuardrails/index.tsx
@@ -305,8 +305,8 @@ export default function MCPGuardrailsPage() {
 
   return (
     <PageHeaderExtended
-      title="MCP Guardrails"
-      description="Configure guardrail rules for MCP tool invocations."
+      title="Guardrails"
+      description="Scan agent tool calls for PII, prohibited content, or prompt injection — block or mask matches."
       tipBoxEntity="ai-gateway-mcp-guardrails"
       helpArticlePath="ai-gateway/mcp-guardrails"
       actionButton={
@@ -326,7 +326,7 @@ export default function MCPGuardrailsPage() {
       ) : rules.length === 0 ? (
         <EmptyState
           icon={Shield}
-          message="No MCP guardrail rules configured yet. Add rules to scan tool inputs for PII, prohibited content, or prompt injection attempts."
+          message="No guardrail rules configured yet. Add rules to scan agent tool calls for PII, prohibited content, or prompt injection attempts."
           showBorder
         >
           <EmptyStateTip
@@ -364,7 +364,7 @@ export default function MCPGuardrailsPage() {
         description={
           isEditing
             ? "Update this guardrail rule's configuration."
-            : "Configure a new guardrail rule for MCP tool invocations."
+            : "Configure a new guardrail rule for agent tool calls."
         }
         onSubmit={handleSubmit}
         submitButtonText={isEditing ? "Save changes" : "Create guardrail"}
@@ -496,7 +496,7 @@ export default function MCPGuardrailsPage() {
       >
         <Stack gap="8px">
           <Typography sx={{ fontSize: 13, color: palette.text.secondary }}>
-            This action takes effect immediately. MCP tool invocations will no longer be checked
+            This action takes effect immediately. Agent tool calls will no longer be checked
             against this rule.
           </Typography>
           <Typography sx={{ fontSize: 13, color: palette.text.tertiary }}>

--- a/Clients/src/presentation/pages/AIGateway/MCPToolCatalog/index.tsx
+++ b/Clients/src/presentation/pages/AIGateway/MCPToolCatalog/index.tsx
@@ -308,7 +308,7 @@ export default function MCPToolCatalogPage() {
           <EmptyStateTip
             icon={AlertTriangle}
             title="Approval workflows"
-            description="Enable approval requirements on sensitive tools to ensure human review before the AI agent can execute them."
+            description="Require approval on sensitive tools so a person reviews them before the agent runs them."
           />
         </EmptyState>
       ) : filteredTools.length === 0 ? (
@@ -420,8 +420,8 @@ export default function MCPToolCatalogPage() {
                 style={{ flexShrink: 0, marginTop: 2 }}
               />
               <Typography sx={{ fontSize: 12, color: "#93370D", lineHeight: 1.5 }}>
-                This tool is marked as high risk. Consider enabling approval to ensure human review
-                before execution.
+                This tool is marked as high risk. Consider requiring approval so a person reviews it
+                before it runs.
               </Typography>
             </Stack>
           )}

--- a/Clients/src/presentation/pages/AIGateway/MCPToolCatalog/index.tsx
+++ b/Clients/src/presentation/pages/AIGateway/MCPToolCatalog/index.tsx
@@ -255,7 +255,7 @@ export default function MCPToolCatalogPage() {
 
   return (
     <PageHeaderExtended
-      title="MCP Tool Catalog"
+      title="MCP Tools"
       description="View and manage all discovered MCP tools across your servers."
       tipBoxEntity="ai-gateway-mcp-tools"
       helpArticlePath="ai-gateway/mcp-tools"

--- a/docs/superpowers/plans/2026-06-16-agent-control-rename.md
+++ b/docs/superpowers/plans/2026-06-16-agent-control-rename.md
@@ -1,0 +1,367 @@
+# Agent Control Rename — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Re-label the "MCP Gateway" UI section as "Agent Control" (and "Audit Log" → "Activity", "Servers"/"Tools" → "MCP Servers"/"MCP Tools") across sidebar, page headers, breadcrumbs, and the de/fr/es DOM-translation keys — display strings only.
+
+**Architecture:** Components render raw English strings in JSX (no `t()` for these labels). A runtime DOM translator (`Clients/src/i18n/domTranslator.ts`) swaps visible text using the English string as the lookup key against `translations[lang]`; `en` uses `{}` (no swap). So a rename = change the raw English string in the component/route-map AND update the matching de/fr/es key+value in `translations.ts`, or non-English UIs fall back to the new English. No backend, no routes, no schema.
+
+**Tech Stack:** React/TypeScript, Vite; `translations.ts` (de/fr/es maps keyed by English string).
+
+**Spec:** `docs/superpowers/specs/2026-06-16-agent-control-rename-design.md`
+**Branch:** `feat/agent-control-rename` (already created, off `develop`)
+
+---
+
+## Label map (the single source of truth for every task)
+
+| Old English string | New English string |
+|---|---|
+| `MCP Gateway` (sidebar group + breadcrumb) | `Agent Control` |
+| `Audit Log` (sidebar) / `Audit log` (breadcrumb) / `MCP Audit Log` (page title) | `Activity` |
+| `Servers` (sidebar) | `MCP Servers` |
+| `Tools` (sidebar) / `Tool catalog` (breadcrumb) / `MCP Tool Catalog` (page title) | `MCP Tools` |
+| `MCP Approvals` (page title) | `Approvals` |
+| `MCP Guardrails` (page title) | `Guardrails` |
+| `Agent Keys` / `Approvals` / `MCP Servers` (page title, already MCP) | *(unchanged)* |
+
+**Branch caveat (from spec):** this branch is off `develop`, which lacks Phase 1/2. Page descriptions must NOT promise native-tool (Bash) gating that isn't live on this branch. Write agent-accurate-but-honest copy: say "agent tool calls" (true for MCP today), not "native tools like Bash". The fuller native-tool copy can be added when Phase 1/2 merge.
+
+---
+
+## File Structure
+
+- **Modify** `Clients/src/presentation/pages/AIGateway/AIGatewaySidebar.tsx` — 4 sidebar labels.
+- **Modify** `Clients/src/presentation/components/breadcrumbs/routeMapping.ts` — 4 breadcrumb labels.
+- **Modify** 4 page components — titles + agent-accurate descriptions: `MCPAuditLog`, `MCPToolCatalog`, `MCPApprovals`, `MCPGuardrails` (under `Clients/src/presentation/pages/AIGateway/`).
+- **Modify** `Clients/src/i18n/translations.ts` — de/fr/es key+value updates for every changed string.
+- **Modify** user-guide content `shared/user-guide-content/` — section title + breadcrumb prose; copy to website repo.
+
+---
+
+## Task 1: Sidebar labels
+
+**Files:**
+- Modify: `Clients/src/presentation/pages/AIGateway/AIGatewaySidebar.tsx:98,110,116,122`
+
+- [ ] **Step 1: Apply the four label edits**
+
+In `AIGatewaySidebar.tsx`:
+- L98 `name: "MCP Gateway",` → `name: "Agent Control",`
+- L110 `label: "Servers",` → `label: "MCP Servers",`
+- L116 `label: "Tools",` → `label: "MCP Tools",`
+- L122 `label: "Audit Log",` → `label: "Activity",`
+
+Leave L104 (`"Agent Keys"`), L128 (`"Approvals"`), L134 (`"Guardrails"`) unchanged. Leave all `value:` and `id:` fields unchanged (routes don't move).
+
+- [ ] **Step 2: Verify no other label drifted**
+
+```bash
+grep -n 'name:\|label:' /Users/gorkemcetin/verifywise/Clients/src/presentation/pages/AIGateway/AIGatewaySidebar.tsx | sed -n '1,12p'
+```
+Expected: group `Agent Control`; items `Agent Keys`, `MCP Servers`, `MCP Tools`, `Activity`, `Approvals`, `Guardrails`.
+
+- [ ] **Step 3: Commit**
+
+```bash
+cd /Users/gorkemcetin/verifywise && git add Clients/src/presentation/pages/AIGateway/AIGatewaySidebar.tsx && git commit -m "feat(ai-gateway): rename sidebar — Agent Control, Activity, MCP Servers/Tools"
+```
+
+---
+
+## Task 2: Breadcrumb labels
+
+**Files:**
+- Modify: `Clients/src/presentation/components/breadcrumbs/routeMapping.ts:154,156,157,158`
+
+- [ ] **Step 1: Apply the breadcrumb edits**
+
+In `routeMapping.ts`, the `// MCP Gateway` block:
+- L154 `"/ai-gateway/mcp": "MCP Gateway",` → `"/ai-gateway/mcp": "Agent Control",`
+- L156 `"/ai-gateway/mcp/servers": "Servers",` → `"/ai-gateway/mcp/servers": "MCP Servers",`
+- L157 `"/ai-gateway/mcp/tools": "Tool catalog",` → `"/ai-gateway/mcp/tools": "MCP Tools",`
+- L158 `"/ai-gateway/mcp/audit": "Audit log",` → `"/ai-gateway/mcp/audit": "Activity",`
+
+Leave agent-keys/approvals/guardrails breadcrumb labels unchanged. Optionally update the `// MCP Gateway` comment on L153 to `// Agent Control` (cosmetic).
+
+- [ ] **Step 2: Verify**
+
+```bash
+sed -n '153,160p' /Users/gorkemcetin/verifywise/Clients/src/presentation/components/breadcrumbs/routeMapping.ts
+```
+Expected: `/ai-gateway/mcp` → `Agent Control`; servers → `MCP Servers`; tools → `MCP Tools`; audit → `Activity`.
+
+- [ ] **Step 3: Commit**
+
+```bash
+cd /Users/gorkemcetin/verifywise && git add Clients/src/presentation/components/breadcrumbs/routeMapping.ts && git commit -m "feat(ai-gateway): rename breadcrumbs to match Agent Control labels"
+```
+
+---
+
+## Task 3: Page headers + agent-accurate descriptions
+
+**Files:**
+- Modify: `Clients/src/presentation/pages/AIGateway/MCPAuditLog/index.tsx:129-130`
+- Modify: `Clients/src/presentation/pages/AIGateway/MCPToolCatalog/index.tsx:258-259`
+- Modify: `Clients/src/presentation/pages/AIGateway/MCPApprovals/index.tsx:127-128`
+- Modify: `Clients/src/presentation/pages/AIGateway/MCPGuardrails/index.tsx:298-299,319,357,468`
+
+- [ ] **Step 1: MCPAuditLog title + description**
+
+L129-130:
+```
+      title="MCP Audit Log"
+      description="Review tool invocation history and audit trail."
+```
+→
+```
+      title="Activity"
+      description="Every tool call your AI agents make, with outcome, latency, and which agent."
+```
+
+- [ ] **Step 2: MCPToolCatalog title (keep MCP) + description**
+
+L258-259:
+```
+      title="MCP Tool Catalog"
+      description="View and manage all discovered MCP tools across your servers."
+```
+→
+```
+      title="MCP Tools"
+      description="View and manage all discovered MCP tools across your servers."
+```
+(Title shortened to match the sidebar; description already MCP-accurate, unchanged.)
+
+- [ ] **Step 3: MCPApprovals title + description**
+
+L127-128:
+```
+      title="MCP Approvals"
+      description="Review and manage tool invocation approval requests."
+```
+→
+```
+      title="Approvals"
+      description="Review and decide on agent tool calls that require human approval before they run."
+```
+
+- [ ] **Step 4: MCPGuardrails title + description + MCP-mention copy**
+
+L298-299:
+```
+      title="MCP Guardrails"
+      description="Configure guardrail rules for MCP tool invocations."
+```
+→
+```
+      title="Guardrails"
+      description="Scan agent tool calls for PII, prohibited content, or prompt injection — block or mask matches."
+```
+
+Also soften the three remaining MCP-specific phrasings (keep meaning, drop the redundant "MCP" where it reads as agent-governance copy; keep "MCP tools" where it specifically means MCP-server tools):
+- L319 empty state: `"No MCP guardrail rules configured yet. Add rules to scan tool inputs for PII, prohibited content, or prompt injection attempts."` → `"No guardrail rules configured yet. Add rules to scan agent tool calls for PII, prohibited content, or prompt injection attempts."`
+- L357 modal subtitle: `"Configure a new guardrail rule for MCP tool invocations."` → `"Configure a new guardrail rule for agent tool calls."`
+- L468 revoke/disable copy: `"...MCP tool invocations will no longer be checked..."` → `"...agent tool calls will no longer be checked..."`
+
+(Leave L325/L330 tip-box copy that legitimately references "MCP tools" as the MCP-server concept — those are accurate.)
+
+- [ ] **Step 5: Verify titles changed and no stray double-rename**
+
+```bash
+cd /Users/gorkemcetin/verifywise/Clients/src/presentation/pages/AIGateway
+grep -n 'title=' MCPAuditLog/index.tsx MCPToolCatalog/index.tsx MCPApprovals/index.tsx MCPGuardrails/index.tsx | grep -i "title="
+```
+Expected titles: `Activity`, `MCP Tools`, `Approvals`, `Guardrails`.
+
+- [ ] **Step 6: Commit**
+
+```bash
+cd /Users/gorkemcetin/verifywise && git add Clients/src/presentation/pages/AIGateway/MCPAuditLog/index.tsx Clients/src/presentation/pages/AIGateway/MCPToolCatalog/index.tsx Clients/src/presentation/pages/AIGateway/MCPApprovals/index.tsx Clients/src/presentation/pages/AIGateway/MCPGuardrails/index.tsx && git commit -m "feat(ai-gateway): rename page headers + agent-accurate descriptions"
+```
+
+---
+
+## Task 4: i18n — update de/fr/es keys + values
+
+The DOM translator keys on the **English string**. Every English label we changed must get a new key in de/fr/es with a translated value, or non-English UIs render the new English. `en` is `{}` — no change. Old keys for strings that no longer appear in the DOM become dead; remove them to keep the file honest.
+
+**Files:**
+- Modify: `Clients/src/i18n/translations.ts` (de block ~L1903-1907,3894; fr ~L9160,10490-10494; es ~L18346-18350,19322)
+
+- [ ] **Step 1: German (de) — replace the menu-label + group keys**
+
+Replace these de entries:
+```
+    "MCP Approvals": "MCP-Genehmigungen",
+    "MCP Audit Log": "MCP-Prüfprotokoll",
+    "MCP Guardrails": "MCP-Guardrails",
+    "MCP Servers": "MCP-Server",
+    "MCP Tool Catalog": "MCP-Tool-Katalog",
+```
+with (new English keys → German values):
+```
+    "Approvals": "Genehmigungen",
+    "Activity": "Aktivität",
+    "Guardrails": "Guardrails",
+    "MCP Servers": "MCP-Server",
+    "MCP Tools": "MCP-Tools",
+```
+And the group key (~L3894):
+```
+    "MCP Gateway": "MCP-Gateway",
+```
+→
+```
+    "Agent Control": "Agentensteuerung",
+```
+
+- [ ] **Step 2: French (fr) — same key changes**
+
+Replace (~L10490-10494):
+```
+    "MCP Approvals": "Approbations MCP",
+    "MCP Audit Log": "Journal d'audit MCP",
+    "MCP Guardrails": "Garde-fous MCP",
+    "MCP Servers": "Serveurs MCP",
+    "MCP Tool Catalog": "Catalogue d'outils MCP",
+```
+with:
+```
+    "Approvals": "Approbations",
+    "Activity": "Activité",
+    "Guardrails": "Garde-fous",
+    "MCP Servers": "Serveurs MCP",
+    "MCP Tools": "Outils MCP",
+```
+And the group key (~L9160):
+```
+    "MCP Gateway": "Passerelle MCP",
+```
+→
+```
+    "Agent Control": "Contrôle des agents",
+```
+
+- [ ] **Step 3: Spanish (es) — same key changes**
+
+Replace (~L18346-18350):
+```
+    "MCP Approvals": "Aprobaciones de MCP",
+    "MCP Audit Log": "Registro de auditoría de MCP",
+    "MCP Guardrails": "Barreras de protección de MCP",
+    "MCP Servers": "Servidores MCP",
+    "MCP Tool Catalog": "Catálogo de herramientas MCP",
+```
+with:
+```
+    "Approvals": "Aprobaciones",
+    "Activity": "Actividad",
+    "Guardrails": "Barreras de protección",
+    "MCP Servers": "Servidores MCP",
+    "MCP Tools": "Herramientas MCP",
+```
+And the group key (~L19322):
+```
+    "MCP Gateway": "MCP Gateway",
+```
+→
+```
+    "Agent Control": "Control de agentes",
+```
+
+- [ ] **Step 4: Sweep for any remaining changed English strings still keyed by old text**
+
+The renamed page descriptions and empty-state copy from Task 3 may also have de/fr/es keys. Search and update any that exist:
+```bash
+grep -n '"Review tool invocation history and audit trail."\|"Configure guardrail rules for MCP tool invocations."\|"Review and manage tool invocation approval requests."\|"No MCP guardrail rules configured yet' /Users/gorkemcetin/verifywise/Clients/src/i18n/translations.ts
+```
+For each hit, update the **key** to the new English string from Task 3 and translate the value. If a description has no translation entry (grep returns nothing for it), it has no de/fr/es override — that's fine, it renders English in all languages today and will continue to; no action needed.
+
+- [ ] **Step 5: Verify the file still parses (typecheck)**
+
+```bash
+cd /Users/gorkemcetin/verifywise/Clients && npx tsc --noEmit 2>&1 | tail -20
+```
+Expected: no new errors referencing `translations.ts` (a trailing-comma or duplicate-key mistake shows here). Pre-existing unrelated errors elsewhere are acceptable — confirm none point at `i18n/translations.ts`.
+
+- [ ] **Step 6: Commit**
+
+```bash
+cd /Users/gorkemcetin/verifywise && git add Clients/src/i18n/translations.ts && git commit -m "i18n(ai-gateway): update de/fr/es keys for Agent Control rename
+
+Non-English copy is machine-translated without a native reviewer; flag
+for a later native-speaker pass. English (en) is authoritative."
+```
+
+> **Translation-quality caveat (carry into PR description):** de/fr/es values above are best-effort, not native-reviewed.
+
+---
+
+## Task 5: User-guide content
+
+**Files:**
+- Modify: `shared/user-guide-content/userGuideConfig.ts` (section title + article labels ~L630-667)
+- Modify: `shared/user-guide-content/content/ai-gateway/mcp-*.ts` (in-prose breadcrumb references)
+
+- [ ] **Step 1: Find the user-guide strings**
+
+```bash
+cd /Users/gorkemcetin/verifywise
+grep -rn "MCP Gateway\|Audit log\|MCP Audit\|> MCP Gateway >\|MCP Gateway >" shared/user-guide-content/ | head -40
+```
+
+- [ ] **Step 2: Update the section title + breadcrumb prose**
+
+In `shared/user-guide-content/userGuideConfig.ts`: rename the collection/section title `"MCP Gateway overview"` → `"Agent Control overview"`. Update any article labels that say "MCP audit log" → "Activity" to match (leave "MCP servers"/"MCP tool catalog" article labels as MCP — those pages keep MCP). In the `content/ai-gateway/mcp-*.ts` files, replace in-prose breadcrumb references like `**AI Gateway > MCP Gateway > Approvals**` → `**AI Gateway > Agent Control > Approvals**`, and `> MCP Gateway > Audit log` → `> Agent Control > Activity`. Do NOT rename the content file names themselves (mcp-*.ts) or their import paths.
+
+- [ ] **Step 3: Copy changed files to the website repo (per docs workflow)**
+
+The user-guide source of truth is `shared/user-guide-content/`; the website consumes a copy. Per the project docs workflow, copy each changed file to `/Users/gorkemcetin/website/verifywise/content/user-guide/` mirroring its path. List what you changed and copy those exact files. Do NOT commit in the website repo (the user handles that).
+
+```bash
+# Example (adjust to the actual changed files):
+# cp shared/user-guide-content/userGuideConfig.ts /Users/gorkemcetin/website/verifywise/content/user-guide/userGuideConfig.ts
+```
+
+- [ ] **Step 4: Commit (monorepo only)**
+
+```bash
+cd /Users/gorkemcetin/verifywise && git add shared/user-guide-content/ && git commit -m "docs(ai-gateway): update user guide for Agent Control rename"
+```
+
+---
+
+## Task 6: Final verification (build + browser smoke)
+
+- [ ] **Step 1: Build**
+
+```bash
+cd /Users/gorkemcetin/verifywise/Clients && npm run build 2>&1 | tail -15
+```
+Expected: build succeeds.
+
+- [ ] **Step 2: Browser smoke (English)**
+
+With the frontend running (5173) and logged in, navigate to `/ai-gateway/mcp/audit`. Confirm:
+- Sidebar group reads **Agent Control**; items: Agent Keys, MCP Servers, MCP Tools, **Activity**, Approvals, Guardrails.
+- Breadcrumb reads **AI gateway > Agent Control > Activity**.
+- Page header reads **Activity**.
+- Visit `/ai-gateway/mcp/tools` (header **MCP Tools**), `/ai-gateway/mcp/approvals` (**Approvals**), `/ai-gateway/mcp/guardrails` (**Guardrails**).
+
+- [ ] **Step 3: Browser smoke (non-English)**
+
+Switch UI language to German (and spot-check French/Spanish). Confirm the renamed sidebar labels render translated (e.g. **Agentensteuerung**, **Aktivität**) — not the raw English — proving the de/fr/es key updates took effect via the DOM translator.
+
+- [ ] **Step 4 (no commit — verification only).** If anything renders raw English in a non-English UI, the corresponding `translations.ts` key wasn't updated to the new English string — fix in Task 4 and re-verify.
+
+---
+
+## Self-review notes
+
+- **Spec coverage:** sidebar labels → Task 1; breadcrumbs → Task 2; page headers + agent-accurate descriptions → Task 3; full de/fr/es i18n → Task 4; user-guide + website copy → Task 5; build + browser (incl. non-English) → Task 6. All spec sections covered.
+- **i18n mechanism (verified):** components render raw English; `domTranslator.ts` swaps DOM text using English string as key; `en` = `{}`. So renames require updating the de/fr/es **keys** (not just values), which Task 4 does. This is the crux the spec's "translate all 4 languages" decision addresses.
+- **Honesty on branch:** descriptions say "agent tool calls" (true for MCP today), not "native tools like Bash" (only true once Phase 1/2 merge) — per the spec's branch caveat. Fuller native-tool copy is a follow-up after Phase 1/2.
+- **No placeholders:** every string edit shows exact before/after. Line numbers are approximate (file may have shifted); each task includes a grep to locate the current string if a line moved.
+- **Untouched:** routes, API endpoints, component/dir names, `value:`/`id:` fields, `MCP Servers` page title (already MCP), `Agent Keys`/`Approvals`/`Guardrails` sidebar labels.

--- a/docs/superpowers/specs/2026-06-16-agent-control-rename-FOLLOWUP-native-copy.md
+++ b/docs/superpowers/specs/2026-06-16-agent-control-rename-FOLLOWUP-native-copy.md
@@ -55,3 +55,46 @@ mirror per the docs workflow.
 - [ ] Browser: Activity + Guardrails descriptions show the native-tool phrasing (en), and de renders translated.
 - [ ] One commit: `feat(ai-gateway): mention native-tool gating in Agent Control copy`.
 - [ ] Delete this follow-up doc (its job is done).
+
+---
+
+# Follow-up B: translate + humanize the Phase 2/3 UI strings
+
+> **Status:** PENDING — same trigger as above (after Phase 1-3 merge + rename rebase).
+> **Why here:** Phases 1/2/3 added new user-facing strings on their own branches. The
+> i18n + humanizer work ran only on this rename branch (off develop), so it never saw
+> them. After the rebase, this branch is the natural home to translate + humanize them
+> in one i18n pass (it already owns translations.ts and the humanizer discipline).
+> **Failure mode if skipped:** these strings render in English for de/fr/es users
+> (the DOM translator falls back to source) — a polish gap, not a crash.
+
+## Strings with NO de/fr/es keys (add them, translated)
+
+In `Clients/src/presentation/pages/AIGateway/MCPGuardrails/index.tsx` (Phase 2 require_approval UI):
+
+1. `"Require approval"` — the rule-type label (appears at lines ~55 and ~76: RULE_TYPE_ITEMS
+   name + RULE_TYPE_LABELS). One key, used twice.
+2. `"Matching tool calls will be paused and routed to a human approver before execution."`
+   — the require_approval explanatory note (line ~409).
+3. `"No block or mask action is needed — approval is enforced automatically."` (line ~410)
+   — **also fix the em dash** (house style: no em dashes). Suggested humanized form:
+   `"No block or mask action is needed. Approval is enforced automatically."`
+
+Add each to the de/fr/es blocks in `Clients/src/i18n/translations.ts` (keyed on the
+English string, per the DOM-translator). Spanish (es) blocks exist repo-wide already.
+
+## Also re-check: Phase 3 description strings
+
+After the rebase, confirm the file-write descriptions on the merged code match the
+humanized English in translations.ts (the rename branch humanized some of these; Phase 3
+may have its own variants). Grep `translations.ts` for any Phase 3 description key whose
+English no longer appears in a component (stale key) or any component description with no
+key (untranslated). Re-key/translate as needed.
+
+## Apply checklist (Follow-up B)
+- [ ] Add the 3 strings above to de/fr/es in translations.ts (translated).
+- [ ] Fix the em dash on MCPGuardrails line ~410.
+- [ ] Reconcile any Phase 3 description key drift.
+- [ ] `cd Clients && npx tsc --noEmit` clean; `npm run build` passes.
+- [ ] Browser: switch to de, confirm the require_approval note renders translated.
+- [ ] Fold into the same rebase commit/PR as Follow-up A.

--- a/docs/superpowers/specs/2026-06-16-agent-control-rename-FOLLOWUP-native-copy.md
+++ b/docs/superpowers/specs/2026-06-16-agent-control-rename-FOLLOWUP-native-copy.md
@@ -1,0 +1,57 @@
+# Follow-up: upgrade Agent Control copy to mention native tools
+
+> **Status:** PENDING — do NOT apply until the trigger condition is met.
+> **Trigger:** Phase 1/2 (`feat/mcp-bash-hook` + `feat/mcp-hook-approval`) are merged to
+> `develop` AND this rename branch (`feat/agent-control-rename`) has been rebased on top.
+> **Why gated:** The fuller copy claims native-tool (Bash) gating. That capability only
+> exists once Phase 1/2 merge. Applying it before then would make `develop` claim a feature
+> it doesn't have. Until then, the truthful copy is "agent tool calls".
+> **Decision (2026-06-16):** land this as a **one-commit follow-up on the rebased rename
+> branch**, in the same PR as the rebased rename.
+
+This is a mechanical, ~2-minute change: 2 English component strings + their 6 i18n
+values (2 keys × de/fr/es). Exact before/after below — apply verbatim.
+
+## 1. Component strings (English)
+
+`Clients/src/presentation/pages/AIGateway/MCPAuditLog/index.tsx` (~L130):
+- FROM: `description="Every tool call your AI agents make, with outcome, latency, and which agent."`
+- TO:   `description="Every tool call your AI agents make — MCP tools and native tools like Bash — with outcome, latency, and which agent."`
+
+`Clients/src/presentation/pages/AIGateway/MCPGuardrails/index.tsx` (~L299):
+- FROM: `description="Scan agent tool calls for PII, prohibited content, or prompt injection — block or mask matches."`
+- TO:   `description="Scan agent tool calls — MCP and native tools like Bash — for PII, prohibited content, or prompt injection; block or mask matches."`
+
+## 2. i18n re-key (Clients/src/i18n/translations.ts)
+
+The DOM translator keys on the English string, so the KEY must change to the new English
+above in all three language blocks, and the VALUE gets the native-tool mention. Both keys
+currently appear once per de/fr/es block (6 entries total).
+
+**Key A — Activity description** (current key: `"Every tool call your AI agents make, with outcome, latency, and which agent."` → new key = new EN above):
+- de value → `"Jeder Tool-Aufruf Ihrer KI-Agenten — MCP-Tools und native Tools wie Bash — mit Ergebnis, Latenz und ausführendem Agenten."`
+- fr value → `"Chaque appel d'outil effectué par vos agents IA — outils MCP et outils natifs comme Bash — avec le résultat, la latence et l'agent concerné."`
+- es value → `"Cada llamada a herramienta que hacen sus agentes de IA — herramientas MCP y herramientas nativas como Bash — con el resultado, la latencia y qué agente."`
+
+**Key B — Guardrails description** (current key: `"Scan agent tool calls for PII, prohibited content, or prompt injection — block or mask matches."` → new key = new EN above):
+- de value → `"Durchsuchen Sie Agent-Tool-Aufrufe — MCP und native Tools wie Bash — nach PII, unzulässigen Inhalten oder Prompt-Injection; Treffer blockieren oder maskieren."`
+- fr value → `"Analysez les appels d'outils des agents — MCP et outils natifs comme Bash — à la recherche de données personnelles, de contenu interdit ou d'injection de prompt ; bloquez ou masquez les correspondances."`
+- es value → `"Analice las llamadas a herramientas de los agentes — MCP y herramientas nativas como Bash — en busca de PII, contenido prohibido o inyección de prompts; bloquee o enmascare las coincidencias."`
+
+(Translations are machine-generated, not native-reviewed — same caveat as the rename i18n.)
+
+## 3. Optional: user-guide native-tool mention
+
+Once Phase 1/2 are in, the Activity user-guide article (`shared/user-guide-content/content/ai-gateway/mcp-audit.ts`)
+and the overview may mention that Activity covers native tools (Bash), not just MCP. Lower
+priority; the descriptions above are the load-bearing copy. If updated, copy to the website
+mirror per the docs workflow.
+
+## Apply checklist (when triggered)
+- [ ] Confirm Phase 1/2 merged to develop and this branch rebased on top.
+- [ ] Edit the 2 component strings (§1).
+- [ ] Re-key + re-translate the 2 i18n keys × 3 languages (§2).
+- [ ] `cd Clients && npx tsc --noEmit` clean for translations.ts; `npm run build` passes.
+- [ ] Browser: Activity + Guardrails descriptions show the native-tool phrasing (en), and de renders translated.
+- [ ] One commit: `feat(ai-gateway): mention native-tool gating in Agent Control copy`.
+- [ ] Delete this follow-up doc (its job is done).

--- a/docs/superpowers/specs/2026-06-16-agent-control-rename-design.md
+++ b/docs/superpowers/specs/2026-06-16-agent-control-rename-design.md
@@ -1,0 +1,107 @@
+# Rename "MCP Gateway" → "Agent Control" (UI re-framing)
+
+> **Status:** Design approved 2026-06-16
+> **Type:** Frontend display-string rename + docs. No backend, no routes, no schema.
+> **Branch:** (to be created) `feat/agent-control-rename`
+
+## Goal
+
+Re-frame the AI Gateway's "MCP Gateway" UI section as **Agent Control** so the UI
+expresses what it actually does — govern and observe **what AI agents do** (tool calls,
+both MCP-proxied and native) — rather than naming itself after a protocol (MCP) and a
+mechanism (gateway). This corrects an existing misnomer: half of the section (the
+Phase 1/2 native-hook work) governs non-MCP tools like Bash, yet it is filed under "MCP."
+
+## Why this is honest (technical basis)
+
+Verified in code. The section governs **two** agent entry paths that share **one**
+governance layer (same `sk-mcp-*` identity, same guardrail scan, same approval flow,
+same audit log, same rate limiter):
+
+| Path | Endpoint | MCP? |
+|---|---|---|
+| MCP proxy — forwards JSON-RPC to a registered MCP server | `POST /v1/mcp` | Yes |
+| Native hook — adjudicates the agent's own built-in tool (Bash/Edit/Write), never forwards | `POST /v1/mcp/hook` | **No** |
+
+"Agent Control" names that shared control plane. MCP is one of two doors into it.
+
+**The product distinction the rename encodes:**
+- **AI Gateway** governs *model calls* (completions, spend, budgets) — what the AI **says**. The LLM-completions proxy (`/v1/chat/completions`, `sk-vw-*` virtual keys) stays here, untouched.
+- **Agent Control** (inside AI Gateway) governs *agent actions* (tool calls, MCP + native) — what the AI **does**.
+
+## Label map (locked)
+
+| Current | New | Decision |
+|---|---|---|
+| **MCP Gateway** (sidebar group) | **Agent Control** | Names the job, not the protocol |
+| **Audit Log** | **Activity** | It is a live observability dashboard (stats, latency charts, per-agent stream), not a passive log |
+| Agent Keys | **Agent Keys** *(unchanged)* | Screen mints/revokes credentials; "Agents" would over-claim an agent registry (status/last-seen/history) that does not exist |
+| Guardrails | **Guardrails** *(unchanged)* | Industry-standard term; matches the existing LLM "Guardrails" screen — renaming only this one would create two words for one concept |
+| Approvals | **Approvals** *(unchanged)* | Already accurate |
+| Servers | **MCP Servers** | Genuinely an MCP-protocol concept — keep "MCP" |
+| Tools | **MCP Tools** | Genuinely an MCP-protocol concept — keep "MCP" |
+
+Sidebar stays a **flat list** under "Agent Control" (no structural change); Servers/Tools
+carry "MCP" in their label.
+
+## Scope
+
+**In scope (display strings + docs):**
+1. Sidebar group name + the two changed item labels + the two MCP-prefixed labels.
+2. Page headers + descriptions for all six pages — rewritten **agent-accurate**: say "agent"/"agent actions" where it means agent behaviour, keep "MCP" only where it means the protocol (Servers, Tools).
+3. Breadcrumb labels (`routeMapping.ts`).
+4. i18n: **all four languages** (en/de/fr/es) for every changed string.
+5. User-guide content: section title + in-prose breadcrumb references, copied to the website repo per the docs workflow.
+
+**Explicitly out of scope (unchanged):**
+- Route paths `/ai-gateway/mcp/*` and all API endpoints — no broken links/bookmarks, no backend change.
+- Component/directory names (`MCPAuditLog/`, `MCPGuardrails/`, etc.) and all variable/type names — internal only; users never see them.
+- The far-left dark-sidebar module label ("AI Gateway") — promoting Agent Control to a top-level module is a separate, larger product decision.
+- An Agent Control overview/landing page — noted as a future gap, not built here.
+- The LLM-completions proxy and the LLM Guardrails screen — different traffic (model calls).
+
+## Files to change (display strings)
+
+| File | What |
+|---|---|
+| `Clients/src/presentation/pages/AIGateway/AIGatewaySidebar.tsx` | group `"MCP Gateway"`→`"Agent Control"` (L98); `"Audit Log"`→`"Activity"` (L122); `"Servers"`→`"MCP Servers"` (L110); `"Tools"`→`"MCP Tools"` (L116) |
+| `Clients/src/presentation/components/breadcrumbs/routeMapping.ts` | `/ai-gateway/mcp` label `"MCP Gateway"`→`"Agent Control"` (L154); `/ai-gateway/mcp/audit` `"Audit log"`→`"Activity"` (L158); servers/tools labels gain "MCP" (L156/157) |
+| `.../AIGateway/MCPAuditLog/index.tsx` | title `"MCP Audit Log"`→`"Activity"`; description → agent-accurate (e.g. "Every action your AI agents take, with outcome and latency.") (L129) |
+| `.../AIGateway/MCPServers/index.tsx` | title stays `"MCP Servers"`; description unchanged (already MCP-accurate) (L205) |
+| `.../AIGateway/MCPToolCatalog/index.tsx` | title `"MCP Tool Catalog"`→`"MCP Tools"`; description unchanged (L258) |
+| `.../AIGateway/MCPApprovals/index.tsx` | title `"MCP Approvals"`→`"Approvals"`; description → "Approve or deny agent actions before they run." (L127) |
+| `.../AIGateway/MCPGuardrails/index.tsx` | title `"MCP Guardrails"`→`"Guardrails"`; description → "Scan agent tool calls for PII, prohibited content, or prompt injection; block, mask, or require approval." (L308); empty-state copy (L329) |
+| `.../AIGateway/MCPAgentKeys/index.tsx` | title stays `"Agent keys"`; description may keep MCP-server reference where accurate (L477) |
+| `Clients/src/i18n/translations.ts` | all of the above strings in en/de/fr/es (group name L3894; menu labels L1903-1907; descriptions/empty-states L2463-3032 and their de/fr/es mirrors) |
+| `shared/user-guide-content/userGuideConfig.ts` + `content/ai-gateway/mcp-*.ts` | `"MCP Gateway overview"` section title; in-prose "AI Gateway > MCP Gateway > …" breadcrumb references → "Agent Control"; copy changed files to the website repo |
+
+## Page copy direction (agent-accurate)
+
+Rewrite descriptions so the noun matches the meaning:
+- **Activity** (was MCP Audit Log): "Every action your AI agents take — MCP tools and native tools like Bash — with outcome, latency, and which agent."
+- **Approvals**: "Review and decide on agent actions that require human approval before they run."
+- **Guardrails**: "Scan agent tool calls for PII, prohibited content, or prompt injection — block, mask, or require approval."
+- **MCP Servers / MCP Tools**: keep MCP-protocol language (these are genuinely MCP).
+- **Agent Keys**: identity/auth language; may reference MCP servers where the key scopes MCP tool access.
+
+## i18n note (known risk)
+
+de/fr/es strings for the renamed labels and rewritten descriptions will be updated in
+this pass. **Caveat:** these translations are produced without a native reviewer, so the
+non-English copy is best-effort and should be flagged for a later native-speaker pass.
+English (en) is authoritative.
+
+## Testing
+
+- `cd Clients && npx tsc --noEmit` clean (string-only changes shouldn't affect types, but a stray key typo in `translations.ts` can).
+- Browser smoke: sidebar shows "Agent Control" with items Agent Keys / MCP Servers / MCP Tools / Activity / Approvals / Guardrails; breadcrumb on `/ai-gateway/mcp/audit` reads "AI gateway > Agent Control > Activity"; each page header matches its new label.
+- Switch UI language to de/fr/es and confirm the renamed labels render (no missing-key fallbacks).
+- `cd Clients && npm run build` succeeds.
+
+## Out-of-scope follow-ups (noted, not built)
+
+- Agent Control overview/landing (counts: active agents, pending approvals, blocked-today, recent activity).
+- Surfacing the native-tool differentiator in on-screen copy beyond descriptions.
+- Aligning internal component/dir names with the new vocabulary (cosmetic refactor).
+- Native-speaker i18n review.
+- Promoting Agent Control to a top-level dark-sidebar module.

--- a/docs/superpowers/specs/2026-06-16-agent-control-rename-design.md
+++ b/docs/superpowers/specs/2026-06-16-agent-control-rename-design.md
@@ -91,6 +91,24 @@ this pass. **Caveat:** these translations are produced without a native reviewer
 non-English copy is best-effort and should be flagged for a later native-speaker pass.
 English (en) is authoritative.
 
+## Branch / merge ordering (important)
+
+This spec is branched off `develop`, which does **not** yet contain the Phase 1/2
+agentic work (`feat/mcp-bash-hook`, `feat/mcp-hook-approval` — both unmerged). Two
+consequences:
+
+1. **`MCPGuardrails/index.tsx` overlaps.** Phase 2 added the `require_approval` rule
+   type to that file; this rename touches its title/description/empty-state. Whichever
+   merges second must reconcile both. **Recommended order:** merge the Phase 1/2 branches
+   first, then rebase this rename branch on top so the Guardrails page already has the
+   `require_approval` UI when the rename copy lands. If this rename merges first, the
+   Phase 2 branch's edits to the same file will need a manual merge.
+2. **Description accuracy depends on Phase 1/2.** The agent-accurate copy (e.g. "MCP tools
+   **and native tools like Bash**") describes the native-hook capability that only exists
+   once Phase 1/2 ship. If this rename ships to `develop` before them, soften those
+   descriptions to not promise native-tool gating that isn't live yet, or hold the rename
+   until Phase 1/2 merge. Simplest: **gate this rename's merge on Phase 1/2 being merged.**
+
 ## Testing
 
 - `cd Clients && npx tsc --noEmit` clean (string-only changes shouldn't affect types, but a stray key typo in `translations.ts` can).

--- a/shared/user-guide-content/content/ai-gateway/mcp-agent-keys.ts
+++ b/shared/user-guide-content/content/ai-gateway/mcp-agent-keys.ts
@@ -10,7 +10,7 @@ export const mcpAgentKeysContent: ArticleContent = {
     },
     {
       type: 'paragraph',
-      text: 'Agent keys are scoped API keys that AI agents use to authenticate with the MCP Gateway. Each key controls which tools the agent can call, how fast it can call them, and when the key expires.',
+      text: 'Agent keys are scoped API keys that AI agents use to authenticate with the MCP Gateway. Each key controls which tools the agent can call, how fast it can call them and when the key expires.',
     },
     {
       type: 'paragraph',
@@ -34,7 +34,7 @@ export const mcpAgentKeysContent: ArticleContent = {
       type: 'bullet-list',
       items: [
         { bold: 'Name', text: 'The display name you gave the key.' },
-        { bold: 'Status chip', text: '"Active", "Revoked", "Expired", or "Inactive".' },
+        { bold: 'Status chip', text: '"Active", "Revoked", "Expired" or "Inactive".' },
         { bold: 'Key prefix', text: 'The first characters of the key in monospace font. The full key is never shown again after creation.' },
         { bold: 'Rate limit', text: 'Shown as RPM (requests per minute) if configured.' },
         { bold: 'Allowed/blocked tools', text: 'Chip showing the count of allowed or blocked tools, if any are configured.' },

--- a/shared/user-guide-content/content/ai-gateway/mcp-agent-keys.ts
+++ b/shared/user-guide-content/content/ai-gateway/mcp-agent-keys.ts
@@ -14,7 +14,7 @@ export const mcpAgentKeysContent: ArticleContent = {
     },
     {
       type: 'paragraph',
-      text: 'You\'ll find them at **AI Gateway > MCP Gateway > Agent keys**.',
+      text: 'You\'ll find them at **AI Gateway > Agent Control > Agent keys**.',
     },
     {
       type: 'paragraph',
@@ -238,13 +238,13 @@ curl -X POST https://your-verifywise-host/v1/mcp \\
         {
           collectionId: 'ai-gateway',
           articleId: 'mcp-overview',
-          title: 'MCP Gateway overview',
+          title: 'Agent Control overview',
           description: 'Understand the full gateway architecture and request flow.',
         },
         {
           collectionId: 'ai-gateway',
           articleId: 'mcp-audit',
-          title: 'Audit log',
+          title: 'Activity',
           description: 'See every tool call made with each agent key.',
         },
         {

--- a/shared/user-guide-content/content/ai-gateway/mcp-agent-keys.ts
+++ b/shared/user-guide-content/content/ai-gateway/mcp-agent-keys.ts
@@ -250,7 +250,7 @@ curl -X POST https://your-verifywise-host/v1/mcp \\
         {
           collectionId: 'ai-gateway',
           articleId: 'mcp-tools',
-          title: 'Tool catalog',
+          title: 'MCP Tools',
           description: 'View the tools that agent keys grant access to.',
         },
       ],

--- a/shared/user-guide-content/content/ai-gateway/mcp-approvals.ts
+++ b/shared/user-guide-content/content/ai-gateway/mcp-approvals.ts
@@ -145,7 +145,7 @@ export const mcpApprovalsContent: ArticleContent = {
       type: 'ordered-list',
       items: [
         { text: 'The agent sends a `tools/call` request to `POST /v1/mcp`.' },
-        { text: 'The gateway returns a JSON-RPC error with code `-32001` and a data payload containing the `approval_id`, `poll_endpoint`, and `expires_at`.' },
+        { text: 'The gateway returns a JSON-RPC error with code `-32001` and a data payload containing the `approval_id`, `poll_endpoint` and `expires_at`.' },
         { text: 'The agent polls `GET /v1/mcp/approvals/{approval_id}/status` periodically to check if the request was approved.' },
         { text: 'Once the status is "approved", the agent retries the original `tools/call` request.' },
         { text: 'If the status is "denied" or "expired", the agent handles the rejection.' },

--- a/shared/user-guide-content/content/ai-gateway/mcp-approvals.ts
+++ b/shared/user-guide-content/content/ai-gateway/mcp-approvals.ts
@@ -14,7 +14,7 @@ export const mcpApprovalsContent: ArticleContent = {
     },
     {
       type: 'paragraph',
-      text: 'You\'ll find it at **AI Gateway > MCP Gateway > Approvals**.',
+      text: 'You\'ll find it at **AI Gateway > Agent Control > Approvals**.',
     },
     {
       type: 'heading',
@@ -206,13 +206,13 @@ export const mcpApprovalsContent: ArticleContent = {
         {
           collectionId: 'ai-gateway',
           articleId: 'mcp-audit',
-          title: 'Audit log',
+          title: 'Activity',
           description: 'See approval_required entries in the audit trail.',
         },
         {
           collectionId: 'ai-gateway',
           articleId: 'mcp-overview',
-          title: 'MCP Gateway overview',
+          title: 'Agent Control overview',
           description: 'Understand the full request flow including the approval step.',
         },
       ],

--- a/shared/user-guide-content/content/ai-gateway/mcp-approvals.ts
+++ b/shared/user-guide-content/content/ai-gateway/mcp-approvals.ts
@@ -200,7 +200,7 @@ export const mcpApprovalsContent: ArticleContent = {
         {
           collectionId: 'ai-gateway',
           articleId: 'mcp-tools',
-          title: 'Tool catalog',
+          title: 'MCP Tools',
           description: 'Enable approval requirements on specific tools.',
         },
         {

--- a/shared/user-guide-content/content/ai-gateway/mcp-audit.ts
+++ b/shared/user-guide-content/content/ai-gateway/mcp-audit.ts
@@ -10,7 +10,7 @@ export const mcpAuditContent: ArticleContent = {
     },
     {
       type: 'paragraph',
-      text: 'The Audit Log records every tool call that flows through the MCP Gateway. It\'s your compliance trail for agent activity: what was called, who called it, whether it succeeded, and how long it took.',
+      text: 'The Audit Log records every tool call that flows through the MCP Gateway. It\'s your compliance trail for agent activity: what was called, who called it, whether it succeeded and how long it took.',
     },
     {
       type: 'paragraph',
@@ -104,7 +104,7 @@ export const mcpAuditContent: ArticleContent = {
       ],
       rows: [
         { field: 'Tool name', description: 'The name of the tool that was called, in monospace font.' },
-        { field: 'Status', description: 'Color-coded chip showing the outcome: success, error, blocked, rate_limited, or approval_required.' },
+        { field: 'Status', description: 'Color-coded chip showing the outcome: success, error, blocked, rate_limited or approval_required.' },
         { field: 'Latency', description: 'Round-trip time in milliseconds.' },
         { field: 'Result summary', description: 'A truncated summary of the tool\'s response (up to 500 characters). Shows a dash if no summary is available.' },
         { field: 'Agent key', description: 'The name of the agent key that made the call.' },
@@ -145,7 +145,7 @@ export const mcpAuditContent: ArticleContent = {
       type: 'bullet-list',
       items: [
         { bold: 'Filter by tool', text: 'Text field. Type a tool name (e.g., "greet") to show only calls to that tool.' },
-        { bold: 'Status', text: 'Dropdown to filter by result status: All statuses, Success, Error, Blocked, or Rate limited.' },
+        { bold: 'Status', text: 'Dropdown to filter by result status: All statuses, Success, Error, Blocked or Rate limited.' },
       ],
     },
     {
@@ -237,7 +237,7 @@ export const mcpAuditContent: ArticleContent = {
         { text: 'What was called (tool name and arguments)' },
         { text: 'When it happened (timestamp)' },
         { text: 'What happened (status, result summary, latency)' },
-        { text: 'Whether it was blocked, rate-limited, or required approval' },
+        { text: 'Whether it was blocked, rate-limited or required approval' },
       ],
     },
     {

--- a/shared/user-guide-content/content/ai-gateway/mcp-audit.ts
+++ b/shared/user-guide-content/content/ai-gateway/mcp-audit.ts
@@ -14,7 +14,7 @@ export const mcpAuditContent: ArticleContent = {
     },
     {
       type: 'paragraph',
-      text: 'You\'ll find it at **AI Gateway > MCP Gateway > Audit log**.',
+      text: 'You\'ll find it at **AI Gateway > Agent Control > Activity**.',
     },
     {
       type: 'heading',

--- a/shared/user-guide-content/content/ai-gateway/mcp-guardrails.ts
+++ b/shared/user-guide-content/content/ai-gateway/mcp-guardrails.ts
@@ -10,7 +10,7 @@ export const mcpGuardrailsContent: ArticleContent = {
     },
     {
       type: 'paragraph',
-      text: 'MCP Guardrails scan tool inputs before the gateway forwards them to the backend server. They catch PII, prohibited content, and prompt injection attempts before they reach your tools.',
+      text: 'MCP Guardrails scan tool inputs before the gateway forwards them to the backend server. They catch PII, prohibited content and prompt injection attempts before they reach your tools.',
     },
     {
       type: 'paragraph',
@@ -38,7 +38,7 @@ export const mcpGuardrailsContent: ArticleContent = {
       type: 'bullet-list',
       items: [
         { bold: 'Name', text: 'The name you gave the rule.' },
-        { bold: 'Rule type chip', text: 'Shows "PII", "Content filter", or "Prompt injection" with a color-coded badge.' },
+        { bold: 'Rule type chip', text: 'Shows "PII", "Content filter" or "Prompt injection" with a color-coded badge.' },
         { bold: 'Action chip', text: 'Shows "Block" or "Mask".' },
         { bold: 'Scope', text: 'Where the rule applies (currently "tool_input").' },
         { bold: 'Tool scope', text: 'Either "Applies to all tools" or a list of specific tool names.' },
@@ -69,7 +69,7 @@ export const mcpGuardrailsContent: ArticleContent = {
       ],
       rows: [
         { type: 'PII detection', chip: 'Blue (info)', description: 'Scans tool inputs for personal identifiable information: email addresses, phone numbers, credit card numbers, SSNs, etc. Uses Presidio-based detection.' },
-        { type: 'Content filter', chip: 'Amber (warning)', description: 'Checks tool inputs against a list of keywords or regex patterns that you define. Useful for blocking profanity, competitor names, or domain-specific terms.' },
+        { type: 'Content filter', chip: 'Amber (warning)', description: 'Checks tool inputs against a list of keywords or regex patterns that you define. Useful for blocking profanity, competitor names or domain-specific terms.' },
         { type: 'Prompt injection', chip: 'Green (success)', description: 'Detects attempts to manipulate the tool\'s behavior through injected instructions in the input data.' },
       ],
     },
@@ -115,7 +115,7 @@ export const mcpGuardrailsContent: ArticleContent = {
       ],
       rows: [
         { field: 'Name', required: 'Yes', description: 'A descriptive name for the rule (e.g., "Block PII in database queries"). Max 255 characters.' },
-        { field: 'Rule type', required: 'Yes', description: 'Select PII detection, Content filter, or Prompt injection.' },
+        { field: 'Rule type', required: 'Yes', description: 'Select PII detection, Content filter or Prompt injection.' },
         { field: 'Action', required: 'Yes', description: 'Select Block or Mask.' },
         { field: 'Scope', required: 'Yes', description: 'Where to apply the rule. Currently only "Tool input" is available.' },
         { field: 'Applies to tools', required: 'No', description: 'Comma-separated tool names. Leave empty to apply to all MCP tools.' },
@@ -271,7 +271,7 @@ export const mcpGuardrailsContent: ArticleContent = {
       items: [
         { bold: 'Scan tool inputs before execution', text: 'Rules are evaluated against tool input data before the tool runs.' },
         { bold: 'Scope rules to specific tools', text: 'Apply guardrails globally or restrict to specific MCP tools.' },
-        { bold: 'Multiple rule types', text: 'Choose from PII detection, content filtering, or prompt injection detection.' },
+        { bold: 'Multiple rule types', text: 'Choose from PII detection, content filtering or prompt injection detection.' },
       ],
     },
     {

--- a/shared/user-guide-content/content/ai-gateway/mcp-guardrails.ts
+++ b/shared/user-guide-content/content/ai-gateway/mcp-guardrails.ts
@@ -14,7 +14,7 @@ export const mcpGuardrailsContent: ArticleContent = {
     },
     {
       type: 'paragraph',
-      text: 'You\'ll find them at **AI Gateway > MCP Gateway > Guardrails**.',
+      text: 'You\'ll find them at **AI Gateway > Agent Control > Guardrails**.',
     },
     {
       type: 'paragraph',
@@ -291,7 +291,7 @@ export const mcpGuardrailsContent: ArticleContent = {
         {
           collectionId: 'ai-gateway',
           articleId: 'mcp-audit',
-          title: 'Audit log',
+          title: 'Activity',
           description: 'Blocked tool calls appear in the audit trail with "blocked" status.',
         },
         {

--- a/shared/user-guide-content/content/ai-gateway/mcp-guardrails.ts
+++ b/shared/user-guide-content/content/ai-gateway/mcp-guardrails.ts
@@ -297,7 +297,7 @@ export const mcpGuardrailsContent: ArticleContent = {
         {
           collectionId: 'ai-gateway',
           articleId: 'mcp-tools',
-          title: 'Tool catalog',
+          title: 'MCP Tools',
           description: 'View which tools your guardrails apply to.',
         },
         {

--- a/shared/user-guide-content/content/ai-gateway/mcp-overview.ts
+++ b/shared/user-guide-content/content/ai-gateway/mcp-overview.ts
@@ -117,7 +117,7 @@ export const mcpOverviewContent: ArticleContent = {
     {
       type: 'ordered-list',
       items: [
-        { text: 'Register an MCP server in **AI Gateway > MCP Gateway > Servers**.' },
+        { text: 'Register an MCP server in **AI Gateway > Agent Control > MCP Servers**.' },
         { text: 'Wait for tool discovery (or trigger it manually once available).' },
         { text: 'Review discovered tools in the **Tools** page. Set risk levels and approval requirements.' },
         { text: 'Create an agent key in **Agent keys**. Scope it to the tools the agent needs.' },
@@ -156,15 +156,15 @@ export const mcpOverviewContent: ArticleContent = {
     },
     {
       type: 'paragraph',
-      text: 'The MCP Gateway section appears as a collapsible group in the AI Gateway sidebar. Click "MCP Gateway" to expand it. You\'ll see six sub-pages:',
+      text: 'The Agent Control section appears as a collapsible group in the AI Gateway sidebar. Click "Agent Control" to expand it. You\'ll see six sub-pages:',
     },
     {
       type: 'bullet-list',
       items: [
         { bold: 'Agent keys', text: 'Create and manage API keys for agents' },
         { bold: 'Servers', text: 'Register and monitor backend MCP servers' },
-        { bold: 'Tools', text: 'View all discovered tools, set risk levels' },
-        { bold: 'Audit log', text: 'Review tool invocation history and stats' },
+        { bold: 'MCP Tools', text: 'View all discovered tools, set risk levels' },
+        { bold: 'Activity', text: 'Review tool invocation history and stats' },
         { bold: 'Approvals', text: 'Approve or deny pending tool calls' },
         { bold: 'Guardrails', text: 'Configure input scanning rules' },
       ],

--- a/shared/user-guide-content/content/ai-gateway/mcp-overview.ts
+++ b/shared/user-guide-content/content/ai-gateway/mcp-overview.ts
@@ -59,7 +59,7 @@ export const mcpOverviewContent: ArticleContent = {
           icon: 'Server',
         },
         {
-          title: 'Tool catalog',
+          title: 'MCP Tools',
           description: 'All discovered tools across your servers, with risk levels and approval requirements you can configure per tool.',
           icon: 'Wrench',
         },
@@ -119,7 +119,7 @@ export const mcpOverviewContent: ArticleContent = {
       items: [
         { text: 'Register an MCP server in **AI Gateway > Agent Control > MCP Servers**.' },
         { text: 'Wait for tool discovery (or trigger it manually once available).' },
-        { text: 'Review discovered tools in the **Tools** page. Set risk levels and approval requirements.' },
+        { text: 'Review discovered tools in the **MCP Tools** page. Set risk levels and approval requirements.' },
         { text: 'Create an agent key in **Agent keys**. Scope it to the tools the agent needs.' },
         { text: 'Point your agent at `POST /v1/mcp` with the key as a Bearer token.' },
       ],
@@ -188,7 +188,7 @@ export const mcpOverviewContent: ArticleContent = {
         {
           collectionId: 'ai-gateway',
           articleId: 'mcp-tools',
-          title: 'Tool catalog',
+          title: 'MCP Tools',
           description: 'Browse discovered tools and configure risk levels.',
         },
       ],

--- a/shared/user-guide-content/content/ai-gateway/mcp-overview.ts
+++ b/shared/user-guide-content/content/ai-gateway/mcp-overview.ts
@@ -14,7 +14,7 @@ export const mcpOverviewContent: ArticleContent = {
     },
     {
       type: 'paragraph',
-      text: 'Without a gateway, agents connect directly to MCP servers. That means no central visibility into what tools they\'re calling, no way to block sensitive operations and no audit log. The MCP Gateway solves all three.',
+      text: 'Without a gateway, agents connect directly to MCP servers. That means no central view of what tools they\'re calling, no way to block sensitive operations and no audit log. The MCP Gateway closes all three gaps.',
     },
     {
       type: 'heading',
@@ -55,7 +55,7 @@ export const mcpOverviewContent: ArticleContent = {
       items: [
         {
           title: 'MCP servers',
-          description: 'Backend servers that expose tools (database queries, file operations, search, etc.). You register them in VerifyWise with their URL and auth credentials.',
+          description: 'Backend servers that expose tools (database queries, file operations, search and so on). You register them in VerifyWise with their URL and auth credentials.',
           icon: 'Server',
         },
         {
@@ -70,7 +70,7 @@ export const mcpOverviewContent: ArticleContent = {
         },
         {
           title: 'Guardrails',
-          description: 'Rules that scan tool inputs before execution. Detect PII, filter prohibited content, or block prompt injection attempts.',
+          description: 'Rules that scan tool inputs before execution. Detect PII, filter prohibited content or block prompt injection attempts.',
           icon: 'Shield',
         },
         {
@@ -93,7 +93,7 @@ export const mcpOverviewContent: ArticleContent = {
     },
     {
       type: 'paragraph',
-      text: 'If your organization runs AI agents that call external tools, you need governance around those calls. The MCP Gateway is built for:',
+      text: 'If your organization runs AI agents that call external tools, you need governance around those calls. The MCP Gateway is for:',
     },
     {
       type: 'bullet-list',

--- a/shared/user-guide-content/content/ai-gateway/mcp-servers.ts
+++ b/shared/user-guide-content/content/ai-gateway/mcp-servers.ts
@@ -14,7 +14,7 @@ export const mcpServersContent: ArticleContent = {
     },
     {
       type: 'paragraph',
-      text: 'You\'ll find it at **AI Gateway > MCP Gateway > Servers**.',
+      text: 'You\'ll find it at **AI Gateway > Agent Control > MCP Servers**.',
     },
     {
       type: 'heading',
@@ -245,7 +245,7 @@ export const mcpServersContent: ArticleContent = {
         {
           collectionId: 'ai-gateway',
           articleId: 'mcp-overview',
-          title: 'MCP Gateway overview',
+          title: 'Agent Control overview',
           description: 'Understand how the gateway proxies agent-to-server communication.',
         },
       ],

--- a/shared/user-guide-content/content/ai-gateway/mcp-servers.ts
+++ b/shared/user-guide-content/content/ai-gateway/mcp-servers.ts
@@ -10,7 +10,7 @@ export const mcpServersContent: ArticleContent = {
     },
     {
       type: 'paragraph',
-      text: 'The Servers page is where you register the backend MCP servers that your AI agents will call through the gateway. Each server exposes one or more tools (database queries, search, file operations, etc.) that agents can discover and invoke.',
+      text: 'The Servers page is where you register the backend MCP servers that your AI agents call through the gateway. Each server exposes one or more tools (database queries, search, file operations and so on) that agents can discover and invoke.',
     },
     {
       type: 'paragraph',
@@ -30,10 +30,10 @@ export const mcpServersContent: ArticleContent = {
       type: 'bullet-list',
       items: [
         { bold: 'Server name', text: 'The display name you gave the server.' },
-        { bold: 'Health status', text: 'A color-coded chip: green for "Healthy", red for "Unhealthy", or gray for "Unknown".' },
+        { bold: 'Health status', text: 'A color-coded chip: green for "Healthy", red for "Unhealthy" or gray for "Unknown".' },
         { bold: 'Tool count', text: 'How many tools have been discovered on this server.' },
         { bold: 'URL', text: 'The server\'s endpoint URL.' },
-        { bold: 'Auth type', text: 'Shows "no auth", "bearer", or "api_key".' },
+        { bold: 'Auth type', text: 'Shows "no auth", "bearer" or "api_key".' },
         { bold: 'Slug', text: 'The URL-safe identifier, shown as a path segment (e.g., /my-server).' },
         { bold: 'Created by', text: 'The user who registered the server and the date.' },
       ],
@@ -64,7 +64,7 @@ export const mcpServersContent: ArticleContent = {
         { field: 'Slug', required: 'Yes', description: 'Auto-generated from the name. Lowercase letters, digits and hyphens only. Must start with a letter or digit. Can\'t be changed after creation.' },
         { field: 'URL', required: 'Yes', description: 'The full URL of the MCP server (e.g., https://mcp-server.example.com).' },
         { field: 'Description', required: 'No', description: 'A short note about what this server does (e.g., "Exposes search and retrieval tools").' },
-        { field: 'Authentication', required: 'No', description: 'How the gateway authenticates with this server. Options: None (default), Bearer token, or API key.' },
+        { field: 'Authentication', required: 'No', description: 'How the gateway authenticates with this server. Options: None (default), Bearer token or API key.' },
       ],
     },
     {

--- a/shared/user-guide-content/content/ai-gateway/mcp-servers.ts
+++ b/shared/user-guide-content/content/ai-gateway/mcp-servers.ts
@@ -233,7 +233,7 @@ export const mcpServersContent: ArticleContent = {
         {
           collectionId: 'ai-gateway',
           articleId: 'mcp-tools',
-          title: 'Tool catalog',
+          title: 'MCP Tools',
           description: 'View and manage discovered tools across your servers.',
         },
         {

--- a/shared/user-guide-content/content/ai-gateway/mcp-tools.ts
+++ b/shared/user-guide-content/content/ai-gateway/mcp-tools.ts
@@ -10,7 +10,7 @@ export const mcpToolsContent: ArticleContent = {
     },
     {
       type: 'paragraph',
-      text: 'The Tool Catalog shows every MCP tool discovered across all your registered servers. It\'s the central place to see what your agents can do, assign risk levels, and decide which tools need human approval before execution.',
+      text: 'The Tool Catalog shows every MCP tool discovered across your registered servers. It\'s where you see what your agents can do, assign risk levels and decide which tools need human approval before execution.',
     },
     {
       type: 'paragraph',
@@ -55,7 +55,7 @@ export const mcpToolsContent: ArticleContent = {
     },
     {
       type: 'paragraph',
-      text: 'Filters work together. Select both a server and a risk level to narrow down to exactly the tools you\'re looking for.',
+      text: 'Filters work together. Select both a server and a risk level to narrow down to exactly the tools you want.',
     },
     {
       type: 'heading',
@@ -77,7 +77,7 @@ export const mcpToolsContent: ArticleContent = {
       rows: [
         { level: 'Low', color: 'Green', when: 'Read-only tools that don\'t access sensitive data. Examples: search, get_weather, list_items.' },
         { level: 'Medium', color: 'Amber', when: 'Tools that modify data or access internal systems. Examples: update_record, send_email, create_ticket.' },
-        { level: 'High', color: 'Red', when: 'Tools that delete data, access PII, or perform irreversible actions. Examples: delete_record, drop_table, transfer_funds.' },
+        { level: 'High', color: 'Red', when: 'Tools that delete data, access PII or perform irreversible actions. Examples: delete_record, drop_table, transfer_funds.' },
       ],
     },
     {
@@ -106,7 +106,7 @@ export const mcpToolsContent: ArticleContent = {
     },
     {
       type: 'paragraph',
-      text: 'You can toggle approval on and off directly from the tool list using the toggle, or from the edit modal.',
+      text: 'You can toggle approval on and off directly from the tool list, or change it from the edit modal.',
     },
     {
       type: 'callout',
@@ -127,8 +127,8 @@ export const mcpToolsContent: ArticleContent = {
     {
       type: 'bullet-list',
       items: [
-        { bold: 'Tool info box', text: 'Read-only section showing the tool name, description, and which server it belongs to.' },
-        { bold: 'Risk level', text: 'Dropdown to select low, medium, or high.' },
+        { bold: 'Tool info box', text: 'Read-only section showing the tool name, description and which server it belongs to.' },
+        { bold: 'Risk level', text: 'Dropdown to select low, medium or high.' },
         { bold: 'Requires approval', text: 'Toggle with a description: "When enabled, tool invocations must be approved before execution."' },
       ],
     },
@@ -144,7 +144,7 @@ export const mcpToolsContent: ArticleContent = {
     },
     {
       type: 'paragraph',
-      text: 'Tools appear in the catalog after the gateway runs tool discovery on a registered server. Discovery calls the server\'s `tools/list` MCP method and stores each tool with its name, description, and input schema.',
+      text: 'Tools appear in the catalog after the gateway runs tool discovery on a registered server. Discovery calls the server\'s `tools/list` MCP method and stores each tool with its name, description and input schema.',
     },
     {
       type: 'paragraph',

--- a/shared/user-guide-content/content/ai-gateway/mcp-tools.ts
+++ b/shared/user-guide-content/content/ai-gateway/mcp-tools.ts
@@ -14,7 +14,7 @@ export const mcpToolsContent: ArticleContent = {
     },
     {
       type: 'paragraph',
-      text: 'You\'ll find it at **AI Gateway > MCP Gateway > Tools**.',
+      text: 'You\'ll find it at **AI Gateway > Agent Control > MCP Tools**.',
     },
     {
       type: 'heading',

--- a/shared/user-guide-content/content/index.ts
+++ b/shared/user-guide-content/content/index.ts
@@ -193,7 +193,7 @@ export const articleContentMap: Record<string, ArticleContent> = {
   'ai-gateway/logs': aiGatewayLogsContent,
   'ai-gateway/prompts': aiGatewayPromptsContent,
   'ai-gateway/models': aiGatewayModelsContent,
-  // MCP Gateway
+  // Agent Control
   'ai-gateway/mcp-overview': mcpOverviewContent,
   'ai-gateway/mcp-servers': mcpServersContent,
   'ai-gateway/mcp-tools': mcpToolsContent,

--- a/shared/user-guide-content/userGuideConfig.ts
+++ b/shared/user-guide-content/userGuideConfig.ts
@@ -627,8 +627,8 @@ export const collections: Collection[] = [
       },
       {
         id: 'mcp-overview',
-        title: 'MCP Gateway overview',
-        description: 'Understand what the MCP Gateway does, how it works, and why you need it for agent governance.',
+        title: 'Agent Control overview',
+        description: 'Understand what Agent Control does, how it works, and why you need it for agent governance.',
         keywords: ['mcp', 'gateway', 'overview', 'agent', 'tool', 'proxy', 'model context protocol', 'json-rpc'],
       },
       {


### PR DESCRIPTION
## Summary

Re-frames the AI Gateway's "MCP Gateway" UI section as **Agent Control**, so the UI describes what it does (govern what AI agents do) rather than naming itself after a protocol. Builds on the native tool-call governance merged in #4083.

### Renames (display strings, breadcrumbs, page headers, de/fr/es i18n, user guide)
- Sidebar group **MCP Gateway → Agent Control**.
- **Audit Log → Activity** (it is a live activity dashboard, not a passive log).
- **Servers → MCP Servers**, **Tools → MCP Tools** (these are genuinely MCP-protocol concepts, so they keep "MCP").
- Agent Keys, Approvals and Guardrails keep their names.
- Page descriptions rewritten to be agent-accurate, and now mention that the gateway covers MCP tools and native tools like Bash (true since #4083 merged).

### Mechanism
The app renders raw English strings; a runtime DOM translator swaps them per language using the English string as the key. Every renamed string updates its de/fr/es key to match, so non-English UIs stay translated.

## Scope
- **Display strings + docs only.** Route paths (`/ai-gateway/mcp/*`), API endpoints and component/file names are unchanged, so no links or bookmarks break.
- The user-guide content under `shared/user-guide-content/` is updated and mirrored to the website content directory.
- A humanizer pass removed AI-writing tells (em dashes, filler) from the Agent Control UI and user-guide copy.

## Changes
- `Clients/.../AIGateway/AIGatewaySidebar.tsx`, `breadcrumbs/routeMapping.ts` — labels.
- `Clients/.../AIGateway/MCP{AuditLog,Approvals,ToolCatalog,Guardrails}/index.tsx` — page titles + descriptions.
- `Clients/src/i18n/translations.ts` — de/fr/es keys for every renamed string, plus a missing ES "Require approval" key carried over from #4083.
- `shared/user-guide-content/...` — section title + breadcrumb prose.

## Notes
- Non-English translations are best-effort and not yet native-reviewed; English is authoritative.
- Rebased cleanly onto develop after #4083 merged. The i18n audit reports 0 gaps and the client build passes.
