### PR TITLE
Enforce Spanish in the i18n audit

### DIFF
--- a/Clients/scripts/i18n-audit.mjs
+++ b/Clients/scripts/i18n-audit.mjs
@@ -17,7 +17,7 @@ import { dirname } from "node:path";
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const SRC_DIR = join(__dirname, "..", "src");
 const TRANSLATIONS_PATH = join(SRC_DIR, "i18n", "translations.ts");
-const SUPPORTED_LANGS = ["de", "fr"];
+const SUPPORTED_LANGS = ["de", "fr", "es"];
 
 const args = process.argv.slice(2);
 const wantJson = args.includes("--json");

--- a/Clients/src/i18n/translations.ts
+++ b/Clients/src/i18n/translations.ts
@@ -17156,6 +17156,7 @@ export const translations: Record<string, Record<string, string>> = {
     "Internal": "Interno",
     "Needs rework": "Requiere correcciones",
     "Needs Rework": "Requiere correcciones",
+    "Require approval": "Aprobación requerida",
     "Requires follow-up": "Requiere seguimiento",
     "Awaiting approval": "A la espera de aprobación",
     "Awaiting Approval": "A la espera de aprobación",


### PR DESCRIPTION
## Summary

The i18n dictionaries for German, French and Spanish are maintained together (each has the same key count), but the strict i18n audit only enforced German and French. Spanish drifted as a result.

This adds Spanish to the audit's checked languages so all three stay in sync, and fixes the one Spanish string that had already fallen behind.

## Changes

- `scripts/i18n-audit.mjs`: add `es` to `SUPPORTED_LANGS`
- `translations.ts`: add the missing Spanish translation for "Require approval" (the recent string that shipped with German and French but no Spanish)

After the change, the strict audit reports 100% coverage and zero gaps for all three languages.