### PR TITLE
docs(ai-gateway): Agent Control reference + CLAUDE.md links

### DIFF
--- a/AIGateway/CLAUDE.md
+++ b/AIGateway/CLAUDE.md
@@ -1,6 +1,6 @@
 # AIGateway — LLM Gateway Service
 
-> **Last Updated:** 2026-03-24
+> **Last Updated:** 2026-06-16
 
 ---
 
@@ -84,6 +84,7 @@ Express backend at `Servers/routes/aiGateway.route.ts` proxies `/api/ai-gateway/
 
 | When working on... | Read this file |
 |---------------------|---------------|
+| Agent Control (native tool-call hook, file-write gating, approval) | `docs/technical/domains/agent-control.md` |
 | AI Advisor | `docs/technical/infrastructure/ai-advisor.md` |
 | Integrations (Slack, GitHub) | `docs/technical/infrastructure/integrations.md` |
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,6 @@
 # VerifyWise - Development Guide
 
-> **Last Updated:** 2026-05-05
+> **Last Updated:** 2026-06-16
 
 This document contains cross-cutting rules for the VerifyWise codebase. Directory-scoped guides load automatically when working in each area:
 
@@ -172,6 +172,7 @@ Read the relevant file BEFORE implementing changes in that area:
 | Detailed coding standards (TS, React, backend, security, testing) | `CodeRules/README.md` |
 | Plugin system | `docs/technical/infrastructure/plugin-system.md` |
 | Approval workflows | `docs/technical/domains/approvals.md` |
+| Agent Control (AI Gateway native tool-call hook + file-write gating) | `docs/technical/domains/agent-control.md` |
 | AI Detection | `docs/technical/domains/ai-detection.md` |
 | Risk management | `docs/technical/domains/risk-management.md` |
 | Vendors | `docs/technical/domains/vendors.md` |

--- a/docs/superpowers/specs/2026-06-16-agent-control-rename-FOLLOWUP-native-copy.md
+++ b/docs/superpowers/specs/2026-06-16-agent-control-rename-FOLLOWUP-native-copy.md
@@ -1,8 +1,11 @@
 # Follow-up: upgrade Agent Control copy to mention native tools
 
-> **Status:** PENDING — do NOT apply until the trigger condition is met.
-> **Trigger:** Phase 1/2 (`feat/mcp-bash-hook` + `feat/mcp-hook-approval`) are merged to
-> `develop` AND this rename branch (`feat/agent-control-rename`) has been rebased on top.
+> **Status:** ✅ DONE — applied and merged in PR #4084 (2026-06-16). Both Follow-up A
+> (native-tool copy) and Follow-up B (Phase 2/3 i18n + em dash) are on `develop`. No action
+> remaining; kept for the record. The text below is historical.
+>
+> _Original (now satisfied) trigger:_ Phase 1/2 merged to `develop` AND the rename branch
+> rebased on top.
 > **Why gated:** The fuller copy claims native-tool (Bash) gating. That capability only
 > exists once Phase 1/2 merge. Applying it before then would make `develop` claim a feature
 > it doesn't have. Until then, the truthful copy is "agent tool calls".

--- a/docs/technical/domains/agent-control.md
+++ b/docs/technical/domains/agent-control.md
@@ -1,0 +1,98 @@
+# Agent Control — native tool-call governance
+
+> **Status:** Shipped to `develop` (PRs #4078, #4083, #4084). Last updated 2026-06-16.
+
+Agent Control gates a coding agent's tool calls through the AI Gateway's guardrails,
+human-approval and audit machinery. It covers two entry paths that share one governance
+layer:
+
+- **MCP proxy** (`POST /v1/mcp`) — the agent calls a tool *through* the gateway, which
+  forwards the JSON-RPC call to a registered MCP server.
+- **Native hook** (`POST /v1/mcp/hook`) — the agent runs its *own* built-in tool (Bash,
+  Edit, Write, MultiEdit, NotebookEdit). The gateway **adjudicates** (allow / deny /
+  approval_required / rate_limited) and **never forwards or executes** the call. A
+  dev-machine adapter (`scripts/vw-tool-hook.sh`, a Claude Code `PreToolUse` hook) calls
+  this endpoint before the tool runs.
+
+"Agent Control" is the UI name for this section (renamed from "MCP Gateway"). Mental model:
+the **AI Gateway** governs what the AI *says* (model calls, spend); **Agent Control** governs
+what the AI *does* (tool calls).
+
+## Request flow (the hook, `AIGateway/src/routers/mcp_hook.py`)
+
+```
+extract_agent_key (sk-mcp-*)                    -- shared with the proxy
+  → scan_tool_input(field_aware=True)           -- guardrail scan; block/mask → deny
+  → check_require_approval                      -- hook-only; match → create/reuse approval
+  → enforce_mcp_rate_limits                     -- LAST, and skipped on an approved re-call
+  → allow
+```
+
+Every path writes an audit row (`log_tool_call`). Audit and the approval argument-hash use
+the **full** arguments; only the guardrail scan uses the field-aware subset.
+
+## Field-aware scanning (`AIGateway/src/utils/mcp_tool_content.py`)
+
+`extract_scannable_content(tool_name, arguments)` returns the subset to scan:
+
+| Tool | Scanned field(s) |
+|---|---|
+| `Write` | `content` |
+| `Edit` | `new_string` |
+| `MultiEdit` | each `edits[].new_string`, joined raw |
+| `NotebookEdit` | `new_source` |
+| Bash / MCP / unknown | full `arguments` |
+
+Only **written** content is scanned, not `old_string` (removed text) or `file_path`. So
+*deleting* a line containing PII is allowed; *writing* PII is denied. A pure deletion (no
+written content) returns `{}` and is allowed.
+
+**Critical:** this is **opt-in** via `scan_tool_input(..., field_aware=True)`. The hook passes
+`True`; the **MCP proxy passes the default `False`** (full-args scan). Without this, a proxied
+MCP tool that happens to be named `Write`/`Edit` would have its args narrowed and bypass
+guardrails. (Closed in review.)
+
+## Human approval (`require_approval` rule type)
+
+A guardrail rule with `rule_type = "require_approval"` (regex/keyword on the command, matched
+in `services/mcp_approval_match.py`) routes a matching call through the existing approval flow
+instead of denying it. The adapter blocks and polls `GET /v1/mcp/approvals/{id}/status`;
+approved → run, denied → block, timeout → `VW_APPROVAL_FAIL_MODE` (default deny).
+
+- Approvals are **argument-scoped** (SHA-256 of full args) — approving one call doesn't
+  authorize a different one.
+- Native approvals carry `tool_id IS NULL`; proxy approvals carry a `tool_id`. Lookups are
+  scoped by `native=True/False` so a native-hook approval can never authorize a proxy call of
+  the same name+args. (Migration `a0006` made `tool_id` nullable.)
+- An already-approved re-call **skips** the rate limiter so an approval is never wasted.
+
+## Adapter (`scripts/vw-tool-hook.sh` + README)
+
+Claude Code config matcher: `Bash|Edit|Write|MultiEdit|NotebookEdit`. Env: `VW_GATEWAY_URL`,
+`VW_AGENT_KEY` (sk-mcp-*), `VW_FAIL_MODE` (open|closed, default open — for gateway-unreachable
+and rate_limited), `VW_TIMEOUT`, `VW_APPROVAL_WAIT`, `VW_APPROVAL_FAIL_MODE` (default closed).
+
+## UI
+
+No bespoke screens. Rules are authored in **Guardrails**, decisions made in **Approvals**,
+and every call appears in **Activity** (the renamed Audit Log) — all under the **Agent Control**
+sidebar group. Servers/Tools keep "MCP" in their labels (genuinely MCP-protocol concepts).
+
+## Not yet built (Phase 4+)
+
+- **Path-based gating** — block/approve writes by *destination* (`~/.ssh`, `.env`, outside the
+  repo). Genuinely new matching logic.
+- Cursor / non-Claude-Code adapter; an Agent Control overview/landing page; a priority rule
+  engine; tamper-evident audit; metering MCP calls into the existing budgets.
+
+## Known issue
+
+The i18n CI audit hard-gates `de`/`fr` coverage but **not `es`**, so Spanish translation gaps
+can land on `develop` unnoticed. Worth extending the gate to `es` or running a periodic
+es-coverage sweep.
+
+## Design history
+
+The spec/plan trail for each increment lives under `docs/superpowers/`:
+`2026-06-15-mcp-bash-hook-*` (Phase 1), `2026-06-15-mcp-hook-approval-*` (Phase 2),
+`2026-06-16-mcp-hook-filewrite-*` (Phase 3), `2026-06-16-agent-control-rename-*` (rename).


### PR DESCRIPTION
## Summary
Adds a reference doc for the native tool-call governance feature shipped via #4083 and #4084, and links it from the root and AIGateway `CLAUDE.md` so future work finds it.

## Changes
- New `docs/technical/domains/agent-control.md` — the hook request flow, field-aware file-write scanning (and the `field_aware` opt-in that keeps the MCP proxy on a full-args scan), `require_approval` rule type, the adapter, the UI surfaces, a known i18n-CI gap, and the Phase 4 backlog.
- Links it from the references table in both `CLAUDE.md` and `AIGateway/CLAUDE.md`; bumps their "Last Updated" dates per the CLAUDE.md rule.
- Marks the now-applied native-tool-copy follow-up spec as DONE.

Docs only — no code changes.