### PR TITLE
feat(ai-apps): standard model picker + add-from-modal policy mapping

### DIFF
--- a/Clients/src/i18n/translations.ts
+++ b/Clients/src/i18n/translations.ts
@@ -62,6 +62,12 @@ export const translations: Record<string, Record<string, string>> = {
     "Manual": "Manuell",
     "Map models, policies and data access": "Modelle, Richtlinien und Datenzugriff zuordnen",
     "Model dependencies": "Modellabhängigkeiten",
+    "Add models": "Modelle hinzufügen",
+    "Model dependencies updated": "Modellabhängigkeiten aktualisiert",
+    "Select the model inventory entries this AI app depends on.":
+      "Wählen Sie die Modellinventar-Einträge aus, von denen diese KI-App abhängt.",
+    'No models linked yet. Use "Add model" to link model inventory entries to this app.':
+      "Noch keine Modelle verknüpft. Verwenden Sie „Modell hinzufügen“, um Modellinventar-Einträge mit dieser App zu verknüpfen.",
     "Model dependencies updated successfully": "Modellabhängigkeiten erfolgreich aktualisiert",
     "New AI app": "Neue KI-App",
     "No models linked to this AI app.": "Keine Modelle mit dieser KI-App verknüpft.",
@@ -8644,6 +8650,12 @@ export const translations: Record<string, Record<string, string>> = {
     "Map models, policies and data access":
       "Associer les modèles, les politiques et l'accès aux données",
     "Model dependencies": "Dépendances de modèles",
+    "Add models": "Ajouter des modèles",
+    "Model dependencies updated": "Dépendances de modèles mises à jour",
+    "Select the model inventory entries this AI app depends on.":
+      "Sélectionnez les entrées de l'inventaire des modèles dont dépend cette application d'IA.",
+    'No models linked yet. Use "Add model" to link model inventory entries to this app.':
+      "Aucun modèle lié pour l'instant. Utilisez « Ajouter un modèle » pour lier des entrées de l'inventaire des modèles à cette application.",
     "Model dependencies updated successfully": "Dépendances de modèles mises à jour avec succès",
     "New AI app": "Nouvelle application IA",
     "No models linked to this AI app.": "Aucun modèle lié à cette application IA.",
@@ -17177,6 +17189,12 @@ export const translations: Record<string, Record<string, string>> = {
     "Manual": "Manual",
     "Map models, policies and data access": "Asignar modelos, políticas y acceso a datos",
     "Model dependencies": "Dependencias de modelos",
+    "Add models": "Agregar modelos",
+    "Model dependencies updated": "Dependencias de modelos actualizadas",
+    "Select the model inventory entries this AI app depends on.":
+      "Selecciona las entradas del inventario de modelos de las que depende esta aplicación de IA.",
+    'No models linked yet. Use "Add model" to link model inventory entries to this app.':
+      'Aún no hay modelos vinculados. Usa "Agregar modelo" para vincular entradas del inventario de modelos a esta aplicación.',
     "Model dependencies updated successfully": "Dependencias de modelos actualizadas correctamente",
     "New AI app": "Nueva aplicación de IA",
     "No models linked to this AI app.": "No hay modelos vinculados a esta aplicación de IA.",

--- a/Clients/src/i18n/translations.ts
+++ b/Clients/src/i18n/translations.ts
@@ -72,6 +72,13 @@ export const translations: Record<string, Record<string, string>> = {
       "Anzahl der Mitarbeitenden, Abteilungen oder externen Nutzer mit Zugriff",
     "Output impact": "Auswirkung der Ausgabe",
     "Policy mapping": "Richtlinienzuordnung",
+    "Add policy": "Richtlinie hinzufügen",
+    "Add policies": "Richtlinien hinzufügen",
+    "Policy mapping saved": "Richtlinienzuordnung gespeichert",
+    "Select the policies that apply to this AI app.":
+      "Wählen Sie die für diese KI-App geltenden Richtlinien aus.",
+    'No policies linked yet. Use "Add policy" to map applicable policies to this app.':
+      "Noch keine Richtlinien verknüpft. Verwenden Sie „Richtlinie hinzufügen“, um geltende Richtlinien dieser App zuzuordnen.",
     "Policy mapping saved successfully": "Richtlinienzuordnung erfolgreich gespeichert",
     "Procurement": "Beschaffung",
     "Promote to AI app": "Zu KI-App hochstufen",
@@ -8647,6 +8654,13 @@ export const translations: Record<string, Record<string, string>> = {
       "Nombre d'employés, de services ou d'utilisateurs externes ayant accès",
     "Output impact": "Impact des résultats",
     "Policy mapping": "Correspondance des politiques",
+    "Add policy": "Ajouter une politique",
+    "Add policies": "Ajouter des politiques",
+    "Policy mapping saved": "Correspondance des politiques enregistrée",
+    "Select the policies that apply to this AI app.":
+      "Sélectionnez les politiques qui s'appliquent à cette application d'IA.",
+    'No policies linked yet. Use "Add policy" to map applicable policies to this app.':
+      "Aucune politique liée pour l'instant. Utilisez « Ajouter une politique » pour associer les politiques applicables à cette application.",
     "Policy mapping saved successfully": "Correspondance des politiques enregistrée avec succès",
     "Procurement": "Achats",
     "Promote to AI app": "Promouvoir en application IA",
@@ -17173,6 +17187,13 @@ export const translations: Record<string, Record<string, string>> = {
       "Número de empleados, departamentos o usuarios externos con acceso",
     "Output impact": "Impacto de los resultados",
     "Policy mapping": "Asignación de políticas",
+    "Add policy": "Agregar política",
+    "Add policies": "Agregar políticas",
+    "Policy mapping saved": "Asignación de políticas guardada",
+    "Select the policies that apply to this AI app.":
+      "Selecciona las políticas que se aplican a esta aplicación de IA.",
+    'No policies linked yet. Use "Add policy" to map applicable policies to this app.':
+      'Aún no hay políticas vinculadas. Usa "Agregar política" para asignar las políticas aplicables a esta aplicación.',
     "Policy mapping saved successfully": "Asignación de políticas guardada correctamente",
     "Procurement": "Compras",
     "Promote to AI app": "Promover a aplicación de IA",

--- a/Clients/src/presentation/components/Inputs/Autocomplete/index.tsx
+++ b/Clients/src/presentation/components/Inputs/Autocomplete/index.tsx
@@ -8,6 +8,7 @@ import {
   Typography,
   useTheme,
 } from "@mui/material";
+import { ChevronDown } from "lucide-react";
 import "./index.css";
 import { getAutocompleteStyles } from "../../../utils/inputStyles";
 
@@ -115,6 +116,7 @@ function AutoCompleteField<
       )}
       <Autocomplete<T, Multiple, DisableClearable, FreeSolo>
         disabled={disabled}
+        popupIcon={<ChevronDown size={16} color={theme.palette.text.tertiary} />}
         renderInput={(params) => (
           <TextField
             {...params}

--- a/Clients/src/presentation/pages/AIApps/AIAppDetail/AIAppModelDependencies.tsx
+++ b/Clients/src/presentation/pages/AIApps/AIAppDetail/AIAppModelDependencies.tsx
@@ -9,10 +9,9 @@ import {
   TableContainer,
   TableRow,
 } from "@mui/material";
-import type { SelectChangeEvent } from "@mui/material";
 import { Cpu } from "lucide-react";
 import { CustomizableButton } from "../../../components/button/customizable-button";
-import MultiSelect from "../../../components/Inputs/MultiSelect";
+import AutoCompleteField from "../../../components/Inputs/Autocomplete";
 import { useLinkModelsToAiApp } from "../../../../application/hooks/useAiApps";
 import { useModelInventories } from "../../../../application/hooks/useModelInventories";
 import { IAIAppModel } from "../../../../domain/interfaces/i.aiApp";
@@ -54,11 +53,16 @@ export default function AIAppModelDependencies({ appId, models }: AIAppModelDepe
   const { data: modelInventories } = useModelInventories();
   const linkModelsMutation = useLinkModelsToAiApp();
 
-  const modelOptions = useMemo(
+  interface ModelOption {
+    id: number;
+    label: string;
+  }
+
+  const modelOptions = useMemo<ModelOption[]>(
     () =>
       (modelInventories ?? []).map((m) => ({
-        _id: m.id!,
-        name: `${m.provider || "Unknown"} - ${m.model || "Unknown"}${
+        id: m.id!,
+        label: `${m.provider || "Unknown"} - ${m.model || "Unknown"}${
           m.version ? ` v${m.version}` : ""
         }`,
       })),
@@ -69,9 +73,13 @@ export default function AIAppModelDependencies({ appId, models }: AIAppModelDepe
     setLocalModelIds(models.map((m) => m.id));
   }, [models]);
 
-  const handleChange = (event: SelectChangeEvent<number[]>) => {
-    const value = event.target.value;
-    setLocalModelIds(typeof value === "string" ? [] : value);
+  const selectedOptions = useMemo<ModelOption[]>(
+    () => modelOptions.filter((o) => localModelIds.includes(o.id)),
+    [modelOptions, localModelIds],
+  );
+
+  const handleChange = (_event: unknown, value: ModelOption[]) => {
+    setLocalModelIds(value.map((v) => v.id));
   };
 
   const handleSave = async () => {
@@ -139,13 +147,15 @@ export default function AIAppModelDependencies({ appId, models }: AIAppModelDepe
       </Stack>
 
       <Box sx={{ mb: "24px" }}>
-        <MultiSelect
-          id="linked-models"
+        <AutoCompleteField<ModelOption, true>
+          multiple
           label="Linked models"
-          placeholder="Select model inventory entries"
-          value={localModelIds}
-          items={modelOptions}
+          placeholder={selectedOptions.length === 0 ? "Select model inventory entries" : ""}
+          options={modelOptions}
+          value={selectedOptions}
           onChange={handleChange}
+          getOptionLabel={(option) => option.label}
+          isOptionEqualToValue={(option, val) => option.id === val.id}
           sx={{ maxWidth: 400 }}
         />
       </Box>

--- a/Clients/src/presentation/pages/AIApps/AIAppDetail/AIAppModelDependencies.tsx
+++ b/Clients/src/presentation/pages/AIApps/AIAppDetail/AIAppModelDependencies.tsx
@@ -8,10 +8,12 @@ import {
   TableCell,
   TableContainer,
   TableRow,
+  IconButton,
 } from "@mui/material";
-import { Cpu } from "lucide-react";
+import { Cpu, CirclePlus, Trash2 } from "lucide-react";
 import { CustomizableButton } from "../../../components/button/customizable-button";
 import AutoCompleteField from "../../../components/Inputs/Autocomplete";
+import StandardModal from "../../../components/Modals/StandardModal";
 import { useLinkModelsToAiApp } from "../../../../application/hooks/useAiApps";
 import { useModelInventories } from "../../../../application/hooks/useModelInventories";
 import { IAIAppModel } from "../../../../domain/interfaces/i.aiApp";
@@ -29,15 +31,24 @@ interface AIAppModelDependenciesProps {
   models: IAIAppModel[];
 }
 
+interface ModelOption {
+  id: number;
+  label: string;
+}
+
 const TABLE_COLUMNS: StandardColumn[] = [
   { id: "provider", label: "Provider", sortable: true },
   { id: "model", label: "Model", sortable: true },
   { id: "version", label: "Version", sortable: false },
   { id: "status", label: "Status", sortable: true },
+  { id: "actions", label: "", sortable: false },
 ];
 
 export default function AIAppModelDependencies({ appId, models }: AIAppModelDependenciesProps) {
-  const [localModelIds, setLocalModelIds] = useState<number[]>([]);
+  // Source of truth for what's linked to this app.
+  const [linkedIds, setLinkedIds] = useState<number[]>([]);
+  const [isAddOpen, setIsAddOpen] = useState(false);
+  const [toAdd, setToAdd] = useState<ModelOption[]>([]);
   const [alert, setAlert] = useState<{
     variant: "success" | "info" | "warning" | "error";
     body: string;
@@ -53,45 +64,87 @@ export default function AIAppModelDependencies({ appId, models }: AIAppModelDepe
   const { data: modelInventories } = useModelInventories();
   const linkModelsMutation = useLinkModelsToAiApp();
 
-  interface ModelOption {
-    id: number;
-    label: string;
-  }
+  // Seed the linked set from the models already mapped to this app.
+  useEffect(() => {
+    setLinkedIds(models.map((m) => m.id));
+  }, [models]);
 
-  const modelOptions = useMemo<ModelOption[]>(
+  // Full inventory detail keyed by id, so a linked id can render a full row.
+  const inventoryById = useMemo(() => {
+    const map = new Map<number, IAIAppModel>();
+    for (const m of modelInventories ?? []) {
+      if (m.id == null) continue;
+      map.set(m.id, {
+        id: m.id,
+        provider: m.provider || "Unknown",
+        model: m.model || "Unknown",
+        version: m.version || "",
+        status: m.status || "",
+      });
+    }
+    return map;
+  }, [modelInventories]);
+
+  // Rows = the linked models, resolved to full detail (fall back to the prop row).
+  const linkedRows = useMemo<IAIAppModel[]>(
     () =>
-      (modelInventories ?? []).map((m) => ({
+      linkedIds.map(
+        (id) =>
+          inventoryById.get(id) ??
+          models.find((m) => m.id === id) ?? {
+            id,
+            provider: "Unknown",
+            model: "Unknown",
+            version: "",
+            status: "",
+          },
+      ),
+    [linkedIds, inventoryById, models],
+  );
+
+  // Inventory entries not yet linked — candidates for the add modal.
+  const addableOptions = useMemo<ModelOption[]>(() => {
+    const linked = new Set(linkedIds);
+    return (modelInventories ?? [])
+      .filter((m) => m.id != null && !linked.has(m.id))
+      .map((m) => ({
         id: m.id!,
         label: `${m.provider || "Unknown"} - ${m.model || "Unknown"}${
           m.version ? ` v${m.version}` : ""
         }`,
-      })),
-    [modelInventories],
+      }));
+  }, [modelInventories, linkedIds]);
+
+  const persist = useCallback(
+    async (next: number[]) => {
+      try {
+        await linkModelsMutation.mutateAsync({ id: appId, modelInventoryIds: next });
+        setAlert({ variant: "success", body: "Model dependencies updated" });
+      } catch (err) {
+        setAlert({ variant: "error", body: "Failed to update model dependencies" });
+        // Re-seed from server-truth so the UI doesn't drift on failure.
+        setLinkedIds(models.map((m) => m.id));
+      }
+    },
+    [appId, models, linkModelsMutation],
   );
 
-  useEffect(() => {
-    setLocalModelIds(models.map((m) => m.id));
-  }, [models]);
-
-  const selectedOptions = useMemo<ModelOption[]>(
-    () => modelOptions.filter((o) => localModelIds.includes(o.id)),
-    [modelOptions, localModelIds],
-  );
-
-  const handleChange = (_event: unknown, value: ModelOption[]) => {
-    setLocalModelIds(value.map((v) => v.id));
+  const handleConfirmAdd = async () => {
+    if (toAdd.length === 0) {
+      setIsAddOpen(false);
+      return;
+    }
+    const next = [...linkedIds, ...toAdd.map((o) => o.id)];
+    setLinkedIds(next);
+    setIsAddOpen(false);
+    setToAdd([]);
+    await persist(next);
   };
 
-  const handleSave = async () => {
-    try {
-      await linkModelsMutation.mutateAsync({
-        id: appId,
-        modelInventoryIds: localModelIds,
-      });
-      setAlert({ variant: "success", body: "Model dependencies updated successfully" });
-    } catch (err) {
-      setAlert({ variant: "error", body: "Failed to update model dependencies" });
-    }
+  const handleRemove = async (modelId: number) => {
+    const next = linkedIds.filter((id) => id !== modelId);
+    setLinkedIds(next);
+    await persist(next);
   };
 
   const sortComparator = useCallback((a: IAIAppModel, b: IAIAppModel, key: string): number => {
@@ -118,7 +171,7 @@ export default function AIAppModelDependencies({ appId, models }: AIAppModelDepe
     getRange,
     totalCount,
   } = useStandardTable<IAIAppModel>({
-    rows: models,
+    rows: linkedRows,
     storageKey: "aiAppModelDependencies",
     defaultSortColumn: "",
     defaultSortDirection: null,
@@ -139,26 +192,16 @@ export default function AIAppModelDependencies({ appId, models }: AIAppModelDepe
           <Typography sx={{ fontSize: 15, fontWeight: 600 }}>Model dependencies</Typography>
         </Stack>
         <CustomizableButton
-          text="Save dependencies"
+          text="Add model"
           variant="contained"
-          onClick={handleSave}
+          icon={<CirclePlus size={14} strokeWidth={1.5} />}
+          onClick={() => {
+            setToAdd([]);
+            setIsAddOpen(true);
+          }}
           disabled={linkModelsMutation.isPending}
         />
       </Stack>
-
-      <Box sx={{ mb: "24px" }}>
-        <AutoCompleteField<ModelOption, true>
-          multiple
-          label="Linked models"
-          placeholder={selectedOptions.length === 0 ? "Select model inventory entries" : ""}
-          options={modelOptions}
-          value={selectedOptions}
-          onChange={handleChange}
-          getOptionLabel={(option) => option.label}
-          isOptionEqualToValue={(option, val) => option.id === val.id}
-          sx={{ maxWidth: 400 }}
-        />
-      </Box>
 
       <TableContainer sx={{ overflowX: "auto" }}>
         <Table sx={singleTheme.tableStyles.primary.frame}>
@@ -181,6 +224,18 @@ export default function AIAppModelDependencies({ appId, models }: AIAppModelDepe
                     <TableCell sx={singleTheme.tableStyles.primary.body.cell}>
                       <Chip label={model.status || "Unknown"} size="small" uppercase={false} />
                     </TableCell>
+                    <TableCell
+                      sx={{ ...singleTheme.tableStyles.primary.body.cell, textAlign: "right" }}
+                    >
+                      <IconButton
+                        size="small"
+                        onClick={() => handleRemove(model.id)}
+                        disabled={linkModelsMutation.isPending}
+                        aria-label={`Remove ${model.provider} ${model.model}`}
+                      >
+                        <Trash2 size={14} strokeWidth={1.5} color={palette.text.tertiary} />
+                      </IconButton>
+                    </TableCell>
                   </TableRow>
                 ))
             ) : (
@@ -189,7 +244,7 @@ export default function AIAppModelDependencies({ appId, models }: AIAppModelDepe
                   colSpan={TABLE_COLUMNS.length}
                   sx={singleTheme.tableStyles.primary.body.cell}
                 >
-                  No models linked to this AI app.
+                  No models linked yet. Use "Add model" to link model inventory entries to this app.
                 </TableCell>
               </TableRow>
             )}
@@ -208,6 +263,31 @@ export default function AIAppModelDependencies({ appId, models }: AIAppModelDepe
           )}
         </Table>
       </TableContainer>
+
+      <StandardModal
+        isOpen={isAddOpen}
+        onClose={() => setIsAddOpen(false)}
+        title="Add models"
+        description="Select the model inventory entries this AI app depends on."
+        onSubmit={handleConfirmAdd}
+        submitButtonText="Add"
+        isSubmitting={linkModelsMutation.isPending}
+        maxWidth="480px"
+      >
+        <AutoCompleteField<ModelOption, true>
+          multiple
+          label="Models"
+          placeholder={
+            addableOptions.length === 0 ? "All models are already linked" : "Select models"
+          }
+          options={addableOptions}
+          value={toAdd}
+          onChange={(_e, value) => setToAdd(value as ModelOption[])}
+          getOptionLabel={(option) => option.label}
+          isOptionEqualToValue={(option, val) => option.id === val.id}
+          disabled={addableOptions.length === 0}
+        />
+      </StandardModal>
 
       {alert && (
         <Alert variant={alert.variant} body={alert.body} isToast onClick={() => setAlert(null)} />

--- a/Clients/src/presentation/pages/AIApps/AIAppDetail/AIAppPolicyMapping.tsx
+++ b/Clients/src/presentation/pages/AIApps/AIAppDetail/AIAppPolicyMapping.tsx
@@ -8,10 +8,12 @@ import {
   TableCell,
   TableContainer,
   TableRow,
+  IconButton,
 } from "@mui/material";
-import { Sparkles, ShieldCheck } from "lucide-react";
+import { Sparkles, ShieldCheck, CirclePlus, Trash2 } from "lucide-react";
 import { CustomizableButton } from "../../../components/button/customizable-button";
-import Toggle from "../../../components/Inputs/Toggle";
+import AutoCompleteField from "../../../components/Inputs/Autocomplete";
+import StandardModal from "../../../components/Modals/StandardModal";
 import {
   useSetPoliciesForAiApp,
   usePolicySuggestions,
@@ -34,19 +36,26 @@ interface AIAppPolicyMappingProps {
   policies: IAIAppPolicy[];
 }
 
-interface LocalPolicy {
+interface LinkedPolicy {
   policy_id: number;
   title: string;
-  status: AiAppPolicyStatus;
+}
+
+interface PolicyOption {
+  id: number;
+  label: string;
 }
 
 const TABLE_COLUMNS: StandardColumn[] = [
   { id: "title", label: "Policy", sortable: true },
-  { id: "applicable", label: "Applicable", sortable: false },
+  { id: "actions", label: "", sortable: false },
 ];
 
 export default function AIAppPolicyMapping({ appId, appName, policies }: AIAppPolicyMappingProps) {
-  const [localPolicies, setLocalPolicies] = useState<LocalPolicy[]>([]);
+  // Only the policies linked to this app — not the whole org catalog.
+  const [linkedPolicies, setLinkedPolicies] = useState<LinkedPolicy[]>([]);
+  const [isAddOpen, setIsAddOpen] = useState(false);
+  const [toAdd, setToAdd] = useState<PolicyOption[]>([]);
   const [alert, setAlert] = useState<{
     variant: "success" | "info" | "warning" | "error";
     body: string;
@@ -63,64 +72,74 @@ export default function AIAppPolicyMapping({ appId, appName, policies }: AIAppPo
   const { data: suggestions } = usePolicySuggestions(appName);
   const setPoliciesMutation = useSetPoliciesForAiApp();
 
-  const allPolicyOptions = useMemo(
-    () =>
-      (allPolicies ?? []).map((policy: PolicyManagerModel) => ({
-        id: policy.id,
-        title: policy.title,
-      })),
-    [allPolicies],
-  );
-
+  // Seed the linked list from the policies already mapped to this app.
   useEffect(() => {
-    const mapped: LocalPolicy[] = allPolicyOptions.map((policy) => {
-      const existing = policies.find((p) => p.id === policy.id);
-      return {
-        policy_id: policy.id,
-        title: policy.title,
-        status: existing?.status || AiAppPolicyStatus.NOT_APPLICABLE,
-      };
-    });
-    setLocalPolicies(mapped);
-  }, [allPolicyOptions, policies]);
+    setLinkedPolicies(policies.map((p) => ({ policy_id: p.id, title: p.title })));
+  }, [policies]);
 
-  const handleToggle = (policyId: number) => {
-    setLocalPolicies((prev) =>
-      prev.map((p) =>
-        p.policy_id === policyId
-          ? {
-              ...p,
-              status:
-                p.status === AiAppPolicyStatus.APPLICABLE
-                  ? AiAppPolicyStatus.NOT_APPLICABLE
-                  : AiAppPolicyStatus.APPLICABLE,
-            }
-          : p,
-      ),
-    );
-  };
+  // Org policies that aren't linked yet — the candidates for the add modal.
+  const addableOptions = useMemo<PolicyOption[]>(() => {
+    const linkedIds = new Set(linkedPolicies.map((p) => p.policy_id));
+    return (allPolicies ?? [])
+      .filter((policy: PolicyManagerModel) => !linkedIds.has(policy.id))
+      .map((policy: PolicyManagerModel) => ({ id: policy.id, label: policy.title }));
+  }, [allPolicies, linkedPolicies]);
 
-  const handleSave = async () => {
-    try {
-      await setPoliciesMutation.mutateAsync({
-        id: appId,
-        policies: localPolicies.map((p) => ({
-          policy_id: p.policy_id,
-          status: p.status,
-        })),
-      });
-      setAlert({ variant: "success", body: "Policy mapping saved successfully" });
-    } catch (err) {
-      setAlert({ variant: "error", body: "Failed to save policy mapping" });
-    }
-  };
-
-  const suggestedTitles = useMemo(
-    () => suggestions?.filter((s) => s.suggested && s.id !== null).map((s) => s.title) || [],
-    [suggestions],
+  const persist = useCallback(
+    async (next: LinkedPolicy[]) => {
+      try {
+        await setPoliciesMutation.mutateAsync({
+          id: appId,
+          policies: next.map((p) => ({
+            policy_id: p.policy_id,
+            status: AiAppPolicyStatus.APPLICABLE,
+          })),
+        });
+        setAlert({ variant: "success", body: "Policy mapping saved" });
+      } catch (err) {
+        setAlert({ variant: "error", body: "Failed to save policy mapping" });
+        // Re-seed from the server-truth prop so the UI doesn't drift on failure.
+        setLinkedPolicies(policies.map((p) => ({ policy_id: p.id, title: p.title })));
+      }
+    },
+    [appId, policies, setPoliciesMutation],
   );
 
-  const sortComparator = useCallback((a: LocalPolicy, b: LocalPolicy, key: string): number => {
+  const handleConfirmAdd = async () => {
+    if (toAdd.length === 0) {
+      setIsAddOpen(false);
+      return;
+    }
+    const next = [...linkedPolicies, ...toAdd.map((o) => ({ policy_id: o.id, title: o.label }))];
+    setLinkedPolicies(next);
+    setIsAddOpen(false);
+    setToAdd([]);
+    await persist(next);
+  };
+
+  const handleRemove = async (policyId: number) => {
+    const next = linkedPolicies.filter((p) => p.policy_id !== policyId);
+    setLinkedPolicies(next);
+    await persist(next);
+  };
+
+  const handleAddSuggested = async (title: string) => {
+    const match = (allPolicies ?? []).find((p: PolicyManagerModel) => p.title === title);
+    if (!match || linkedPolicies.some((p) => p.policy_id === match.id)) return;
+    const next = [...linkedPolicies, { policy_id: match.id, title: match.title }];
+    setLinkedPolicies(next);
+    await persist(next);
+  };
+
+  // Suggested policies that aren't already linked.
+  const suggestedTitles = useMemo(() => {
+    const linkedTitles = new Set(linkedPolicies.map((p) => p.title));
+    return (suggestions ?? [])
+      .filter((s) => s.suggested && s.id !== null && !linkedTitles.has(s.title))
+      .map((s) => s.title);
+  }, [suggestions, linkedPolicies]);
+
+  const sortComparator = useCallback((a: LinkedPolicy, b: LinkedPolicy, key: string): number => {
     if (key === "title") return (a.title || "").localeCompare(b.title || "");
     return 0;
   }, []);
@@ -135,8 +154,8 @@ export default function AIAppPolicyMapping({ appId, appName, policies }: AIAppPo
     handleChangeRowsPerPage,
     getRange,
     totalCount,
-  } = useStandardTable<LocalPolicy>({
-    rows: localPolicies,
+  } = useStandardTable<LinkedPolicy>({
+    rows: linkedPolicies,
     storageKey: "aiAppPolicyMapping",
     defaultSortColumn: "",
     defaultSortDirection: null,
@@ -157,9 +176,13 @@ export default function AIAppPolicyMapping({ appId, appName, policies }: AIAppPo
           <Typography sx={{ fontSize: 15, fontWeight: 600 }}>Policy mapping</Typography>
         </Stack>
         <CustomizableButton
-          text="Save mapping"
+          text="Add policy"
           variant="contained"
-          onClick={handleSave}
+          icon={<CirclePlus size={14} strokeWidth={1.5} />}
+          onClick={() => {
+            setToAdd([]);
+            setIsAddOpen(true);
+          }}
           disabled={setPoliciesMutation.isPending}
         />
       </Stack>
@@ -178,9 +201,18 @@ export default function AIAppPolicyMapping({ appId, appName, policies }: AIAppPo
             <Sparkles size={14} strokeWidth={1.5} color={palette.text.secondary} />
             <Typography sx={{ fontSize: 13, fontWeight: 600 }}>Suggested policies</Typography>
           </Stack>
-          <Typography sx={{ fontSize: 13, color: palette.text.secondary }}>
-            {suggestedTitles.join(", ")}
-          </Typography>
+          <Stack direction="row" gap="8px" flexWrap="wrap">
+            {suggestedTitles.map((title) => (
+              <CustomizableButton
+                key={title}
+                text={`+ ${title}`}
+                variant="outlined"
+                size="small"
+                onClick={() => handleAddSuggested(title)}
+                disabled={setPoliciesMutation.isPending}
+              />
+            ))}
+          </Stack>
         </Box>
       )}
 
@@ -191,30 +223,32 @@ export default function AIAppPolicyMapping({ appId, appName, policies }: AIAppPo
             {totalCount > 0 ? (
               sortedRows
                 .slice(validPage * rowsPerPage, validPage * rowsPerPage + rowsPerPage)
-                .map((policy) => {
-                  const isApplicable = policy.status === AiAppPolicyStatus.APPLICABLE;
-                  return (
-                    <TableRow key={policy.policy_id} sx={singleTheme.tableStyles.primary.body.row}>
-                      <TableCell sx={singleTheme.tableStyles.primary.body.cell}>
-                        {policy.title}
-                      </TableCell>
-                      <TableCell sx={singleTheme.tableStyles.primary.body.cell}>
-                        <Toggle
-                          checked={isApplicable}
-                          onChange={() => handleToggle(policy.policy_id)}
-                          inputProps={{ "aria-label": `Toggle ${policy.title}` }}
-                        />
-                      </TableCell>
-                    </TableRow>
-                  );
-                })
+                .map((policy) => (
+                  <TableRow key={policy.policy_id} sx={singleTheme.tableStyles.primary.body.row}>
+                    <TableCell sx={singleTheme.tableStyles.primary.body.cell}>
+                      {policy.title}
+                    </TableCell>
+                    <TableCell
+                      sx={{ ...singleTheme.tableStyles.primary.body.cell, textAlign: "right" }}
+                    >
+                      <IconButton
+                        size="small"
+                        onClick={() => handleRemove(policy.policy_id)}
+                        disabled={setPoliciesMutation.isPending}
+                        aria-label={`Remove ${policy.title}`}
+                      >
+                        <Trash2 size={14} strokeWidth={1.5} color={palette.text.tertiary} />
+                      </IconButton>
+                    </TableCell>
+                  </TableRow>
+                ))
             ) : (
               <TableRow>
                 <TableCell
                   colSpan={TABLE_COLUMNS.length}
                   sx={singleTheme.tableStyles.primary.body.cell}
                 >
-                  No policies available.
+                  No policies linked yet. Use "Add policy" to map applicable policies to this app.
                 </TableCell>
               </TableRow>
             )}
@@ -234,6 +268,31 @@ export default function AIAppPolicyMapping({ appId, appName, policies }: AIAppPo
           )}
         </Table>
       </TableContainer>
+
+      <StandardModal
+        isOpen={isAddOpen}
+        onClose={() => setIsAddOpen(false)}
+        title="Add policies"
+        description="Select the policies that apply to this AI app."
+        onSubmit={handleConfirmAdd}
+        submitButtonText="Add"
+        isSubmitting={setPoliciesMutation.isPending}
+        maxWidth="480px"
+      >
+        <AutoCompleteField<PolicyOption, true>
+          multiple
+          label="Policies"
+          placeholder={
+            addableOptions.length === 0 ? "All policies are already linked" : "Select policies"
+          }
+          options={addableOptions}
+          value={toAdd}
+          onChange={(_e, value) => setToAdd(value as PolicyOption[])}
+          getOptionLabel={(option) => option.label}
+          isOptionEqualToValue={(option, val) => option.id === val.id}
+          disabled={addableOptions.length === 0}
+        />
+      </StandardModal>
 
       {alert && (
         <Alert variant={alert.variant} body={alert.body} isToast onClick={() => setAlert(null)} />


### PR DESCRIPTION
## Summary

Two fixes on the AI App detail page (`/ai-apps/:id`).

**Linked Models** used a one-off `MultiSelect` component (used nowhere else in the app). Replaced it with the app-standard searchable `Autocomplete` (chips, type-to-filter) that every other multi-entity picker uses.

**Policy mapping** previously listed every org policy with applicable/not-applicable toggles, with no way to "add" a policy. Redesigned to an add-from-modal model: the table now shows only the policies linked to this app, an "Add policy" button opens a modal to multi-select from the org policy list, and each linked row has a remove action. Suggested policies become one-click add chips. Changes persist immediately through the existing setPolicies endpoint (status = applicable).

## Changes

- Linked Models: `MultiSelect` -> `Autocomplete` (multiple, searchable).
- Policy mapping: linked-only table, add modal, removable rows, clickable suggestions.
- i18n: de/fr/es for the new strings.

## Benefits

- Consistent, searchable model selection that matches the rest of the app.
- Policy mapping reflects what actually applies to the app instead of the full catalog.