### PR TITLE
feat(ai-gateway): capture tool results + events timeline + invocation drawer

### DIFF
--- a/AIGateway/src/crud/mcp_audit.py
+++ b/AIGateway/src/crud/mcp_audit.py
@@ -183,6 +183,22 @@ async def get_audit_stats_by_agent(org_id: int, days: int = 7) -> list[dict]:
         ]
 
 
+async def get_audit_log_by_id(org_id: int, log_id: int) -> dict | None:
+    async with get_db() as db:
+        row = (await db.execute(
+            text("""
+                SELECT id, agent_key_id, server_id, tool_name, arguments,
+                       result_status, result_summary, is_error, latency_ms,
+                       session_id, tool_use_id, result_response, result_truncated,
+                       events, created_at
+                FROM ai_gateway_mcp_audit_logs
+                WHERE organization_id = :org_id AND id = :log_id
+            """),
+            {"org_id": org_id, "log_id": log_id},
+        )).mappings().fetchone()
+        return dict(row) if row else None
+
+
 async def delete_expired_audit_logs(retention_days: int = 30, batch_size: int = 5000) -> int:
     """Delete audit logs older than retention_days in batches. Returns count of deleted rows."""
     from utils.batch_delete import batch_delete_expired

--- a/AIGateway/src/crud/mcp_audit.py
+++ b/AIGateway/src/crud/mcp_audit.py
@@ -187,12 +187,14 @@ async def get_audit_log_by_id(org_id: int, log_id: int) -> dict | None:
     async with get_db() as db:
         row = (await db.execute(
             text("""
-                SELECT id, agent_key_id, server_id, tool_name, arguments,
-                       result_status, result_summary, is_error, latency_ms,
-                       session_id, tool_use_id, result_response, result_truncated,
-                       events, created_at
-                FROM ai_gateway_mcp_audit_logs
-                WHERE organization_id = :org_id AND id = :log_id
+                SELECT al.id, al.agent_key_id, al.server_id, al.tool_name, al.arguments,
+                       al.result_status, al.result_summary, al.is_error, al.latency_ms,
+                       al.session_id, al.tool_use_id, al.result_response, al.result_truncated,
+                       al.events, al.created_at,
+                       ak.name AS agent_key_name
+                FROM ai_gateway_mcp_audit_logs al
+                LEFT JOIN ai_gateway_mcp_agent_keys ak ON ak.id = al.agent_key_id
+                WHERE al.organization_id = :org_id AND al.id = :log_id
             """),
             {"org_id": org_id, "log_id": log_id},
         )).mappings().fetchone()

--- a/AIGateway/src/database/migrations/versions/a0007_mcp_audit_results.py
+++ b/AIGateway/src/database/migrations/versions/a0007_mcp_audit_results.py
@@ -1,0 +1,42 @@
+"""Add tool result + events columns to mcp audit logs
+
+Revision ID: a0007
+Revises: a0006
+Create Date: 2026-06-16
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+
+revision: str = "a0007"
+down_revision: Union[str, None] = "a0006"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.execute("SET search_path TO verifywise")
+    op.execute("""
+        ALTER TABLE ai_gateway_mcp_audit_logs
+            ADD COLUMN IF NOT EXISTS tool_use_id      VARCHAR(128),
+            ADD COLUMN IF NOT EXISTS result_response  JSONB,
+            ADD COLUMN IF NOT EXISTS result_truncated BOOLEAN DEFAULT false,
+            ADD COLUMN IF NOT EXISTS events           JSONB DEFAULT '[]'
+    """)
+    op.execute("""
+        CREATE INDEX IF NOT EXISTS idx_gw_mcp_audit_invocation
+            ON ai_gateway_mcp_audit_logs(organization_id, session_id, tool_use_id)
+    """)
+
+
+def downgrade() -> None:
+    op.execute("SET search_path TO verifywise")
+    op.execute("DROP INDEX IF EXISTS idx_gw_mcp_audit_invocation")
+    op.execute("""
+        ALTER TABLE ai_gateway_mcp_audit_logs
+            DROP COLUMN IF EXISTS tool_use_id,
+            DROP COLUMN IF EXISTS result_response,
+            DROP COLUMN IF EXISTS result_truncated,
+            DROP COLUMN IF EXISTS events
+    """)

--- a/AIGateway/src/routers/mcp_audit.py
+++ b/AIGateway/src/routers/mcp_audit.py
@@ -1,9 +1,10 @@
 from typing import Optional
 
-from fastapi import APIRouter, Request, status
+from fastapi import APIRouter, HTTPException, Request, status
 
 from crud.mcp_audit import (
     delete_expired_audit_logs,
+    get_audit_log_by_id,
     get_audit_logs,
     get_audit_stats,
     get_audit_stats_by_agent,
@@ -53,6 +54,20 @@ async def list_audit_logs(
         "limit": result["limit"],
         "offset": result["offset"],
     }
+
+
+# ---------------------------------------------------------------------------
+# GET /mcp/audit/logs/{log_id}
+# ---------------------------------------------------------------------------
+
+@router.get("/logs/{log_id}", status_code=status.HTTP_200_OK)
+async def get_audit_log(log_id: int, request: Request):
+    verify_internal_key(request)
+    org_id = get_org_id(request)
+    row = await get_audit_log_by_id(org_id, log_id)
+    if not row:
+        raise HTTPException(status_code=404, detail="Audit log not found")
+    return {"status": "success", "data": row}
 
 
 # ---------------------------------------------------------------------------

--- a/AIGateway/src/routers/mcp_hook.py
+++ b/AIGateway/src/routers/mcp_hook.py
@@ -20,9 +20,9 @@ from fastapi.responses import JSONResponse
 
 from config import settings
 from crud.mcp_approvals import create_approval_request, get_active_request
-from services.mcp_audit_service import log_tool_call
+from services.mcp_audit_service import log_tool_call, update_tool_result
 from services.mcp_approval_match import check_require_approval
-from services.mcp_guardrail_service import scan_tool_input
+from services.mcp_guardrail_service import scan_tool_input, scan_result_blob
 from services.mcp_proxy_service import extract_agent_key, enforce_mcp_rate_limits
 from utils.mcp_arguments import hash_arguments
 from utils.notifications import notify_approval_pending
@@ -46,13 +46,19 @@ async def mcp_hook(request: Request):
     tool_name = body.get("tool_name")
     arguments = body.get("arguments") or {}
     session_id = body.get("session_id")
+    tool_use_id = body.get("tool_use_id")
 
     if not tool_name or not isinstance(arguments, dict):
         raise HTTPException(status_code=400, detail="tool_name (str) and arguments (object) are required")
 
     start_time = time.time()
+    received_at = datetime.now(timezone.utc).isoformat()
 
-    async def _audit(status: str, summary: str, is_error: bool = False):
+    async def _audit(status: str, summary: str, decided_detail: str, is_error: bool = False):
+        events = [
+            {"type": "received", "at": received_at},
+            {"type": "decided", "at": datetime.now(timezone.utc).isoformat(), "detail": decided_detail},
+        ]
         await log_tool_call(
             organization_id=org_id,
             agent_key_id=agent_key["id"],
@@ -64,6 +70,8 @@ async def mcp_hook(request: Request):
             is_error=is_error,
             latency_ms=int((time.time() - start_time) * 1000),
             session_id=session_id,
+            tool_use_id=tool_use_id,
+            events=events,
         )
 
     # ── Guardrail scan (UNCHANGED shared path): block / mask -> deny ─────────
@@ -89,7 +97,7 @@ async def mcp_hook(request: Request):
             {"rule": d.guardrail_type, "action": d.action, "snippet": d.entity_type}
             for d in scan_result.detections
         ]
-        await _audit("blocked", f"Hook deny: {reason}")
+        await _audit("blocked", f"Hook deny: {reason}", "deny")
         return JSONResponse(content={"decision": "deny", "reason": reason, "detections": detections})
 
     # ── require_approval (hook-only matcher): create/reuse approval request ──
@@ -128,7 +136,7 @@ async def mcp_hook(request: Request):
                     "agent_key_id": agent_key["id"],
                     "agent_key_name": agent_key.get("name"),
                 })
-            await _audit("approval_required", f"Approval request {approval.get('id')} created")
+            await _audit("approval_required", f"Approval request {approval.get('id')} created", "approval_required")
             exp = approval.get("expires_at")
             return JSONResponse(content={
                 "decision": "approval_required",
@@ -147,13 +155,69 @@ async def mcp_hook(request: Request):
             await enforce_mcp_rate_limits(agent_key, tool_name)
         except HTTPException as e:
             if e.status_code == 429:
-                await _audit("rate_limited", "Hook rate limited")
+                await _audit("rate_limited", "Hook rate limited", "rate_limited")
                 return JSONResponse(content={"decision": "rate_limited", "reason": "rate limit exceeded"})
             # Any other error while adjudicating must not escape to a 500 (the
             # adapter treats a non-200 as fail-open and would run the command).
             # Audit and deny instead.
-            await _audit("error", f"Hook error during rate-limit check: {e.detail}", is_error=True)
+            await _audit("error", f"Hook error during rate-limit check: {e.detail}", "error", is_error=True)
             return JSONResponse(content={"decision": "deny", "reason": "internal error during adjudication"})
 
-    await _audit("success", "Hook allow")
+    await _audit("success", "Hook allow", "allow")
     return JSONResponse(content={"decision": "allow"})
+
+
+MCP_RESULT_CAP_BYTES = getattr(settings, "mcp_result_cap_bytes", 10240)
+
+
+@router.post("/v1/mcp/hook/result")
+async def mcp_hook_result(request: Request):
+    """Receive a PostToolUse result and attach it to the existing audit row.
+    Never executes anything. Best-effort: returns 200 even when no row matches."""
+    agent_key = await extract_agent_key(request)
+    org_id = agent_key["organization_id"]
+    try:
+        body = await request.json()
+    except Exception:
+        raise HTTPException(status_code=400, detail="Invalid JSON body")
+
+    session_id = body.get("session_id")
+    tool_use_id = body.get("tool_use_id")
+    tool_name = body.get("tool_name") or "unknown"
+    tool_response = body.get("tool_response")
+    if not session_id or not tool_use_id:
+        raise HTTPException(status_code=400, detail="session_id and tool_use_id are required")
+
+    import json as _json
+    serialized = _json.dumps(tool_response) if tool_response is not None else "{}"
+    truncated = len(serialized.encode("utf-8")) > MCP_RESULT_CAP_BYTES
+    if truncated:
+        serialized = serialized.encode("utf-8")[:MCP_RESULT_CAP_BYTES].decode("utf-8", "ignore")
+    masked = await scan_result_blob(org_id, serialized)
+    try:
+        stored = _json.loads(masked)
+    except Exception:
+        stored = {"_raw": masked}
+
+    now = datetime.now(timezone.utc).isoformat()
+    if tool_name == "Bash" and isinstance(tool_response, dict) and tool_response.get("interrupted"):
+        outcome = {"type": "interrupted", "at": now}
+    elif tool_name in ("Write", "Edit") and isinstance(tool_response, dict) and tool_response.get("success") is False:
+        outcome = {"type": "failed", "at": now}
+    else:
+        outcome = {"type": "completed", "at": now}
+
+    status = await update_tool_result(
+        organization_id=org_id,
+        session_id=session_id,
+        tool_use_id=tool_use_id,
+        agent_key_id=agent_key["id"],
+        result_response=stored,
+        result_truncated=truncated,
+        outcome_event=outcome,
+    )
+    if status == "forbidden":
+        raise HTTPException(status_code=403, detail="result does not belong to this agent key")
+    if status == "error":
+        raise HTTPException(status_code=500, detail="failed to store tool result")
+    return JSONResponse(content={"status": status})

--- a/AIGateway/src/routers/mcp_hook.py
+++ b/AIGateway/src/routers/mcp_hook.py
@@ -11,6 +11,7 @@ an approval request and tell the caller to poll. Rate-limit exceed is reported a
 a distinct decision so the adapter can apply its infra fail-mode.
 """
 
+import json
 import logging
 import time
 from datetime import datetime, timezone, timedelta
@@ -188,15 +189,15 @@ async def mcp_hook_result(request: Request):
     if not session_id or not tool_use_id:
         raise HTTPException(status_code=400, detail="session_id and tool_use_id are required")
 
-    import json as _json
-    serialized = _json.dumps(tool_response) if tool_response is not None else "{}"
+    serialized = json.dumps(tool_response) if tool_response is not None else "{}"
     truncated = len(serialized.encode("utf-8")) > MCP_RESULT_CAP_BYTES
     if truncated:
         serialized = serialized.encode("utf-8")[:MCP_RESULT_CAP_BYTES].decode("utf-8", "ignore")
     masked = await scan_result_blob(org_id, serialized)
     try:
-        stored = _json.loads(masked)
+        stored = json.loads(masked)
     except Exception:
+        logger.warning("scan_result_blob produced non-JSON result; storing as _raw")
         stored = {"_raw": masked}
 
     now = datetime.now(timezone.utc).isoformat()

--- a/AIGateway/src/services/mcp_audit_service.py
+++ b/AIGateway/src/services/mcp_audit_service.py
@@ -37,6 +37,8 @@ async def log_tool_call(
     latency_ms: int,
     session_id: Optional[str] = None,
     metadata: Optional[dict] = None,
+    tool_use_id: Optional[str] = None,
+    events: Optional[list] = None,
 ) -> None:
     """Insert an MCP audit log entry. Fire-and-forget with error catch."""
     try:
@@ -50,11 +52,12 @@ async def log_tool_call(
                     INSERT INTO ai_gateway_mcp_audit_logs
                         (organization_id, agent_key_id, server_id, tool_name,
                          arguments, result_status, result_summary, is_error,
-                         latency_ms, session_id, metadata)
+                         latency_ms, session_id, metadata, tool_use_id, events)
                     VALUES
                         (:org_id, :agent_key_id, :server_id, :tool_name,
                          CAST(:arguments AS jsonb), :result_status, :result_summary, :is_error,
-                         :latency_ms, :session_id, CAST(:metadata AS jsonb))
+                         :latency_ms, :session_id, CAST(:metadata AS jsonb),
+                         :tool_use_id, CAST(:events AS jsonb))
                 """),
                 {
                     "org_id": organization_id,
@@ -68,8 +71,73 @@ async def log_tool_call(
                     "latency_ms": latency_ms,
                     "session_id": session_id,
                     "metadata": json.dumps(metadata or {}),
+                    "tool_use_id": tool_use_id,
+                    "events": json.dumps(events or []),
                 },
             )
             await db.commit()
     except Exception as e:
         logger.error(f"Failed to log MCP tool call: {e}")
+
+
+async def update_tool_result(
+    organization_id: int,
+    session_id: str,
+    tool_use_id: str,
+    agent_key_id: int,
+    result_response: dict,
+    result_truncated: bool,
+    outcome_event: dict,  # {"type": "...", "at": "...", "detail"?: "..."}
+) -> str:
+    """Update the audit row for (org, session_id, tool_use_id) with the tool result.
+    Flips approval_required -> success, stores result_response, appends outcome_event.
+    Returns: "ok" | "no_match" | "forbidden". Fire-and-forget safe."""
+    try:
+        async with get_db() as db:
+            row = (await db.execute(
+                text("""
+                    SELECT id, agent_key_id, result_status, events
+                    FROM ai_gateway_mcp_audit_logs
+                    WHERE organization_id = :org_id
+                      AND session_id = :session_id
+                      AND tool_use_id = :tool_use_id
+                    ORDER BY created_at DESC
+                    LIMIT 1
+                """),
+                {"org_id": organization_id, "session_id": session_id, "tool_use_id": tool_use_id},
+            )).mappings().fetchone()
+
+            if not row:
+                return "no_match"
+            if row["agent_key_id"] != agent_key_id:
+                return "forbidden"
+
+            existing_events = row["events"] or []
+            if isinstance(existing_events, str):
+                existing_events = json.loads(existing_events)
+            new_events = existing_events + [outcome_event]
+
+            new_status = "success" if row["result_status"] == "approval_required" else row["result_status"]
+
+            await db.execute(
+                text("""
+                    UPDATE ai_gateway_mcp_audit_logs
+                    SET result_response = CAST(:result_response AS jsonb),
+                        result_truncated = :result_truncated,
+                        result_status = :new_status,
+                        events = CAST(:events AS jsonb)
+                    WHERE id = :id
+                """),
+                {
+                    "id": row["id"],
+                    "result_response": json.dumps(result_response),
+                    "result_truncated": result_truncated,
+                    "new_status": new_status,
+                    "events": json.dumps(new_events),
+                },
+            )
+            await db.commit()
+            return "ok"
+    except Exception as e:
+        logger.error(f"Failed to update MCP tool result: {e}")
+        return "no_match"

--- a/AIGateway/src/services/mcp_audit_service.py
+++ b/AIGateway/src/services/mcp_audit_service.py
@@ -91,7 +91,7 @@ async def update_tool_result(
 ) -> str:
     """Update the audit row for (org, session_id, tool_use_id) with the tool result.
     Flips approval_required -> success, stores result_response, appends outcome_event.
-    Returns: "ok" | "no_match" | "forbidden". Fire-and-forget safe."""
+    Returns: "ok" | "no_match" | "forbidden" | "error". Fire-and-forget safe."""
     try:
         async with get_db() as db:
             row = (await db.execute(
@@ -140,4 +140,4 @@ async def update_tool_result(
             return "ok"
     except Exception as e:
         logger.error(f"Failed to update MCP tool result: {e}")
-        return "no_match"
+        return "error"

--- a/AIGateway/src/services/mcp_guardrail_service.py
+++ b/AIGateway/src/services/mcp_guardrail_service.py
@@ -204,19 +204,28 @@ async def scan_result_blob(org_id: int, blob: str) -> str:
             settings_row = settings_result.mappings().fetchone()
             guardrail_settings = dict(settings_row) if settings_row else {}
 
-        transformed_rules = [
-            {
+        transformed_rules = []
+        for r in mcp_rules:
+            rule_type = r.get("rule_type")
+            if rule_type not in ("pii", "content_filter"):
+                continue
+            cfg = dict(r.get("config") or {})
+            # A result has already executed — "block" is meaningless. Force every
+            # configured entity to "mask" so block-action rules still sanitize at rest
+            # instead of short-circuiting scan_text into a blocked result (which would
+            # return masked_text=None and leak the unmasked blob).
+            entities = cfg.get("entities")
+            if isinstance(entities, dict):
+                cfg["entities"] = {k: "mask" for k in entities}
+            transformed_rules.append({
                 "id": r["id"],
-                "guardrail_type": r["rule_type"],
+                "guardrail_type": rule_type,
                 "name": r["name"],
-                "config": r.get("config") or {},
+                "config": cfg,
                 "scope": "output",
                 "action": "mask",
                 "is_active": True,
-            }
-            for r in mcp_rules
-            if r.get("rule_type") in ("pii", "content_filter")
-        ]
+            })
         if not transformed_rules:
             return blob
         result = scan_text(text=blob, guardrail_rules=transformed_rules, settings=guardrail_settings)

--- a/AIGateway/src/services/mcp_guardrail_service.py
+++ b/AIGateway/src/services/mcp_guardrail_service.py
@@ -184,8 +184,7 @@ async def scan_result_blob(org_id: int, blob: str) -> str:
         async with get_db() as db:
             rules_result = await db.execute(
                 text("""
-                    SELECT id, name, rule_type, config, scope, action,
-                           applies_to_tools, is_active
+                    SELECT id, name, rule_type, config, scope, action
                     FROM ai_gateway_mcp_guardrail_rules
                     WHERE organization_id = :org_id AND is_active = true
                     ORDER BY created_at
@@ -221,6 +220,7 @@ async def scan_result_blob(org_id: int, blob: str) -> str:
         if not transformed_rules:
             return blob
         result = scan_text(text=blob, guardrail_rules=transformed_rules, settings=guardrail_settings)
+        # masked_text is None when nothing matched — fall back to the original blob
         return result.masked_text or blob
     except Exception as e:
         logger.error(f"scan_result_blob failed, storing unmasked: {e}")

--- a/AIGateway/src/services/mcp_guardrail_service.py
+++ b/AIGateway/src/services/mcp_guardrail_service.py
@@ -173,6 +173,60 @@ async def scan_tool_input(
     return result
 
 
+async def scan_result_blob(org_id: int, blob: str) -> str:
+    """Mask PII / filtered content in a flat result string (tool stdout/stderr,
+    serialized tool_response). Returns the masked string. Never blocks — a tool
+    result has already been produced; we only sanitize what we store at rest.
+    Fails open (returns the original blob) on any error."""
+    if not blob or not blob.strip():
+        return blob
+    try:
+        async with get_db() as db:
+            rules_result = await db.execute(
+                text("""
+                    SELECT id, name, rule_type, config, scope, action,
+                           applies_to_tools, is_active
+                    FROM ai_gateway_mcp_guardrail_rules
+                    WHERE organization_id = :org_id AND is_active = true
+                    ORDER BY created_at
+                """),
+                {"org_id": org_id},
+            )
+            mcp_rules = [dict(r) for r in rules_result.mappings().fetchall()]
+            settings_result = await db.execute(
+                text("""
+                    SELECT pii_on_error, content_filter_on_error,
+                           pii_replacement_format, content_filter_replacement
+                    FROM ai_gateway_guardrail_settings
+                    WHERE organization_id = :org_id
+                """),
+                {"org_id": org_id},
+            )
+            settings_row = settings_result.mappings().fetchone()
+            guardrail_settings = dict(settings_row) if settings_row else {}
+
+        transformed_rules = [
+            {
+                "id": r["id"],
+                "guardrail_type": r["rule_type"],
+                "name": r["name"],
+                "config": r.get("config") or {},
+                "scope": "output",
+                "action": "mask",
+                "is_active": True,
+            }
+            for r in mcp_rules
+            if r.get("rule_type") in ("pii", "content_filter")
+        ]
+        if not transformed_rules:
+            return blob
+        result = scan_text(text=blob, guardrail_rules=transformed_rules, settings=guardrail_settings)
+        return result.masked_text or blob
+    except Exception as e:
+        logger.error(f"scan_result_blob failed, storing unmasked: {e}")
+        return blob
+
+
 # ─── Anomaly Detection ──────────────────────────────────────────────────────
 
 ANOMALY_WINDOW = 3600  # 1 hour

--- a/AIGateway/tests/test_16_mcp_hook_results.py
+++ b/AIGateway/tests/test_16_mcp_hook_results.py
@@ -19,3 +19,72 @@ def test_setup_result_key_and_pii_rule(api):
         "config": {"entities": {"EMAIL_ADDRESS": "mask"}, "score_thresholds": {"ALL": 0.5}, "language": "en"},
     })
     assert rule_res.status_code in (200, 201), rule_res.text
+
+
+def _hook(key, tool_name, arguments, session_id, tool_use_id):
+    return _client.post(
+        f"{GATEWAY_URL}/v1/mcp/hook",
+        headers={"Authorization": f"Bearer {key}", "Content-Type": "application/json"},
+        json={"tool_name": tool_name, "arguments": arguments,
+              "session_id": session_id, "tool_use_id": tool_use_id},
+    )
+
+
+def _result(key, tool_name, tool_response, session_id, tool_use_id):
+    return _client.post(
+        f"{GATEWAY_URL}/v1/mcp/hook/result",
+        headers={"Authorization": f"Bearer {key}", "Content-Type": "application/json"},
+        json={"tool_name": tool_name, "tool_response": tool_response,
+              "session_id": session_id, "tool_use_id": tool_use_id},
+    )
+
+
+def test_allow_then_result_attaches():
+    key = get_state("result_agent_key")
+    if not key:
+        pytest.skip("no key")
+    sid, tuid = "sess-A", "toolu_A1"
+    assert _hook(key, "Bash", {"command": "ls"}, sid, tuid).json()["decision"] == "allow"
+    res = _result(key, "Bash", {"stdout": "file1\nfile2", "stderr": "", "interrupted": False, "isImage": False}, sid, tuid)
+    assert res.status_code == 200, res.text
+    assert res.json()["status"] == "ok"
+
+
+def test_result_masks_pii_in_stdout():
+    key = get_state("result_agent_key")
+    if not key:
+        pytest.skip("no key")
+    sid, tuid = "sess-B", "toolu_B1"
+    _hook(key, "Bash", {"command": "cat creds"}, sid, tuid)
+    res = _result(key, "Bash", {"stdout": "token for attacker@evil.com", "stderr": "", "interrupted": False, "isImage": False}, sid, tuid)
+    assert res.status_code == 200, res.text
+    assert res.json()["status"] == "ok"
+    # Masking is verified at storage; reading the row back requires the internal
+    # key path (GET /mcp/audit/logs/{id}) which the `api` fixture covers. If your
+    # harness exposes the row, assert "attacker@evil.com" not in the stored result.
+
+
+def test_result_no_match_returns_ok_status():
+    key = get_state("result_agent_key")
+    if not key:
+        pytest.skip("no key")
+    res = _result(key, "Bash", {"stdout": "x"}, "sess-never", "toolu-never")
+    assert res.status_code == 200, res.text
+    assert res.json()["status"] == "no_match"
+
+
+def test_result_missing_ids_returns_400():
+    key = get_state("result_agent_key")
+    if not key:
+        pytest.skip("no key")
+    res = _client.post(f"{GATEWAY_URL}/v1/mcp/hook/result",
+        headers={"Authorization": f"Bearer {key}", "Content-Type": "application/json"},
+        json={"tool_name": "Bash", "tool_response": {"stdout": "x"}})
+    assert res.status_code == 400, res.text
+
+
+def test_result_bad_key_returns_401():
+    res = _client.post(f"{GATEWAY_URL}/v1/mcp/hook/result",
+        headers={"Authorization": "Bearer sk-mcp-not-a-real-key", "Content-Type": "application/json"},
+        json={"tool_name": "Bash", "tool_response": {"stdout": "x"}, "session_id": "s", "tool_use_id": "t"})
+    assert res.status_code == 401, res.text

--- a/AIGateway/tests/test_16_mcp_hook_results.py
+++ b/AIGateway/tests/test_16_mcp_hook_results.py
@@ -1,4 +1,5 @@
 """E2E: native tool-call result capture (/v1/mcp/hook/result)."""
+import json
 import os
 import httpx
 import pytest
@@ -50,18 +51,45 @@ def test_allow_then_result_attaches():
     assert res.json()["status"] == "ok"
 
 
-def test_result_masks_pii_in_stdout():
+def test_result_masks_pii_in_stdout(api):
     key = get_state("result_agent_key")
     if not key:
         pytest.skip("no key")
     sid, tuid = "sess-B", "toolu_B1"
-    _hook(key, "Bash", {"command": "cat creds"}, sid, tuid)
-    res = _result(key, "Bash", {"stdout": "token for attacker@evil.com", "stderr": "", "interrupted": False, "isImage": False}, sid, tuid)
+
+    # Guard: pre-tool hook must allow the command (no PII in arguments).
+    assert _hook(key, "Bash", {"command": "cat creds"}, sid, tuid).json()["decision"] == "allow"
+
+    # Post-tool result contains an email — masking rule must fire.
+    res = _result(
+        key, "Bash",
+        {"stdout": "token for attacker@evil.com", "stderr": "", "interrupted": False, "isImage": False},
+        sid, tuid,
+    )
     assert res.status_code == 200, res.text
     assert res.json()["status"] == "ok"
-    # Masking is verified at storage; reading the row back requires the internal
-    # key path (GET /mcp/audit/logs/{id}) which the `api` fixture covers. If your
-    # harness exposes the row, assert "attacker@evil.com" not in the stored result.
+
+    # Read the row back and verify PII was masked at storage.
+    #
+    # Strategy: LIST endpoint (GET /mcp/audit/logs) returns `id` and `session_id`
+    # but NOT `tool_use_id`/`result_response`. We find the row by session_id to
+    # get its `id`, then fetch the single-row endpoint which does expose
+    # `tool_use_id` and `result_response`.
+    listed = api.get("/mcp/audit/logs?limit=100")
+    assert listed.status_code == 200, listed.text
+    rows = listed.json().get("data") or []
+    # Locate the row written for this session.
+    match = next((r for r in rows if r.get("session_id") == sid), None)
+    assert match is not None, f"audit row not found for session_id={sid!r}"
+
+    # Fetch single-row endpoint for result_response (not in LIST SELECT).
+    log_id = match["id"]
+    detail = api.get(f"/mcp/audit/logs/{log_id}")
+    assert detail.status_code == 200, detail.text
+    row = detail.json().get("data") or {}
+    assert row.get("tool_use_id") == tuid, "tool_use_id mismatch in stored row"
+    # The raw email must not appear in the stored result (it must have been masked).
+    assert "attacker@evil.com" not in json.dumps(row.get("result_response") or {})
 
 
 def test_result_no_match_returns_ok_status():

--- a/AIGateway/tests/test_16_mcp_hook_results.py
+++ b/AIGateway/tests/test_16_mcp_hook_results.py
@@ -1,0 +1,21 @@
+"""E2E: native tool-call result capture (/v1/mcp/hook/result)."""
+import os
+import httpx
+import pytest
+from conftest import set_state, get_state
+
+GATEWAY_URL = os.getenv("GATEWAY_URL", "http://localhost:8100")
+_client = httpx.Client(timeout=30.0)
+
+
+def test_setup_result_key_and_pii_rule(api):
+    key_res = api.post("/mcp/agent-keys", json={"name": "E2E Result Key"})
+    assert key_res.status_code in (200, 201), key_res.text
+    set_state("result_agent_key", key_res.json()["data"]["plain_key"])
+    rule_res = api.post("/mcp/guardrails", json={
+        "name": "E2E Result PII Mask",
+        "rule_type": "pii",
+        "action": "mask",
+        "config": {"entities": {"EMAIL_ADDRESS": "mask"}, "score_thresholds": {"ALL": 0.5}, "language": "en"},
+    })
+    assert rule_res.status_code in (200, 201), rule_res.text

--- a/Clients/src/i18n/translations.ts
+++ b/Clients/src/i18n/translations.ts
@@ -3994,6 +3994,9 @@ export const translations: Record<string, Record<string, string>> = {
     "Rate limit": "Ratenlimit",
     "Time": "Zeit",
     "Require approval": "Genehmigung erforderlich",
+    "TOOL USE ID": "TOOL-USE-ID",
+    "No result captured (older adapter, or the tool did not report back).":
+      "Kein Ergebnis erfasst (älterer Adapter oder das Tool hat nicht zurückgemeldet).",
 
     // MCP Approvals page
     "No pending approvals": "Keine ausstehenden Genehmigungen",
@@ -9363,6 +9366,9 @@ export const translations: Record<string, Record<string, string>> = {
     "Rate limit": "Limite de débit",
     "Time": "Heure",
     "Require approval": "Approbation requise",
+    "TOOL USE ID": "ID D'UTILISATION D'OUTIL",
+    "No result captured (older adapter, or the tool did not report back).":
+      "Aucun résultat capturé (adaptateur plus ancien ou l'outil n'a rien renvoyé).",
     "No pending approvals": "Aucune approbation en attente",
     "No approval history yet": "Aucun historique d'approbation pour le moment",
 
@@ -19637,6 +19643,9 @@ export const translations: Record<string, Record<string, string>> = {
     "Review request": "Revisar solicitud",
     "No approval history yet": "Aún no hay historial de aprobaciones",
     "Approval history": "Historial de aprobaciones",
+    "TOOL USE ID": "ID DE USO DE HERRAMIENTA",
+    "No result captured (older adapter, or the tool did not report back).":
+      "No se capturó ningún resultado (adaptador antiguo o la herramienta no respondió).",
     "Label (optional)": "Etiqueta (opcional)",
     "Name (optional)": "Nombre (opcional)",
     "Description (optional)": "Descripción (opcional)",

--- a/Clients/src/presentation/pages/AIGateway/MCPAuditLog/index.tsx
+++ b/Clients/src/presentation/pages/AIGateway/MCPAuditLog/index.tsx
@@ -16,6 +16,7 @@ import { apiServices } from "../../../../infrastructure/api/networkServices";
 import palette from "../../../themes/palette";
 import { sectionTitleSx, useCardSx, MCP_STATUS_COLORS, MCP_STATUS_FALLBACK } from "../shared";
 import MCPTable from "../MCPTable";
+import MCPInvocationDrawer from "../MCPInvocationDrawer";
 import { displayFormattedDate } from "../../../tools/isoDateToString";
 
 interface AuditLog {
@@ -69,6 +70,7 @@ export default function MCPAuditLogPage() {
   const [total, setTotal] = useState(0);
   const [filterTool, setFilterTool] = useState("");
   const [filterStatus, setFilterStatus] = useState("all");
+  const [drawerLogId, setDrawerLogId] = useState<number | null>(null);
 
   const loadStats = useCallback(async () => {
     try {
@@ -318,6 +320,7 @@ export default function MCPAuditLogPage() {
                   ]}
                   rows={logs}
                   rowKey={(log) => log.id}
+                  onRowClick={(log) => setDrawerLogId(log.id)}
                   renderRow={(log) => {
                     const colors = MCP_STATUS_COLORS[log.result_status] || MCP_STATUS_FALLBACK;
                     return [
@@ -376,6 +379,12 @@ export default function MCPAuditLogPage() {
           </Stack>
         </>
       )}
+
+      <MCPInvocationDrawer
+        logId={drawerLogId}
+        open={drawerLogId !== null}
+        onClose={() => setDrawerLogId(null)}
+      />
     </PageHeaderExtended>
   );
 }

--- a/Clients/src/presentation/pages/AIGateway/MCPInvocationDrawer.tsx
+++ b/Clients/src/presentation/pages/AIGateway/MCPInvocationDrawer.tsx
@@ -28,6 +28,7 @@ interface InvocationEvent {
 interface AuditLogDetail {
   id: number;
   tool_name: string;
+  agent_key_name?: string | null;
   result_status: string;
   result_summary: string | null;
   tool_use_id: string | null;
@@ -81,6 +82,9 @@ export default function MCPInvocationDrawer({ logId, open, onClose }: Invocation
               </Typography>
               <Typography sx={{ fontSize: 12, color: palette.text.tertiary }}>
                 {displayFormattedDate(row.created_at)}
+              </Typography>
+              <Typography sx={{ fontSize: 12, color: palette.text.tertiary }}>
+                {(row.agent_key_name || "—") + " · " + (row.session_id || "—")}
               </Typography>
             </Box>
             <IconButton size="small" onClick={onClose} aria-label="Close">

--- a/Clients/src/presentation/pages/AIGateway/MCPInvocationDrawer.tsx
+++ b/Clients/src/presentation/pages/AIGateway/MCPInvocationDrawer.tsx
@@ -4,7 +4,13 @@ import { useState, useEffect } from "react";
 import Chip from "../../components/Chip";
 import { apiServices } from "../../../infrastructure/api/networkServices";
 import palette from "../../themes/palette";
-import { MCP_STATUS_COLORS, MCP_STATUS_FALLBACK } from "./shared";
+import {
+  MCP_STATUS_COLORS,
+  MCP_STATUS_FALLBACK,
+  KEY_DISPLAY_BG,
+  CODE_BLOCK_BG,
+  CODE_BLOCK_TEXT,
+} from "./shared";
 import { displayFormattedDate } from "../../tools/isoDateToString";
 
 interface InvocationDrawerProps {
@@ -13,8 +19,28 @@ interface InvocationDrawerProps {
   onClose: () => void;
 }
 
+interface InvocationEvent {
+  type: string;
+  at: string;
+  detail?: string;
+}
+
+interface AuditLogDetail {
+  id: number;
+  tool_name: string;
+  result_status: string;
+  result_summary: string | null;
+  tool_use_id: string | null;
+  session_id: string | null;
+  arguments: Record<string, unknown> | null;
+  result_response: Record<string, unknown> | null;
+  result_truncated: boolean;
+  events: InvocationEvent[];
+  created_at: string;
+}
+
 export default function MCPInvocationDrawer({ logId, open, onClose }: InvocationDrawerProps) {
-  const [row, setRow] = useState<any | null>(null);
+  const [row, setRow] = useState<AuditLogDetail | null>(null);
   const [showRaw, setShowRaw] = useState(false);
 
   useEffect(() => {
@@ -23,7 +49,7 @@ export default function MCPInvocationDrawer({ logId, open, onClose }: Invocation
     setShowRaw(false);
     apiServices
       .get<Record<string, any>>(`/ai-gateway/mcp/audit/logs/${logId}`)
-      .then((res) => setRow(res?.data?.data || null))
+      .then((res) => setRow((res?.data?.data as AuditLogDetail) || null))
       .catch(() => setRow(null));
   }, [open, logId]);
 
@@ -79,7 +105,7 @@ export default function MCPInvocationDrawer({ logId, open, onClose }: Invocation
                 fontSize: 12,
                 fontFamily: "monospace",
                 whiteSpace: "pre-wrap",
-                bgcolor: "#F9FAFB",
+                bgcolor: KEY_DISPLAY_BG,
                 p: "8px",
                 borderRadius: "4px",
                 overflow: "auto",
@@ -99,7 +125,7 @@ export default function MCPInvocationDrawer({ logId, open, onClose }: Invocation
                   fontSize: 12,
                   fontFamily: "monospace",
                   whiteSpace: "pre-wrap",
-                  bgcolor: "#F9FAFB",
+                  bgcolor: KEY_DISPLAY_BG,
                   p: "8px",
                   borderRadius: "4px",
                   overflow: "auto",
@@ -119,7 +145,7 @@ export default function MCPInvocationDrawer({ logId, open, onClose }: Invocation
           <Box>
             <Typography sx={labelSx}>EVENTS</Typography>
             <Stack gap="4px" sx={{ mt: "4px" }}>
-              {(row.events || []).map((e: any, i: number) => (
+              {(row.events || []).map((e: InvocationEvent, i: number) => (
                 <Stack key={i} direction="row" justifyContent="space-between">
                   <Typography sx={{ fontSize: 12 }}>
                     {e.type}
@@ -134,12 +160,21 @@ export default function MCPInvocationDrawer({ logId, open, onClose }: Invocation
           </Box>
 
           <Box>
-            <Typography
-              sx={{ fontSize: 12, color: palette.brand.primary, cursor: "pointer" }}
+            <Box
+              component="button"
               onClick={() => setShowRaw((v) => !v)}
+              sx={{
+                fontSize: 12,
+                color: palette.brand.primary,
+                cursor: "pointer",
+                background: "none",
+                border: "none",
+                p: 0,
+                textAlign: "left",
+              }}
             >
               {showRaw ? "Hide raw JSON" : "Show raw JSON"}
-            </Typography>
+            </Box>
             {showRaw && (
               <Box
                 component="pre"
@@ -147,8 +182,8 @@ export default function MCPInvocationDrawer({ logId, open, onClose }: Invocation
                   fontSize: 11,
                   fontFamily: "monospace",
                   whiteSpace: "pre-wrap",
-                  bgcolor: "#1E1E1E",
-                  color: "#D4D4D4",
+                  bgcolor: CODE_BLOCK_BG,
+                  color: CODE_BLOCK_TEXT,
                   p: "8px",
                   borderRadius: "4px",
                   overflow: "auto",

--- a/Clients/src/presentation/pages/AIGateway/MCPInvocationDrawer.tsx
+++ b/Clients/src/presentation/pages/AIGateway/MCPInvocationDrawer.tsx
@@ -1,0 +1,166 @@
+import { Box, Drawer, Typography, Stack, IconButton } from "@mui/material";
+import { X } from "lucide-react";
+import { useState, useEffect } from "react";
+import Chip from "../../components/Chip";
+import { apiServices } from "../../../infrastructure/api/networkServices";
+import palette from "../../themes/palette";
+import { MCP_STATUS_COLORS, MCP_STATUS_FALLBACK } from "./shared";
+import { displayFormattedDate } from "../../tools/isoDateToString";
+
+interface InvocationDrawerProps {
+  logId: number | null;
+  open: boolean;
+  onClose: () => void;
+}
+
+export default function MCPInvocationDrawer({ logId, open, onClose }: InvocationDrawerProps) {
+  const [row, setRow] = useState<any | null>(null);
+  const [showRaw, setShowRaw] = useState(false);
+
+  useEffect(() => {
+    if (!open || !logId) return;
+    setRow(null);
+    setShowRaw(false);
+    apiServices
+      .get<Record<string, any>>(`/ai-gateway/mcp/audit/logs/${logId}`)
+      .then((res) => setRow(res?.data?.data || null))
+      .catch(() => setRow(null));
+  }, [open, logId]);
+
+  const colors = row
+    ? MCP_STATUS_COLORS[row.result_status] || MCP_STATUS_FALLBACK
+    : MCP_STATUS_FALLBACK;
+  const labelSx = {
+    fontSize: 11,
+    fontWeight: 600,
+    color: palette.text.tertiary,
+    letterSpacing: "0.5px",
+  };
+
+  return (
+    <Drawer
+      anchor="right"
+      open={open}
+      onClose={onClose}
+      sx={{ "& .MuiDrawer-paper": { width: 520, p: 3 } }}
+    >
+      {!row ? (
+        <Typography sx={{ fontSize: 13, color: palette.text.tertiary }}>Loading…</Typography>
+      ) : (
+        <Stack gap="16px">
+          <Stack direction="row" justifyContent="space-between" alignItems="flex-start">
+            <Box>
+              <Typography sx={{ fontSize: 16, fontWeight: 600, fontFamily: "monospace" }}>
+                {row.tool_name}
+              </Typography>
+              <Typography sx={{ fontSize: 12, color: palette.text.tertiary }}>
+                {displayFormattedDate(row.created_at)}
+              </Typography>
+            </Box>
+            <IconButton size="small" onClick={onClose} aria-label="Close">
+              <X size={16} />
+            </IconButton>
+          </Stack>
+
+          <Chip label={row.result_status} backgroundColor={colors.bg} textColor={colors.text} />
+
+          <Box>
+            <Typography sx={labelSx}>TOOL USE ID</Typography>
+            <Typography sx={{ fontSize: 12, fontFamily: "monospace" }}>
+              {row.tool_use_id || "—"}
+            </Typography>
+          </Box>
+
+          <Box>
+            <Typography sx={labelSx}>ARGUMENTS</Typography>
+            <Box
+              component="pre"
+              sx={{
+                fontSize: 12,
+                fontFamily: "monospace",
+                whiteSpace: "pre-wrap",
+                bgcolor: "#F9FAFB",
+                p: "8px",
+                borderRadius: "4px",
+                overflow: "auto",
+                maxHeight: 200,
+              }}
+            >
+              {JSON.stringify(row.arguments ?? {}, null, 2)}
+            </Box>
+          </Box>
+
+          <Box>
+            <Typography sx={labelSx}>RESULT</Typography>
+            {row.result_response ? (
+              <Box
+                component="pre"
+                sx={{
+                  fontSize: 12,
+                  fontFamily: "monospace",
+                  whiteSpace: "pre-wrap",
+                  bgcolor: "#F9FAFB",
+                  p: "8px",
+                  borderRadius: "4px",
+                  overflow: "auto",
+                  maxHeight: 280,
+                }}
+              >
+                {JSON.stringify(row.result_response, null, 2)}
+                {row.result_truncated ? "\n… (truncated)" : ""}
+              </Box>
+            ) : (
+              <Typography sx={{ fontSize: 12, color: palette.text.tertiary }}>
+                No result captured (older adapter, or the tool did not report back).
+              </Typography>
+            )}
+          </Box>
+
+          <Box>
+            <Typography sx={labelSx}>EVENTS</Typography>
+            <Stack gap="4px" sx={{ mt: "4px" }}>
+              {(row.events || []).map((e: any, i: number) => (
+                <Stack key={i} direction="row" justifyContent="space-between">
+                  <Typography sx={{ fontSize: 12 }}>
+                    {e.type}
+                    {e.detail ? ` · ${e.detail}` : ""}
+                  </Typography>
+                  <Typography sx={{ fontSize: 12, color: palette.text.tertiary }}>
+                    {displayFormattedDate(e.at)}
+                  </Typography>
+                </Stack>
+              ))}
+            </Stack>
+          </Box>
+
+          <Box>
+            <Typography
+              sx={{ fontSize: 12, color: palette.brand.primary, cursor: "pointer" }}
+              onClick={() => setShowRaw((v) => !v)}
+            >
+              {showRaw ? "Hide raw JSON" : "Show raw JSON"}
+            </Typography>
+            {showRaw && (
+              <Box
+                component="pre"
+                sx={{
+                  fontSize: 11,
+                  fontFamily: "monospace",
+                  whiteSpace: "pre-wrap",
+                  bgcolor: "#1E1E1E",
+                  color: "#D4D4D4",
+                  p: "8px",
+                  borderRadius: "4px",
+                  overflow: "auto",
+                  maxHeight: 320,
+                }}
+              >
+                {JSON.stringify(row, null, 2)}
+              </Box>
+            )}
+          </Box>
+        </Stack>
+      )}
+    </Drawer>
+  );
+}

--- a/docs/superpowers/plans/2026-06-16-agent-control-tool-results.md
+++ b/docs/superpowers/plans/2026-06-16-agent-control-tool-results.md
@@ -1,0 +1,951 @@
+# Agent Control Tool Result Capture Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Capture each native tool call's result and a per-invocation events timeline, and surface both in a detail drawer on the Agent Control Activity page.
+
+**Architecture:** A new `POST /v1/mcp/hook/result` endpoint receives the tool result from a Claude Code PostToolUse hook and updates the existing audit row, correlated by `(organization_id, session_id, tool_use_id)`. The PreToolUse hook now stores `tool_use_id` and seeds an events array. The adapter gains a result mode. The frontend makes Activity rows open a detail drawer.
+
+**Tech Stack:** FastAPI + SQLAlchemy Core (raw SQL) + Alembic (AIGateway, Python 3.11); React 19 + MUI 7 + TypeScript (Clients); bash adapter; pytest httpx E2E.
+
+**Spec:** `docs/superpowers/specs/2026-06-16-agent-control-tool-results-design.md`
+
+---
+
+## File Structure
+
+**Backend (AIGateway):**
+- Create: `AIGateway/src/database/migrations/versions/a0007_mcp_audit_results.py` — additive columns + index.
+- Modify: `AIGateway/src/services/mcp_audit_service.py` — `log_tool_call` gains `tool_use_id` + `events`; new `update_tool_result(...)`.
+- Modify: `AIGateway/src/routers/mcp_hook.py` — pass `tool_use_id`/`events` into `_audit`; add `POST /v1/mcp/hook/result`.
+- Modify: `AIGateway/src/services/mcp_guardrail_service.py` — new `scan_result_blob(org_id, text)` masking helper.
+- Modify: `AIGateway/src/crud/mcp_audit.py` — new `get_audit_log_by_id(org_id, log_id)`.
+- Modify: `AIGateway/src/routers/mcp_audit.py` — new `GET /mcp/audit/logs/{log_id}`.
+- Test: `AIGateway/tests/test_16_mcp_hook_results.py`.
+
+**Adapter:**
+- Modify: `scripts/vw-tool-hook.sh` — send `session_id`/`tool_use_id`; add result mode.
+- Modify: `scripts/vw-tool-hook.README.md` (or the adapter README) — PostToolUse config block.
+
+**Frontend (Clients):**
+- Create: `Clients/src/presentation/pages/AIGateway/MCPInvocationDrawer.tsx`.
+- Modify: `Clients/src/presentation/pages/AIGateway/MCPAuditLog/index.tsx` — clickable rows + drawer state.
+
+> **Branch note:** This plan builds on the `MCPTable` component and the `(session_id)` audit column, both of which already exist on `develop` / PR #4096. Implement on a branch off `develop` after #4096 merges, or rebase. If `MCPTable` is absent, the row-click step must be adapted to whatever Activity table is present.
+
+---
+
+## Task 1: Migration — additive audit result columns
+
+**Files:**
+- Create: `AIGateway/src/database/migrations/versions/a0007_mcp_audit_results.py`
+
+- [ ] **Step 1: Write the migration**
+
+```python
+"""Add tool result + events columns to mcp audit logs
+
+Revision ID: a0007
+Revises: a0006
+Create Date: 2026-06-16
+"""
+from alembic import op
+
+revision = "a0007"
+down_revision = "a0006"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.execute("SET search_path TO verifywise")
+    op.execute("""
+        ALTER TABLE ai_gateway_mcp_audit_logs
+            ADD COLUMN IF NOT EXISTS tool_use_id      VARCHAR(128),
+            ADD COLUMN IF NOT EXISTS result_response  JSONB,
+            ADD COLUMN IF NOT EXISTS result_truncated BOOLEAN DEFAULT false,
+            ADD COLUMN IF NOT EXISTS events           JSONB DEFAULT '[]'
+    """)
+    op.execute("""
+        CREATE INDEX IF NOT EXISTS idx_gw_mcp_audit_invocation
+            ON ai_gateway_mcp_audit_logs(organization_id, session_id, tool_use_id)
+    """)
+
+
+def downgrade():
+    op.execute("SET search_path TO verifywise")
+    op.execute("DROP INDEX IF EXISTS idx_gw_mcp_audit_invocation")
+    op.execute("""
+        ALTER TABLE ai_gateway_mcp_audit_logs
+            DROP COLUMN IF EXISTS tool_use_id,
+            DROP COLUMN IF EXISTS result_response,
+            DROP COLUMN IF EXISTS result_truncated,
+            DROP COLUMN IF EXISTS events
+    """)
+```
+
+- [ ] **Step 2: Run the migration**
+
+Run: `cd AIGateway/src && alembic upgrade head`
+Expected: completes; `\d ai_gateway_mcp_audit_logs` shows the 4 new columns.
+
+- [ ] **Step 3: Verify downgrade is reversible (then re-up)**
+
+Run: `cd AIGateway/src && alembic downgrade -1 && alembic upgrade head`
+Expected: both succeed without error.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add AIGateway/src/database/migrations/versions/a0007_mcp_audit_results.py
+git commit -m "feat(ai-gateway): migration for mcp audit result + events columns"
+```
+
+---
+
+## Task 2: `scan_result_blob` masking helper
+
+**Files:**
+- Modify: `AIGateway/src/services/mcp_guardrail_service.py`
+- Test: `AIGateway/tests/test_16_mcp_hook_results.py`
+
+- [ ] **Step 1: Write the failing test**
+
+Add to a new file `AIGateway/tests/test_16_mcp_hook_results.py`:
+
+```python
+"""E2E: native tool-call result capture (/v1/mcp/hook/result)."""
+import os
+import httpx
+import pytest
+from conftest import set_state, get_state
+
+GATEWAY_URL = os.getenv("GATEWAY_URL", "http://localhost:8100")
+_client = httpx.Client(timeout=30.0)
+
+
+def test_setup_result_key_and_pii_rule(api):
+    key_res = api.post("/mcp/agent-keys", json={"name": "E2E Result Key"})
+    assert key_res.status_code in (200, 201), key_res.text
+    set_state("result_agent_key", key_res.json()["data"]["plain_key"])
+    # A mask rule so result PII is masked at rest.
+    rule_res = api.post("/mcp/guardrails", json={
+        "name": "E2E Result PII Mask",
+        "rule_type": "pii",
+        "action": "mask",
+        "config": {"entities": {"EMAIL_ADDRESS": "mask"}, "score_thresholds": {"ALL": 0.5}, "language": "en"},
+    })
+    assert rule_res.status_code in (200, 201), rule_res.text
+```
+
+- [ ] **Step 2: Run it to confirm setup passes**
+
+Run: `cd AIGateway && GATEWAY_URL=http://localhost:8100 pytest tests/test_16_mcp_hook_results.py::test_setup_result_key_and_pii_rule -v`
+Expected: PASS (requires the gateway running on 8100 and a seeded org, same as test_13).
+
+- [ ] **Step 3: Implement `scan_result_blob`**
+
+Add to `AIGateway/src/services/mcp_guardrail_service.py` (after `scan_tool_input`). It mirrors how `scan_tool_input` fetches rules + settings, but takes a flat string and returns the masked string:
+
+```python
+async def scan_result_blob(org_id: int, blob: str) -> str:
+    """Mask PII / filtered content in a flat result string (tool stdout/stderr,
+    serialized tool_response). Returns the masked string. Never blocks — a tool
+    result has already been produced; we only sanitize what we store at rest.
+    Fails open (returns the original blob) on any error."""
+    if not blob or not blob.strip():
+        return blob
+    try:
+        async with get_db() as db:
+            rules_result = await db.execute(
+                text("""
+                    SELECT id, name, rule_type, config, scope, action,
+                           applies_to_tools, is_active
+                    FROM ai_gateway_mcp_guardrail_rules
+                    WHERE organization_id = :org_id AND is_active = true
+                    ORDER BY created_at
+                """),
+                {"org_id": org_id},
+            )
+            mcp_rules = [dict(r) for r in rules_result.mappings().fetchall()]
+            settings_result = await db.execute(
+                text("""
+                    SELECT pii_on_error, content_filter_on_error,
+                           pii_replacement_format, content_filter_replacement
+                    FROM ai_gateway_guardrail_settings
+                    WHERE organization_id = :org_id
+                """),
+                {"org_id": org_id},
+            )
+            settings_row = settings_result.mappings().fetchone()
+            guardrail_settings = dict(settings_row) if settings_row else {}
+
+        # Force mask action: we sanitize at rest, never "block" a stored result.
+        transformed_rules = [
+            {
+                "id": r["id"],
+                "guardrail_type": r["rule_type"],
+                "name": r["name"],
+                "config": r.get("config") or {},
+                "scope": "output",
+                "action": "mask",
+                "is_active": True,
+            }
+            for r in mcp_rules
+            if r.get("rule_type") in ("pii", "content_filter")
+        ]
+        if not transformed_rules:
+            return blob
+        result = scan_text(text=blob, guardrail_rules=transformed_rules, settings=guardrail_settings)
+        return result.masked_text or blob
+    except Exception as e:
+        logger.error(f"scan_result_blob failed, storing unmasked: {e}")
+        return blob
+```
+
+Confirm `logger` and `scan_text` are already imported in this module (they are — `scan_tool_input` uses both).
+
+- [ ] **Step 4: Add a direct unit assertion**
+
+Append to `test_16_mcp_hook_results.py`:
+
+```python
+def test_scan_result_blob_masks_email():
+    # Import inside the test so the module path matches the gateway venv.
+    import asyncio, sys
+    sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
+    from services.mcp_guardrail_service import scan_result_blob
+    masked = asyncio.get_event_loop().run_until_complete(
+        scan_result_blob(get_state("org_id") or 1, "contact me at attacker@evil.com please")
+    )
+    assert "attacker@evil.com" not in masked
+```
+
+> If the test env can't import the gateway module directly, mark this test `@pytest.mark.skip` and rely on the end-to-end masking assertion in Task 6 instead. Do not delete it — leave the skip with a reason.
+
+- [ ] **Step 5: Run the unit assertion**
+
+Run: `cd AIGateway && pytest tests/test_16_mcp_hook_results.py::test_scan_result_blob_masks_email -v`
+Expected: PASS (or SKIP with reason if import-path constrained).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add AIGateway/src/services/mcp_guardrail_service.py AIGateway/tests/test_16_mcp_hook_results.py
+git commit -m "feat(ai-gateway): scan_result_blob helper to mask stored tool results"
+```
+
+---
+
+## Task 3: Audit service — store `tool_use_id` + events, and `update_tool_result`
+
+**Files:**
+- Modify: `AIGateway/src/services/mcp_audit_service.py`
+
+- [ ] **Step 1: Extend `log_tool_call` signature and INSERT**
+
+In `mcp_audit_service.py`, add two params to `log_tool_call` (keep them optional/defaulted so existing callers are unaffected):
+
+```python
+async def log_tool_call(
+    organization_id: int,
+    agent_key_id: int,
+    server_id: Optional[int],
+    tool_name: str,
+    arguments: Optional[dict],
+    result_status: str,
+    result_summary: Optional[str],
+    is_error: bool,
+    latency_ms: int,
+    session_id: Optional[str] = None,
+    metadata: Optional[dict] = None,
+    tool_use_id: Optional[str] = None,
+    events: Optional[list] = None,
+) -> None:
+```
+
+Update the INSERT column list + VALUES to include `tool_use_id` and `events`:
+
+```python
+                INSERT INTO ai_gateway_mcp_audit_logs
+                    (organization_id, agent_key_id, server_id, tool_name,
+                     arguments, result_status, result_summary, is_error,
+                     latency_ms, session_id, metadata, tool_use_id, events)
+                VALUES
+                    (:org_id, :agent_key_id, :server_id, :tool_name,
+                     CAST(:arguments AS jsonb), :result_status, :result_summary, :is_error,
+                     :latency_ms, :session_id, CAST(:metadata AS jsonb),
+                     :tool_use_id, CAST(:events AS jsonb))
+```
+
+And in the params dict add:
+
+```python
+                    "tool_use_id": tool_use_id,
+                    "events": json.dumps(events or []),
+```
+
+- [ ] **Step 2: Add `update_tool_result`**
+
+Append to `mcp_audit_service.py`. It updates the most-recent matching row and appends the outcome event. Note: `events` is replaced wholesale (read-modify-write) because Postgres JSONB has no cheap append; this is fine — one row, one writer.
+
+```python
+async def update_tool_result(
+    organization_id: int,
+    session_id: str,
+    tool_use_id: str,
+    agent_key_id: int,
+    result_response: dict,
+    result_truncated: bool,
+    outcome_event: dict,  # {"type": "...", "at": "...", "detail"?: "..."}
+) -> str:
+    """Update the audit row for (org, session_id, tool_use_id) with the tool result.
+    Flips approval_required -> success, stores result_response, appends outcome_event.
+    Returns: "ok" | "no_match" | "forbidden". Fire-and-forget safe."""
+    try:
+        async with get_db() as db:
+            row = (await db.execute(
+                text("""
+                    SELECT id, agent_key_id, result_status, events
+                    FROM ai_gateway_mcp_audit_logs
+                    WHERE organization_id = :org_id
+                      AND session_id = :session_id
+                      AND tool_use_id = :tool_use_id
+                    ORDER BY created_at DESC
+                    LIMIT 1
+                """),
+                {"org_id": organization_id, "session_id": session_id, "tool_use_id": tool_use_id},
+            )).mappings().fetchone()
+
+            if not row:
+                return "no_match"
+            if row["agent_key_id"] != agent_key_id:
+                return "forbidden"
+
+            existing_events = row["events"] or []
+            if isinstance(existing_events, str):
+                existing_events = json.loads(existing_events)
+            new_events = existing_events + [outcome_event]
+
+            new_status = "success" if row["result_status"] == "approval_required" else row["result_status"]
+
+            await db.execute(
+                text("""
+                    UPDATE ai_gateway_mcp_audit_logs
+                    SET result_response = CAST(:result_response AS jsonb),
+                        result_truncated = :result_truncated,
+                        result_status = :new_status,
+                        events = CAST(:events AS jsonb)
+                    WHERE id = :id
+                """),
+                {
+                    "id": row["id"],
+                    "result_response": json.dumps(result_response),
+                    "result_truncated": result_truncated,
+                    "new_status": new_status,
+                    "events": json.dumps(new_events),
+                },
+            )
+            await db.commit()
+            return "ok"
+    except Exception as e:
+        logger.error(f"Failed to update MCP tool result: {e}")
+        return "no_match"
+```
+
+- [ ] **Step 3: Syntax check**
+
+Run: `cd AIGateway/src && python -c "import services.mcp_audit_service"`
+Expected: no output (imports clean).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add AIGateway/src/services/mcp_audit_service.py
+git commit -m "feat(ai-gateway): audit service stores tool_use_id/events and update_tool_result"
+```
+
+---
+
+## Task 4: Hook — seed events + `tool_use_id`, add `/v1/mcp/hook/result`
+
+**Files:**
+- Modify: `AIGateway/src/routers/mcp_hook.py`
+
+- [ ] **Step 1: Thread `tool_use_id` + events through `_audit`**
+
+In `mcp_hook`, read `tool_use_id` from the body and seed a `received` + `decided` event in each branch. Replace the `_audit` helper and the `body.get` block:
+
+```python
+    tool_name = body.get("tool_name")
+    arguments = body.get("arguments") or {}
+    session_id = body.get("session_id")
+    tool_use_id = body.get("tool_use_id")
+
+    if not tool_name or not isinstance(arguments, dict):
+        raise HTTPException(status_code=400, detail="tool_name (str) and arguments (object) are required")
+
+    start_time = time.time()
+    received_at = datetime.now(timezone.utc).isoformat()
+
+    async def _audit(status: str, summary: str, decided_detail: str, is_error: bool = False):
+        events = [
+            {"type": "received", "at": received_at},
+            {"type": "decided", "at": datetime.now(timezone.utc).isoformat(), "detail": decided_detail},
+        ]
+        await log_tool_call(
+            organization_id=org_id,
+            agent_key_id=agent_key["id"],
+            server_id=None,
+            tool_name=tool_name,
+            arguments=arguments,
+            result_status=status,
+            result_summary=summary,
+            is_error=is_error,
+            latency_ms=int((time.time() - start_time) * 1000),
+            session_id=session_id,
+            tool_use_id=tool_use_id,
+            events=events,
+        )
+```
+
+Then update each `_audit(...)` call to pass `decided_detail`:
+- blocked branch: `await _audit("blocked", f"Hook deny: {reason}", "deny")`
+- approval branch: `await _audit("approval_required", f"Approval request {approval.get('id')} created", "approval_required")`
+- rate-limit branch: `await _audit("rate_limited", "Hook rate limited", "rate_limited")`
+- error branch: `await _audit("error", f"Hook error during rate-limit check: {e.detail}", "error", is_error=True)`
+- allow branch: `await _audit("success", "Hook allow", "allow")`
+
+- [ ] **Step 2: Add the result endpoint**
+
+Append to `mcp_hook.py`. Add imports at top: `from services.mcp_audit_service import log_tool_call, update_tool_result` and `from services.mcp_guardrail_service import scan_tool_input, scan_result_blob`.
+
+```python
+# Uses settings.mcp_result_cap_bytes if defined, else falls back to 10240.
+# No separate config task is required; add the field to config.py only if you
+# want it env-tunable.
+MCP_RESULT_CAP_BYTES = getattr(settings, "mcp_result_cap_bytes", 10240)
+
+
+@router.post("/v1/mcp/hook/result")
+async def mcp_hook_result(request: Request):
+    """Receive a PostToolUse result and attach it to the existing audit row.
+    Never executes anything. Best-effort: returns 200 even when no row matches."""
+    agent_key = await extract_agent_key(request)
+    org_id = agent_key["organization_id"]
+    try:
+        body = await request.json()
+    except Exception:
+        raise HTTPException(status_code=400, detail="Invalid JSON body")
+
+    session_id = body.get("session_id")
+    tool_use_id = body.get("tool_use_id")
+    tool_name = body.get("tool_name") or "unknown"
+    tool_response = body.get("tool_response")
+    if not session_id or not tool_use_id:
+        raise HTTPException(status_code=400, detail="session_id and tool_use_id are required")
+
+    # Serialize, cap, mask the whole tool_response.
+    import json as _json
+    serialized = _json.dumps(tool_response) if tool_response is not None else "{}"
+    truncated = len(serialized.encode("utf-8")) > MCP_RESULT_CAP_BYTES
+    if truncated:
+        serialized = serialized.encode("utf-8")[:MCP_RESULT_CAP_BYTES].decode("utf-8", "ignore")
+    masked = await scan_result_blob(org_id, serialized)
+    try:
+        stored = _json.loads(masked)
+    except Exception:
+        stored = {"_raw": masked}  # masking broke JSON shape; keep the masked text
+
+    # Per-tool outcome event.
+    now = datetime.now(timezone.utc).isoformat()
+    if tool_name == "Bash" and isinstance(tool_response, dict) and tool_response.get("interrupted"):
+        outcome = {"type": "interrupted", "at": now}
+    elif tool_name in ("Write", "Edit") and isinstance(tool_response, dict) and tool_response.get("success") is False:
+        outcome = {"type": "failed", "at": now}
+    else:
+        outcome = {"type": "completed", "at": now}
+
+    status = await update_tool_result(
+        organization_id=org_id,
+        session_id=session_id,
+        tool_use_id=tool_use_id,
+        agent_key_id=agent_key["id"],
+        result_response=stored,
+        result_truncated=truncated,
+        outcome_event=outcome,
+    )
+    if status == "forbidden":
+        raise HTTPException(status_code=403, detail="result does not belong to this agent key")
+    return JSONResponse(content={"status": status})
+```
+
+- [ ] **Step 3: Syntax check + restart gateway**
+
+Run: `cd AIGateway/src && python -c "import routers.mcp_hook"`
+Expected: clean import. Then restart the dev gateway (uvicorn --reload picks it up).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add AIGateway/src/routers/mcp_hook.py
+git commit -m "feat(ai-gateway): seed events in hook + POST /v1/mcp/hook/result"
+```
+
+---
+
+## Task 5: Audit read endpoint — `GET /mcp/audit/logs/{id}`
+
+**Files:**
+- Modify: `AIGateway/src/crud/mcp_audit.py`
+- Modify: `AIGateway/src/routers/mcp_audit.py`
+
+- [ ] **Step 1: Add CRUD function**
+
+Append to `AIGateway/src/crud/mcp_audit.py`:
+
+```python
+async def get_audit_log_by_id(org_id: int, log_id: int) -> dict | None:
+    async with get_db() as db:
+        row = (await db.execute(
+            text("""
+                SELECT id, agent_key_id, server_id, tool_name, arguments,
+                       result_status, result_summary, is_error, latency_ms,
+                       session_id, tool_use_id, result_response, result_truncated,
+                       events, created_at
+                FROM ai_gateway_mcp_audit_logs
+                WHERE organization_id = :org_id AND id = :log_id
+            """),
+            {"org_id": org_id, "log_id": log_id},
+        )).mappings().fetchone()
+        return dict(row) if row else None
+```
+
+Confirm `get_db` and `text` are already imported at the top of the file (the existing functions use them).
+
+- [ ] **Step 2: Add the route**
+
+In `AIGateway/src/routers/mcp_audit.py`, import `get_audit_log_by_id` alongside the others, then add:
+
+```python
+@router.get("/logs/{log_id}", status_code=status.HTTP_200_OK)
+async def get_audit_log(log_id: int, request: Request):
+    org_id = request.state.organization_id
+    row = await get_audit_log_by_id(org_id, log_id)
+    if not row:
+        raise HTTPException(status_code=404, detail="Audit log not found")
+    return {"data": row}
+```
+
+> Match how the other routes read `org_id` (e.g. `request.state.organization_id` or a helper). Copy whatever `list_audit_logs` uses in this same file. Import `HTTPException` if not already.
+
+- [ ] **Step 3: Syntax check**
+
+Run: `cd AIGateway/src && python -c "import routers.mcp_audit"`
+Expected: clean.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add AIGateway/src/crud/mcp_audit.py AIGateway/src/routers/mcp_audit.py
+git commit -m "feat(ai-gateway): GET /mcp/audit/logs/{id} for the invocation drawer"
+```
+
+---
+
+## Task 6: E2E — result capture happy path, masking, no-match, cross-key
+
+**Files:**
+- Modify: `AIGateway/tests/test_16_mcp_hook_results.py`
+
+- [ ] **Step 1: Write the E2E tests**
+
+Append to `test_16_mcp_hook_results.py`:
+
+```python
+def _hook(key, tool_name, arguments, session_id, tool_use_id):
+    return _client.post(
+        f"{GATEWAY_URL}/v1/mcp/hook",
+        headers={"Authorization": f"Bearer {key}", "Content-Type": "application/json"},
+        json={"tool_name": tool_name, "arguments": arguments,
+              "session_id": session_id, "tool_use_id": tool_use_id},
+    )
+
+
+def _result(key, tool_name, tool_response, session_id, tool_use_id):
+    return _client.post(
+        f"{GATEWAY_URL}/v1/mcp/hook/result",
+        headers={"Authorization": f"Bearer {key}", "Content-Type": "application/json"},
+        json={"tool_name": tool_name, "tool_response": tool_response,
+              "session_id": session_id, "tool_use_id": tool_use_id},
+    )
+
+
+def test_allow_then_result_attaches():
+    key = get_state("result_agent_key")
+    if not key:
+        pytest.skip("no key")
+    sid, tuid = "sess-A", "toolu_A1"
+    assert _hook(key, "Bash", {"command": "ls"}, sid, tuid).json()["decision"] == "allow"
+    res = _result(key, "Bash", {"stdout": "file1\nfile2", "stderr": "", "interrupted": False, "isImage": False}, sid, tuid)
+    assert res.status_code == 200, res.text
+    assert res.json()["status"] == "ok"
+
+
+def test_result_masks_pii_in_stdout():
+    key = get_state("result_agent_key")
+    if not key:
+        pytest.skip("no key")
+    sid, tuid = "sess-B", "toolu_B1"
+    _hook(key, "Bash", {"command": "cat creds"}, sid, tuid)
+    _result(key, "Bash", {"stdout": "token for attacker@evil.com", "stderr": "", "interrupted": False, "isImage": False}, sid, tuid)
+    # Read it back via the audit list and confirm the email is masked.
+    # (Uses the same `api` fixture base as other tests; find the row by tool_use_id.)
+
+
+def test_result_no_match_returns_ok():
+    key = get_state("result_agent_key")
+    if not key:
+        pytest.skip("no key")
+    res = _result(key, "Bash", {"stdout": "x"}, "sess-never", "toolu-never")
+    assert res.status_code == 200, res.text
+    assert res.json()["status"] == "no_match"
+
+
+def test_result_missing_ids_returns_400():
+    key = get_state("result_agent_key")
+    if not key:
+        pytest.skip("no key")
+    res = _client.post(f"{GATEWAY_URL}/v1/mcp/hook/result",
+        headers={"Authorization": f"Bearer {key}", "Content-Type": "application/json"},
+        json={"tool_name": "Bash", "tool_response": {"stdout": "x"}})
+    assert res.status_code == 400, res.text
+
+
+def test_result_cross_key_forbidden():
+    key = get_state("result_agent_key")
+    if not key:
+        pytest.skip("no key")
+    sid, tuid = "sess-C", "toolu_C1"
+    _hook(key, "Bash", {"command": "ls"}, sid, tuid)
+    # A second key tries to write the first key's result.
+    other = _client.post(  # create via the same gateway admin path used in setup
+        f"{GATEWAY_URL}/v1/mcp/hook/result",
+        headers={"Authorization": "Bearer sk-mcp-not-a-real-key", "Content-Type": "application/json"},
+        json={"tool_name": "Bash", "tool_response": {"stdout": "x"}, "session_id": sid, "tool_use_id": tuid})
+    assert other.status_code == 401  # bad key rejected before reaching the row
+```
+
+> The cross-key 403 path (a *valid* second key hitting another key's row) requires creating a second agent key via the `api` fixture; if that's awkward in the harness, the 401 (invalid key) test above still covers auth, and the 403 branch is covered by the `update_tool_result` unit logic. Note this in the test docstring rather than leaving it untested silently.
+
+- [ ] **Step 2: Run the E2E file**
+
+Run: `cd AIGateway && GATEWAY_URL=http://localhost:8100 pytest tests/test_16_mcp_hook_results.py -v`
+Expected: all PASS (or documented SKIPs when the gateway/org isn't seeded).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add AIGateway/tests/test_16_mcp_hook_results.py
+git commit -m "test(ai-gateway): E2E for tool result capture, masking, no-match, auth"
+```
+
+---
+
+## Task 7: Adapter — send ids + result mode
+
+**Files:**
+- Modify: `scripts/vw-tool-hook.sh`
+
+- [ ] **Step 1: Send `session_id` + `tool_use_id` in PreToolUse**
+
+In `vw-tool-hook.sh`, after the existing `tool_name`/`arguments` extraction, add:
+
+```bash
+session_id="$(printf '%s' "$input" | jq -r '.session_id // empty')"
+tool_use_id="$(printf '%s' "$input" | jq -r '.tool_use_id // empty')"
+hook_event="$(printf '%s' "$input" | jq -r '.hook_event_name // "PreToolUse"')"
+```
+
+And include them in the PreToolUse payload:
+
+```bash
+payload="$(jq -nc --arg t "$tool_name" --argjson a "$arguments" \
+  --arg s "$session_id" --arg u "$tool_use_id" \
+  '{tool_name:$t, arguments:$a, session_id:$s, tool_use_id:$u}')"
+```
+
+- [ ] **Step 2: Add result-mode dispatch**
+
+Near the top, after the env checks, branch on the event. Result mode is best-effort and always exits 0:
+
+```bash
+if [ "$hook_event" = "PostToolUse" ]; then
+  tool_response="$(printf '%s' "$input" | jq -c '.tool_response // {}')"
+  duration_ms="$(printf '%s' "$input" | jq -r '.duration_ms // empty')"
+  rpayload="$(jq -nc --arg t "$tool_name" --argjson r "$tool_response" \
+    --arg s "$session_id" --arg u "$tool_use_id" \
+    '{tool_name:$t, tool_response:$r, session_id:$s, tool_use_id:$u}')"
+  curl -s --max-time "$TIMEOUT" -o /dev/null \
+    -X POST "$VW_GATEWAY_URL/v1/mcp/hook/result" \
+    -H "Authorization: Bearer $VW_AGENT_KEY" \
+    -H "Content-Type: application/json" \
+    -d "$rpayload" 2>/dev/null || true
+  exit 0   # result capture never blocks
+fi
+```
+
+Place this AFTER `session_id`/`tool_use_id`/`hook_event` are set and after the env/`jq`/`curl` checks, but BEFORE the PreToolUse adjudication block.
+
+- [ ] **Step 3: Lint the script**
+
+Run: `bash -n scripts/vw-tool-hook.sh`
+Expected: no syntax errors.
+
+- [ ] **Step 4: Manual smoke (optional, requires gateway)**
+
+```bash
+echo '{"hook_event_name":"PostToolUse","tool_name":"Bash","session_id":"s1","tool_use_id":"t1","tool_response":{"stdout":"hi","stderr":"","interrupted":false,"isImage":false}}' \
+  | VW_GATEWAY_URL=http://localhost:8100 VW_AGENT_KEY=sk-mcp-... bash scripts/vw-tool-hook.sh; echo "exit=$?"
+```
+Expected: `exit=0` (no output; result POSTed or silently failed open).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add scripts/vw-tool-hook.sh
+git commit -m "feat(adapter): send session_id/tool_use_id and add PostToolUse result mode"
+```
+
+---
+
+## Task 8: Adapter README — PostToolUse config
+
+**Files:**
+- Modify: the adapter README (`scripts/vw-tool-hook.README.md` if present, else the doc that holds the PreToolUse config block — find it with `grep -rl PreToolUse scripts docs`)
+
+- [ ] **Step 1: Add the PostToolUse hook config block**
+
+Document, next to the existing PreToolUse config, a PostToolUse entry pointing the same script at the same matcher:
+
+```json
+{
+  "hooks": {
+    "PreToolUse":  [{ "matcher": "Bash|Edit|Write", "hooks": [{ "type": "command", "command": "/path/to/vw-tool-hook.sh" }] }],
+    "PostToolUse": [{ "matcher": "Bash|Edit|Write", "hooks": [{ "type": "command", "command": "/path/to/vw-tool-hook.sh" }] }]
+  }
+}
+```
+
+Add a sentence: "`MultiEdit`/`NotebookEdit` are not confirmed as PostToolUse matchers in the Claude Code docs; test before adding them to the PostToolUse matcher. Result capture is best-effort: if the gateway is unreachable, the tool still runs and the invocation simply shows no result."
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add scripts/vw-tool-hook.README.md
+git commit -m "docs(adapter): document PostToolUse result-capture hook"
+```
+
+---
+
+## Task 9: Frontend — clickable rows + invocation drawer
+
+**Files:**
+- Create: `Clients/src/presentation/pages/AIGateway/MCPInvocationDrawer.tsx`
+- Modify: `Clients/src/presentation/pages/AIGateway/MCPAuditLog/index.tsx`
+
+- [ ] **Step 1: Create the drawer component**
+
+```tsx
+import { Box, Drawer, Typography, Stack, IconButton } from "@mui/material";
+import { X } from "lucide-react";
+import { useState, useEffect } from "react";
+import Chip from "../../components/Chip";
+import { apiServices } from "../../../infrastructure/api/networkServices";
+import palette from "../../themes/palette";
+import { MCP_STATUS_COLORS, MCP_STATUS_FALLBACK } from "./shared";
+import { displayFormattedDate } from "../../tools/isoDateToString";
+
+interface InvocationDrawerProps {
+  logId: number | null;
+  open: boolean;
+  onClose: () => void;
+}
+
+export default function MCPInvocationDrawer({ logId, open, onClose }: InvocationDrawerProps) {
+  const [row, setRow] = useState<any | null>(null);
+  const [showRaw, setShowRaw] = useState(false);
+
+  useEffect(() => {
+    if (!open || !logId) return;
+    setRow(null);
+    setShowRaw(false);
+    apiServices
+      .get<Record<string, any>>(`/ai-gateway/mcp/audit/logs/${logId}`)
+      .then((res) => setRow(res?.data?.data || null))
+      .catch(() => setRow(null));
+  }, [open, logId]);
+
+  const colors = row ? MCP_STATUS_COLORS[row.result_status] || MCP_STATUS_FALLBACK : MCP_STATUS_FALLBACK;
+  const labelSx = { fontSize: 11, fontWeight: 600, color: palette.text.tertiary, letterSpacing: "0.5px" };
+
+  return (
+    <Drawer anchor="right" open={open} onClose={onClose} sx={{ "& .MuiDrawer-paper": { width: 520, p: 3 } }}>
+      {!row ? (
+        <Typography sx={{ fontSize: 13, color: palette.text.tertiary }}>Loading…</Typography>
+      ) : (
+        <Stack gap="16px">
+          <Stack direction="row" justifyContent="space-between" alignItems="flex-start">
+            <Box>
+              <Typography sx={{ fontSize: 16, fontWeight: 600, fontFamily: "monospace" }}>
+                {row.tool_name}
+              </Typography>
+              <Typography sx={{ fontSize: 12, color: palette.text.tertiary }}>
+                {displayFormattedDate(row.created_at)}
+              </Typography>
+            </Box>
+            <IconButton size="small" onClick={onClose} aria-label="Close">
+              <X size={16} />
+            </IconButton>
+          </Stack>
+
+          <Chip label={row.result_status} backgroundColor={colors.bg} textColor={colors.text} />
+
+          <Box>
+            <Typography sx={labelSx}>TOOL USE ID</Typography>
+            <Typography sx={{ fontSize: 12, fontFamily: "monospace" }}>
+              {row.tool_use_id || "—"}
+            </Typography>
+          </Box>
+
+          <Box>
+            <Typography sx={labelSx}>ARGUMENTS</Typography>
+            <Box component="pre" sx={{ fontSize: 12, fontFamily: "monospace", whiteSpace: "pre-wrap",
+              bgcolor: "#F9FAFB", p: "8px", borderRadius: "4px", overflow: "auto", maxHeight: 200 }}>
+              {JSON.stringify(row.arguments ?? {}, null, 2)}
+            </Box>
+          </Box>
+
+          <Box>
+            <Typography sx={labelSx}>RESULT</Typography>
+            {row.result_response ? (
+              <Box component="pre" sx={{ fontSize: 12, fontFamily: "monospace", whiteSpace: "pre-wrap",
+                bgcolor: "#F9FAFB", p: "8px", borderRadius: "4px", overflow: "auto", maxHeight: 280 }}>
+                {JSON.stringify(row.result_response, null, 2)}
+                {row.result_truncated ? "\n… (truncated)" : ""}
+              </Box>
+            ) : (
+              <Typography sx={{ fontSize: 12, color: palette.text.tertiary }}>
+                No result captured (older adapter, or the tool did not report back).
+              </Typography>
+            )}
+          </Box>
+
+          <Box>
+            <Typography sx={labelSx}>EVENTS</Typography>
+            <Stack gap="4px" sx={{ mt: "4px" }}>
+              {(row.events || []).map((e: any, i: number) => (
+                <Stack key={i} direction="row" justifyContent="space-between">
+                  <Typography sx={{ fontSize: 12 }}>
+                    {e.type}{e.detail ? ` · ${e.detail}` : ""}
+                  </Typography>
+                  <Typography sx={{ fontSize: 12, color: palette.text.tertiary }}>
+                    {displayFormattedDate(e.at)}
+                  </Typography>
+                </Stack>
+              ))}
+            </Stack>
+          </Box>
+
+          <Box>
+            <Typography
+              sx={{ fontSize: 12, color: palette.primary.main, cursor: "pointer" }}
+              onClick={() => setShowRaw((v) => !v)}
+            >
+              {showRaw ? "Hide raw JSON" : "Show raw JSON"}
+            </Typography>
+            {showRaw && (
+              <Box component="pre" sx={{ fontSize: 11, fontFamily: "monospace", whiteSpace: "pre-wrap",
+                bgcolor: "#1E1E1E", color: "#D4D4D4", p: "8px", borderRadius: "4px", overflow: "auto", maxHeight: 320 }}>
+                {JSON.stringify(row, null, 2)}
+              </Box>
+            )}
+          </Box>
+        </Stack>
+      )}
+    </Drawer>
+  );
+}
+```
+
+> Verify the import paths resolve from `pages/AIGateway/` (the existing `MCPAuditLog/index.tsx` imports `Chip` as `../../../components/Chip` because it is one directory deeper; `MCPInvocationDrawer.tsx` sits directly in `pages/AIGateway/`, so it uses `../../components/Chip`). Match `MCPTable.tsx`'s import depth, which lives in the same folder.
+
+- [ ] **Step 2: Wire row click in MCPAuditLog**
+
+In `MCPAuditLog/index.tsx`: import the drawer, add state, pass `onRowClick` to the existing `MCPTable`, render the drawer.
+
+```tsx
+import MCPInvocationDrawer from "../MCPInvocationDrawer";
+// ...
+const [drawerLogId, setDrawerLogId] = useState<number | null>(null);
+// ... on the <MCPTable ...>:
+onRowClick={(log) => setDrawerLogId(log.id)}
+// ... after the table block, before </PageHeaderExtended>:
+<MCPInvocationDrawer
+  logId={drawerLogId}
+  open={drawerLogId !== null}
+  onClose={() => setDrawerLogId(null)}
+/>
+```
+
+- [ ] **Step 3: Typecheck + format (full, unfiltered)**
+
+Run: `cd Clients && npm run typecheck && npm run format-check`
+Expected: no errors in the changed files; if format-check flags them, run `npm run format` and re-stage.
+
+- [ ] **Step 4: Build**
+
+Run: `cd Clients && npm run build`
+Expected: build succeeds.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add Clients/src/presentation/pages/AIGateway/MCPInvocationDrawer.tsx Clients/src/presentation/pages/AIGateway/MCPAuditLog/index.tsx
+git commit -m "feat(ai-gateway): invocation detail drawer on Activity rows"
+```
+
+---
+
+## Task 10: i18n + final gates
+
+**Files:**
+- Modify: `Clients/src/i18n/translations.ts`
+
+- [ ] **Step 1: Add de/fr/es for new drawer strings**
+
+New user-facing strings introduced by the drawer: `Arguments` (already added in PR #4096 — verify), `Result`, `Events`, `Tool use id`, `Show raw JSON`, `Hide raw JSON`, `No result captured (older adapter, or the tool did not report back).`. Add any that are missing to the `de`, `fr`, and `es` blocks of `translations.ts` (mirror the pattern: insert near the existing Agent Control keys). German/French/Spanish translations required — do not leave English-only.
+
+- [ ] **Step 2: Run the full pre-PR gate set (unfiltered)**
+
+Run: `cd Clients && npm run typecheck && npm run i18n:audit:strict && npm run format-check`
+Expected: typecheck clean, i18n audit reports **0 gaps**, format clean.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add Clients/src/i18n/translations.ts
+git commit -m "i18n(ai-gateway): de/fr/es for invocation drawer strings"
+```
+
+---
+
+## Done criteria
+
+- A native Bash/Edit/Write call with the PostToolUse hook configured produces an Activity row whose drawer shows arguments, result, and an events timeline (received → decided → completed).
+- A denied/rate-limited call shows a drawer with no result and a timeline ending at "decided".
+- An approved-then-run call shows one row, status `success`, timeline received → approval_required → completed.
+- PII in stdout is masked in the stored result.
+- An old adapter (no PostToolUse) leaves rows showing "No result captured" — nothing breaks.
+- `cd AIGateway && pytest tests/test_16_mcp_hook_results.py -v` passes.
+- `cd Clients && npm run typecheck && npm run i18n:audit:strict && npm run format-check` all pass.

--- a/docs/superpowers/specs/2026-06-16-agent-control-tool-results-design.md
+++ b/docs/superpowers/specs/2026-06-16-agent-control-tool-results-design.md
@@ -1,0 +1,215 @@
+# Agent Control — tool result capture, events timeline, and invocation drawer
+
+> **Status:** Design approved 2026-06-16. Not yet implemented.
+> **Scope:** Feature #4 from the Atyrum gap analysis — capture each native tool call's
+> *result* and a per-invocation *events timeline*, and surface both in a detail drawer on
+> the Activity page.
+
+## Problem
+
+Atyrum's "Invocations" view has a per-invocation detail drawer showing the tool's RESULT
+(stdout/stderr/interrupted) and an EVENTS timeline (Received → Decided → Completed). We
+already store arguments, status, latency and a 500-char summary per call, but:
+
+1. We never capture what a native tool actually *did* — the native hook is **PreToolUse
+   only**. It adjudicates before the tool runs and never sees the result.
+2. We have no per-invocation event timeline.
+3. Activity rows aren't clickable and there is no detail drawer.
+
+This feature closes #4: result capture + events + drawer. It does **not** cover decision
+provenance (which rule matched / "Create rule from this") — that is a separate follow-up.
+
+## Verified facts this design rests on
+
+- **Claude Code passes `tool_use_id` and `session_id` on stdin to BOTH PreToolUse and
+  PostToolUse hooks.** `tool_use_id` is the per-tool-call identifier and is identical
+  across the two events for the same call. `session_id` identifies the whole session, not
+  a single call. (Confirmed against the official Claude Code hooks reference.)
+- **PostToolUse provides `tool_response`, whose shape differs per tool.** Bash:
+  `{stdout, stderr, interrupted, isImage}`. Write: `{filePath, success}`. Edit: a
+  success-shaped object. Read: file content. **There is no exit code.**
+- **PostToolUse also provides `duration_ms`** (optional).
+- **`MultiEdit`/`NotebookEdit` are not in the documented PostToolUse matchable-tool table.**
+  Treat them as unverified for PostToolUse; test before adding to the matcher.
+- **The native hook (`mcp_hook.py`) has 5 terminal decisions**: `allow`, `deny`/blocked,
+  `approval_required`, `rate_limited`, internal `error`. Only `allow` (and an
+  `approval_required` that the human approves) leads to the tool actually running.
+- **Auditing is fire-and-forget** (`log_tool_call` does an INSERT and swallows errors,
+  returns nothing). It must stay off the hot path.
+- **The approval flow produces ONE audit row today.** The adapter polls in-process and
+  `exit 0`s on approval; it never makes a second `/v1/mcp/hook` call, so there is no
+  separate `success` row. The approved tool then runs and (with this feature) its
+  PostToolUse result updates the original `approval_required` row in place.
+
+## Model
+
+**One audit row per invocation, correlated by `(organization_id, session_id, tool_use_id)`,
+updated in place.**
+
+```
+PreToolUse  → POST /v1/mcp/hook {tool_name, arguments, session_id, tool_use_id}
+   adjudicate → INSERT one row, store session_id + tool_use_id
+   seed events: [received, decided:<outcome>]
+   status: success(allow) | blocked | rate_limited | approval_required | error
+
+   allow              → tool runs
+   approval_required  → adapter polls in-process; on approved, tool runs
+   deny / rate_limited(closed) / error → TERMINAL, tool never runs, no result
+
+PostToolUse → POST /v1/mcp/hook/result
+              {session_id, tool_use_id, tool_name, tool_response, duration_ms}
+   find row WHERE (org, session_id, tool_use_id), most recent
+   cap (serialized tool_response ≤ MCP_RESULT_CAP_BYTES, default 10240) + mask
+   UPDATE row:
+     - if status was approval_required → success
+     - store result_response (capped + masked), set result_truncated
+     - append outcome event (per-tool heuristic, below)
+   no row found → 200 {"status": "no_match"}   (deny / rate-limited / old adapter — benign)
+```
+
+### Correlation
+
+`(session_id, tool_use_id)` read from Claude Code stdin by both hook processes. Nothing is
+minted; nothing is persisted between the two separate hook processes; the hot path is
+unchanged. An adapter that does not send `tool_use_id` (or an old adapter) simply never
+matches a result → the drawer shows "No result captured." Purely additive, fully
+backward-compatible.
+
+### Result outcome (no exit code exists)
+
+Append exactly one terminal event derived per tool:
+
+- **Bash**: `tool_response.interrupted === true` → `interrupted`, else `completed`.
+  (stderr alone is NOT treated as failure — many tools write to stderr on success.)
+- **Write / Edit**: `tool_response.success === false` → `failed`, else `completed`.
+- **Other tools**: `completed`.
+
+## Schema (additive Alembic migration, AIGateway)
+
+`session_id` already exists on `ai_gateway_mcp_audit_logs`. Add:
+
+```sql
+ALTER TABLE ai_gateway_mcp_audit_logs
+  ADD COLUMN tool_use_id      VARCHAR(128),
+  ADD COLUMN result_response  JSONB,                 -- whole tool_response, capped + masked
+  ADD COLUMN result_truncated BOOLEAN DEFAULT false,
+  ADD COLUMN events           JSONB DEFAULT '[]';    -- [{type, at, detail?}]
+
+CREATE INDEX idx_gw_mcp_audit_invocation
+  ON ai_gateway_mcp_audit_logs(organization_id, session_id, tool_use_id);
+```
+
+All columns nullable / defaulted → old rows and old adapters keep working. No exit-code
+column; no fixed stdout/stderr columns (those are Bash-specific and live inside
+`result_response`).
+
+### `events` shape
+
+```json
+[
+  {"type": "received",          "at": "2026-06-16T13:05:01Z"},
+  {"type": "decided",           "at": "2026-06-16T13:05:01Z", "detail": "allow"},
+  {"type": "completed",         "at": "2026-06-16T13:05:02Z"}
+]
+```
+
+Possible `type` values: `received`, `decided` (detail = allow/deny/rate_limited/error),
+`approval_required`, `approved`, `denied`, `completed`, `interrupted`, `failed`.
+
+## Backend
+
+### `mcp_audit_service.log_tool_call`
+
+Gains optional `tool_use_id` and `events` params. Each of the 5 decision branches in
+`mcp_hook.py` passes its seed events via the existing `_audit()` helper (the single place
+that calls `log_tool_call` in the hook). Still fire-and-forget.
+
+### New endpoint `POST /v1/mcp/hook/result`
+
+- Auth: `extract_agent_key` (same sk-mcp-* path as `/v1/mcp/hook`).
+- Body: `{session_id, tool_use_id, tool_name, tool_response, duration_ms?}`.
+- Look up the most-recent row `WHERE (organization_id, session_id, tool_use_id)`.
+- **Reject** (403) if the matched row's `agent_key_id` != caller's key id — one key can't
+  write another key's result.
+- **No match** → `200 {"status": "no_match"}`. Never 500: deny/rate-limited/old-adapter
+  cases are expected and benign.
+- Serialize `tool_response`, cap to `MCP_RESULT_CAP_BYTES` (config, default 10240), set
+  `result_truncated`.
+- Mask via a **new** `scan_result_blob(org_id, text)` helper (NOT `scan_tool_input`, which
+  is field-aware for tool arguments). The blob helper runs the org's PII/content guardrails
+  over a flat string and returns the masked string. This keeps result data-at-rest
+  consistent with how input is treated.
+- UPDATE: flip `approval_required` → `success`; store `result_response`,
+  `result_truncated`; append the outcome event.
+
+### New read endpoint `GET /mcp/audit/logs/{id}`
+
+Returns a single audit row by primary key, including `arguments`, `result_response`,
+`events`, `status`, `tool_use_id`, `session_id`, timestamps. Org-scoped. Used by the drawer.
+
+## Adapter (`scripts/vw-tool-hook.sh`)
+
+- PreToolUse POST gains `session_id` and `tool_use_id`, read from stdin
+  (`.session_id`, `.tool_use_id`).
+- New **result mode** (same script, dispatched by `hook_event_name` or an arg): reads
+  `tool_response`, `session_id`, `tool_use_id`, `tool_name`, `duration_ms` from stdin and
+  POSTs to `/v1/mcp/hook/result`.
+- Result mode is **best-effort, fail-open, silent**: any failure (gateway down, non-200,
+  timeout) exits 0 without output. The tool has already run; result capture must never
+  block or error.
+- README/config: add a **PostToolUse** matcher. Start with `Bash|Edit|Write` (documented).
+  `MultiEdit|NotebookEdit` are unverified for PostToolUse — note that they must be tested
+  before being added to the matcher.
+
+## Frontend
+
+- Activity rows become clickable (`onRowClick` on the existing `MCPTable`).
+- New `MCPInvocationDrawer` built on the existing right-anchored MUI `Drawer` pattern
+  (`components/Drawer/*`), ~520px wide.
+- Drawer data: `GET /ai-gateway/mcp/audit/logs/:id` (single row).
+- Sections, top to bottom:
+  - **Header**: `tool_name · agent key`, status chip, timestamp, `tool_use_id` (the
+    per-call identifier, shown as the invocation id), session id. The internal row PK is
+    used only as the `GET .../logs/:id` lookup key, not surfaced as the user-facing id.
+  - **Arguments**: key/value table from `arguments` (already stored).
+  - **Result**: rendered per tool from `result_response` — Bash shows stdout/stderr +
+    interrupted; Write shows filePath/success; etc. If absent → "No result captured
+    (older adapter, or the tool did not report back)."
+  - **Events**: vertical timeline from `events`.
+  - **Show raw JSON**: collapsible, dumps the full row.
+- No "Summarize" button (no summary model configured; out of scope).
+
+## Error handling
+
+- Result endpoint: never 500 on missing row; 403 on cross-key write; cap + mask before
+  store; events are append-only.
+- Adapter result mode: fail-open silent.
+- Drawer: render each state (full result / no result / terminal-deny with no result /
+  approval-then-completed timeline); long output scrolls inside the result block.
+
+## Testing
+
+**Backend E2E** (extend the existing MCP hook E2E suite):
+- allow → PostToolUse result → row updated, `completed` event, result stored.
+- deny → no result call → row terminal at `decided`, drawer shows no result.
+- approval_required → approve → tool runs → PostToolUse updates the SAME row to `success`
+  with result (events: received → approval_required → approved → completed).
+- oversized `tool_response` → `result_truncated = true`, capped.
+- PII in stdout → masked in stored `result_response`.
+- PostToolUse for an unknown `(session_id, tool_use_id)` → `200 no_match`, no row created.
+- cross-key result write → 403.
+
+**Adapter**: result POST failure is silent/fail-open; correct fields sent for Bash vs Write.
+
+**Frontend**: drawer renders full-result, no-result, terminal-deny and approval-timeline
+states; raw-JSON toggle; long output scrolls.
+
+## Out of scope (separate follow-ups)
+
+- **Decision provenance**: which rule matched, the "RULE" badge, "Create rule from this".
+  Needs `matched_rule_id`/type recorded in the scan + approval-match services.
+- **LLM "Summarize"** of a result (needs a configured summary model).
+- **Server / Decision columns** on the Activity table (server_id is stored; decision needs
+  the provenance work above).
+- Non-Claude-Code adapters (Cursor etc.) — they get no result capture until they send
+  `tool_use_id` + a PostToolUse equivalent.

--- a/docs/technical/domains/agent-control.md
+++ b/docs/technical/domains/agent-control.md
@@ -1,6 +1,7 @@
 # Agent Control — native tool-call governance
 
-> **Status:** Shipped to `develop` (PRs #4078, #4083, #4084). Last updated 2026-06-16.
+> **Status:** Core shipped to `develop` (PRs #4078, #4083, #4084). Tool result capture +
+> events timeline + invocation drawer in PR #4103 (open). Last updated 2026-06-17.
 
 Agent Control gates a coding agent's tool calls through the AI Gateway's guardrails,
 human-approval and audit machinery. It covers two entry paths that share one governance
@@ -28,8 +29,9 @@ extract_agent_key (sk-mcp-*)                    -- shared with the proxy
   → allow
 ```
 
-Every path writes an audit row (`log_tool_call`). Audit and the approval argument-hash use
-the **full** arguments; only the guardrail scan uses the field-aware subset.
+Every path writes an audit row (`log_tool_call`), seeded with a `received` + `decided` event
+and the call's `tool_use_id`. Audit and the approval argument-hash use the **full** arguments;
+only the guardrail scan uses the field-aware subset.
 
 ## Field-aware scanning (`AIGateway/src/utils/mcp_tool_content.py`)
 
@@ -66,33 +68,96 @@ approved → run, denied → block, timeout → `VW_APPROVAL_FAIL_MODE` (default
   the same name+args. (Migration `a0006` made `tool_id` nullable.)
 - An already-approved re-call **skips** the rate limiter so an approval is never wasted.
 
+## Tool result capture & events timeline (PR #4103)
+
+The PreToolUse hook records that a call happened and how it was adjudicated, but not what the
+tool *did*. A second, post-execution call captures the result, and every invocation carries an
+events timeline.
+
+**Correlation.** One audit row per invocation, keyed by
+`(organization_id, session_id, tool_use_id)`. All three are present in both the Claude Code
+PreToolUse and PostToolUse hook payloads, so nothing is minted or persisted between the two
+separate hook processes. The row is updated in place.
+
+```
+PreToolUse  → POST /v1/mcp/hook         -- INSERT row, store tool_use_id,
+                                           events: [received, decided:<outcome>]
+[allow → the tool runs; approval_required → adapter polls, then runs]
+PostToolUse → POST /v1/mcp/hook/result  -- find row by (org, session_id, tool_use_id),
+                                           cap + mask the result, append outcome event
+```
+
+- **`POST /v1/mcp/hook/result`** (`mcp_hook.py`): serializes the tool's `tool_response`, caps
+  it to `MCP_RESULT_CAP_BYTES` (default 10240, byte-safe slice), masks it via
+  `scan_result_blob`, then calls `update_tool_result`. Returns `forbidden` → 403,
+  `error` → 500, and `ok`/`no_match` → 200. A missing row (deny, rate-limited, or an old
+  adapter that never sends the result) is a benign `no_match`, not an error.
+- **Per-tool outcome event.** `tool_response` shape differs per tool and has no exit code, so
+  the result is stored as a generic `result_response` JSONB and the outcome event is derived
+  per tool: Bash `interrupted` → `interrupted`; Write/Edit `success === false` → `failed`;
+  otherwise `completed`.
+- **Approval flow stays one row.** When an approval-gated call is approved and re-runs, its
+  PostToolUse result updates the original `approval_required` row in place
+  (`update_tool_result` flips it to `success`).
+- **`GET /mcp/audit/logs/{id}`** returns a single audit row (with `result_response` and
+  `events`) for the invocation drawer; envelope `{"status": "success", "data": row}`.
+
+### Masking the result (`scan_result_blob`, `mcp_guardrail_service.py`)
+
+`scan_result_blob(org_id, blob)` runs the org's PII / content-filter guardrails over the flat
+serialized result and returns the masked string. Fail-open: any error stores the original blob
+rather than dropping the result. A tool result has already executed, so **every** detected
+entity is forced to `mask` — a per-entity `block` action would otherwise short-circuit
+`scan_text` into a blocked result (`masked_text=None`) and leak the unmasked blob. (This was a
+real leak caught by the masking E2E test against a live org that had a block-action PII rule.)
+
+### Schema (migration `a0007`, additive)
+
+`ai_gateway_mcp_audit_logs` gains `tool_use_id VARCHAR(128)`, `result_response JSONB`,
+`result_truncated BOOLEAN`, `events JSONB DEFAULT '[]'`, plus an index on
+`(organization_id, session_id, tool_use_id)`. All nullable/defaulted, so old rows and old
+adapters keep working.
+
 ## Adapter (`scripts/vw-tool-hook.sh` + README)
 
-Claude Code config matcher: `Bash|Edit|Write|MultiEdit|NotebookEdit`. Env: `VW_GATEWAY_URL`,
-`VW_AGENT_KEY` (sk-mcp-*), `VW_FAIL_MODE` (open|closed, default open — for gateway-unreachable
-and rate_limited), `VW_TIMEOUT`, `VW_APPROVAL_WAIT`, `VW_APPROVAL_FAIL_MODE` (default closed).
+Two Claude Code hooks point at the same script:
+
+- **PreToolUse** (matcher `Bash|Edit|Write|MultiEdit|NotebookEdit`) adjudicates the call and
+  blocks on approval polling.
+- **PostToolUse** (matcher `Bash|Edit|Write`) captures the result, best-effort: it POSTs the
+  `tool_response` to `/v1/mcp/hook/result` and always exits 0 — the tool has already run, so
+  result capture never blocks. (`MultiEdit`/`NotebookEdit` aren't confirmed as PostToolUse
+  matchers in the Claude Code docs; test before adding them.)
+
+Env: `VW_GATEWAY_URL`, `VW_AGENT_KEY` (sk-mcp-*), `VW_FAIL_MODE` (open|closed, default open —
+for gateway-unreachable and rate_limited), `VW_TIMEOUT`, `VW_APPROVAL_WAIT`,
+`VW_APPROVAL_FAIL_MODE` (default closed).
 
 ## UI
 
-No bespoke screens. Rules are authored in **Guardrails**, decisions made in **Approvals**,
-and every call appears in **Activity** (the renamed Audit Log) — all under the **Agent Control**
-sidebar group. Servers/Tools keep "MCP" in their labels (genuinely MCP-protocol concepts).
+No bespoke screens for governance: rules are authored in **Guardrails**, decisions made in
+**Approvals**, and every call appears in **Activity** (the renamed Audit Log) — all under the
+**Agent Control** sidebar group. Servers/Tools keep "MCP" in their labels (genuinely
+MCP-protocol concepts).
+
+**Invocation drawer** (PR #4103): Activity rows are clickable and open a right-side drawer
+(`MCPInvocationDrawer.tsx`) showing the call's status, `tool_use_id`, agent key + session,
+arguments, the captured result (or "no result captured"), the events timeline, and a raw-JSON
+toggle. It reads `GET /ai-gateway/mcp/audit/logs/{id}`.
 
 ## Not yet built (Phase 4+)
 
 - **Path-based gating** — block/approve writes by *destination* (`~/.ssh`, `.env`, outside the
   repo). Genuinely new matching logic.
+- **Decision provenance** — record which rule matched each call (the "RULE" badge and "Create
+  rule from this" in comparable products); Server/Decision columns on Activity depend on it.
 - Cursor / non-Claude-Code adapter; an Agent Control overview/landing page; a priority rule
-  engine; tamper-evident audit; metering MCP calls into the existing budgets.
-
-## Known issue
-
-The i18n CI audit hard-gates `de`/`fr` coverage but **not `es`**, so Spanish translation gaps
-can land on `develop` unnoticed. Worth extending the gate to `es` or running a periodic
-es-coverage sweep.
+  engine; tamper-evident audit; metering MCP calls into the existing budgets; an LLM
+  "summarize" for captured results.
 
 ## Design history
 
 The spec/plan trail for each increment lives under `docs/superpowers/`:
 `2026-06-15-mcp-bash-hook-*` (Phase 1), `2026-06-15-mcp-hook-approval-*` (Phase 2),
-`2026-06-16-mcp-hook-filewrite-*` (Phase 3), `2026-06-16-agent-control-rename-*` (rename).
+`2026-06-16-mcp-hook-filewrite-*` (Phase 3), `2026-06-16-agent-control-rename-*` (rename),
+`2026-06-16-agent-control-tool-results-*` (result capture + events + drawer).

--- a/scripts/vw-tool-hook.README.md
+++ b/scripts/vw-tool-hook.README.md
@@ -5,7 +5,9 @@ Gates Claude Code's built-in tools (**Bash**, plus file writes via **Edit**,
 runs, the gateway scans the call against your org's MCP guardrail rules and the
 call is allowed or denied. For Bash it scans the command; for file writes it
 scans the content being written (not the path or the text being removed). Every
-call is recorded in the MCP Audit Log.
+call is recorded in the MCP Audit Log. When the PostToolUse hook is also
+configured (below), the gateway records each tool's result and a per-invocation
+events timeline, viewable in the Activity drawer.
 
 ## Setup
 
@@ -32,10 +34,21 @@ call is recorded in the MCP Audit Log.
        "PreToolUse": [
          { "matcher": "Bash|Edit|Write|MultiEdit|NotebookEdit",
            "hooks": [{ "type": "command", "command": "scripts/vw-tool-hook.sh" }] }
+       ],
+       "PostToolUse": [
+         { "matcher": "Bash|Edit|Write",
+           "hooks": [{ "type": "command", "command": "scripts/vw-tool-hook.sh" }] }
        ]
      }
    }
    ```
+
+   The PostToolUse matcher uses `Bash|Edit|Write` because `MultiEdit` and
+   `NotebookEdit` are not confirmed as PostToolUse-matchable tools in the Claude
+   Code docs — test before adding them to the PostToolUse matcher.
+
+   Result capture is best-effort: if the gateway is unreachable the tool still
+   runs and the invocation simply shows "no result captured". It never blocks.
 
 ## Behavior
 
@@ -48,6 +61,7 @@ call is recorded in the MCP Audit Log.
 | Approval not decided in time | `VW_APPROVAL_FAIL_MODE=closed` (default) blocks; `open` runs |
 | Gateway rate-limits the call | `VW_FAIL_MODE=open` (default) runs; `closed` blocks |
 | Gateway unreachable / timeout | `VW_FAIL_MODE=open` runs; `closed` blocks |
+| PostToolUse result capture | best-effort; tool already ran, result POSTed to the gateway, never blocks |
 
 File-write tools (Write, Edit, MultiEdit, NotebookEdit) are gated on the content being written.
 A guardrail or approval rule that matches that content blocks or pauses the write;

--- a/scripts/vw-tool-hook.sh
+++ b/scripts/vw-tool-hook.sh
@@ -1,8 +1,10 @@
 #!/usr/bin/env bash
-# VerifyWise tool gate, a Claude Code PreToolUse hook.
-# Reads the tool call as JSON on stdin, asks the AI Gateway to adjudicate,
-# and exits 0 (allow) or non-zero (deny). Fails open by default so a gateway
-# outage never halts your workflow.
+# VerifyWise tool gate — Claude Code PreToolUse/PostToolUse hook.
+# PreToolUse: reads the tool call as JSON on stdin, asks the AI Gateway to
+# adjudicate, and exits 0 (allow) or non-zero (deny). Fails open by default
+# so a gateway outage never halts your workflow.
+# PostToolUse: captures the tool result and forwards it to the gateway
+# best-effort; always exits 0 — result capture must never block.
 #
 # Env:
 #   VW_GATEWAY_URL  (required)  e.g. http://localhost:8100
@@ -32,8 +34,28 @@ command -v curl >/dev/null 2>&1 || fail "curl not found"
 input="$(cat)"
 tool_name="$(printf '%s' "$input" | jq -r '.tool_name // .tool.name // "unknown"')"
 arguments="$(printf '%s' "$input" | jq -c '.tool_input // .arguments // {}')"
+session_id="$(printf '%s' "$input" | jq -r '.session_id // empty')"
+tool_use_id="$(printf '%s' "$input" | jq -r '.tool_use_id // empty')"
+hook_event="$(printf '%s' "$input" | jq -r '.hook_event_name // "PreToolUse"')"
 
-payload="$(jq -nc --arg t "$tool_name" --argjson a "$arguments" '{tool_name:$t, arguments:$a}')"
+# PostToolUse: capture the tool result, best-effort. Never blocks — the tool
+# has already run, so any failure here must still exit 0.
+if [ "$hook_event" = "PostToolUse" ]; then
+  tool_response="$(printf '%s' "$input" | jq -c '.tool_response // {}')"
+  rpayload="$(jq -nc --arg t "$tool_name" --argjson r "$tool_response" \
+    --arg s "$session_id" --arg u "$tool_use_id" \
+    '{tool_name:$t, tool_response:$r, session_id:$s, tool_use_id:$u}')"
+  curl -s --max-time "$TIMEOUT" -o /dev/null \
+    -X POST "$VW_GATEWAY_URL/v1/mcp/hook/result" \
+    -H "Authorization: Bearer $VW_AGENT_KEY" \
+    -H "Content-Type: application/json" \
+    -d "$rpayload" 2>/dev/null || true
+  exit 0
+fi
+
+payload="$(jq -nc --arg t "$tool_name" --argjson a "$arguments" \
+  --arg s "$session_id" --arg u "$tool_use_id" \
+  '{tool_name:$t, arguments:$a, session_id:$s, tool_use_id:$u}')"
 
 # Append the HTTP status on its own trailing line so we never write a
 # response file to a predictable /tmp path (symlink-attack surface).


### PR DESCRIPTION
## Summary

Agent Control's Activity log recorded that a tool call happened, but not what it did. This adds per-invocation **result capture** and an **events timeline**, surfaced in a detail drawer on the Activity page. 

A coding agent's native tool calls (Bash/Edit/Write) are correlated by `(organization_id, session_id, tool_use_id)` — all present in both the Claude Code PreToolUse and PostToolUse hook payloads. One audit row per invocation, updated in place.

## How it works

- **PreToolUse** (`POST /v1/mcp/hook`) adjudicates as before, now also storing `tool_use_id` and seeding a received/decided events array.
- **PostToolUse** (new `POST /v1/mcp/hook/result`) receives the tool's `tool_response`, caps it (~10KB), masks PII/content via the org guardrails, and attaches it to the matching audit row with an outcome event. Best-effort and fail-open: if it never arrives (old adapter, crash), the row simply shows "no result captured."
- The adapter (`vw-tool-hook.sh`) gains a PostToolUse result mode; README documents the config.
- The Activity page rows are now clickable and open a right-side drawer showing arguments, result, events timeline, and raw JSON.

## Notes

- Additive migration (`a0007`): `tool_use_id`, `result_response` (JSONB), `result_truncated`, `events` (JSONB) + index. Fully backward-compatible.
- E2E verified against a live stack: 6/6 new result-capture tests pass, plus 28/28 existing hook tests (no regression). The masking test caught and fixed a real leak where a per-entity `block` rule would skip masking on the result path.
- Result storage is a generic `result_response` JSONB because `tool_response` shape differs per tool (Bash has stdout/stderr/interrupted, Write has filePath/success, no exit code).
- i18n: de/fr/es for the new drawer strings.

## Deferred (separate follow-ups)

Decision provenance (which rule matched / "Create rule from this"), LLM summarize, Server/Decision columns on Activity, non-Claude-Code adapters.