### PR TITLE
fix(ai-gateway): Agent Control UI polish

### DIFF
--- a/Clients/src/i18n/translations.ts
+++ b/Clients/src/i18n/translations.ts
@@ -1443,6 +1443,8 @@ export const translations: Record<string, Record<string, string>> = {
     "Create a password": "Passwort erstellen",
     "Create a use case": "Anwendungsfall erstellen",
     "Create agent key": "Agentenschlüssel erstellen",
+    "Denylist for MCP server tools called through the proxy: these are always denied, even if also in the allowlist. Comma-separated; leave empty to block none.":
+      "Sperrliste für MCP-Server-Tools, die über den Proxy aufgerufen werden: Sie werden immer abgelehnt, auch wenn sie in der Erlaubnisliste stehen. Durch Kommas getrennt; leer lassen, um keine zu blockieren.",
     "Create alert rule": "Benachrichtigungsregel erstellen",
     "Create and manage intake forms for external submissions":
       "Eingangsformulare für externe Einreichungen erstellen und verwalten",
@@ -10172,6 +10174,8 @@ export const translations: Record<string, Record<string, string>> = {
     "Create a password": "Créer un mot de passe",
     "Create a use case": "Créer un cas d'usage",
     "Create agent key": "Créer une clé d'agent",
+    "Denylist for MCP server tools called through the proxy: these are always denied, even if also in the allowlist. Comma-separated; leave empty to block none.":
+      "Liste de blocage pour les outils de serveur MCP appelés via le proxy : ils sont toujours refusés, même s'ils figurent aussi dans la liste d'autorisation. Séparés par des virgules ; laissez vide pour n'en bloquer aucun.",
     "Create alert rule": "Créer une règle d'alerte",
     "Create and manage intake forms for external submissions":
       "Créer et gérer des formulaires d'entrée pour les soumissions externes",
@@ -18110,6 +18114,8 @@ export const translations: Record<string, Record<string, string>> = {
     "Create a password": "Cree una contraseña",
     "Create a use case": "Crear un caso de uso",
     "Create agent key": "Crear clave de agente",
+    "Denylist for MCP server tools called through the proxy: these are always denied, even if also in the allowlist. Comma-separated; leave empty to block none.":
+      "Lista de denegación para herramientas de servidor MCP llamadas a través del proxy: siempre se deniegan, incluso si también están en la lista de permitidos. Separadas por comas; deja vacío para no bloquear ninguna.",
     "Create alert rule": "Crear regla de alerta",
     "Create arena battle": "Crear batalla de arena",
     "Create Configuration": "Crear configuración",

--- a/Clients/src/presentation/components/Inputs/Field/index.tsx
+++ b/Clients/src/presentation/components/Inputs/Field/index.tsx
@@ -123,7 +123,7 @@ const Field = forwardRef(
             color={theme.palette.text.secondary}
             fontWeight={500}
             fontSize={"13px"}
-            sx={{ margin: 0, height: "22px", display: "block", cursor: "pointer" }}
+            sx={{ margin: 0, height: "22px", display: "block" }}
           >
             {label}
             {isRequired && (

--- a/Clients/src/presentation/components/Inputs/Select/index.tsx
+++ b/Clients/src/presentation/components/Inputs/Select/index.tsx
@@ -151,7 +151,6 @@ function Select({
             height: "22px",
             display: "flex",
             alignItems: "center",
-            cursor: "pointer",
           }}
         >
           {label}

--- a/Clients/src/presentation/pages/AIGateway/MCPAgentKeys/index.tsx
+++ b/Clients/src/presentation/pages/AIGateway/MCPAgentKeys/index.tsx
@@ -337,15 +337,17 @@ export default function MCPAgentKeysPage() {
           />
           <Field
             label="Allowed tools"
-            placeholder="e.g., search, get_weather, run_query (comma-separated, leave empty for all)"
+            placeholder="e.g., search, get_weather, run_query"
             value={createForm.allowed_tools}
             onChange={(e) => setCreateForm((p) => ({ ...p, allowed_tools: e.target.value }))}
+            helperText="Allowlist for MCP server tools called through the proxy: if set, this key may call only these tools. Comma-separated; leave empty to allow all. (Does not apply to native tools like Bash/Edit/Write — govern those with guardrails.)"
           />
           <Field
             label="Blocked tools"
-            placeholder="e.g., delete_record, drop_table (comma-separated)"
+            placeholder="e.g., delete_record, drop_table"
             value={createForm.blocked_tools}
             onChange={(e) => setCreateForm((p) => ({ ...p, blocked_tools: e.target.value }))}
+            helperText="Denylist for MCP server tools called through the proxy: these are always denied, even if also in the allowlist. Comma-separated; leave empty to block none."
           />
           <Field
             label="Rate limit (requests per minute)"

--- a/Clients/src/presentation/pages/AIGateway/MCPAuditLog/index.tsx
+++ b/Clients/src/presentation/pages/AIGateway/MCPAuditLog/index.tsx
@@ -197,7 +197,7 @@ export default function MCPAuditLogPage() {
           )}
 
           {toolStats.length > 0 && (
-            <Stack direction={{ xs: "column", md: "row" }} spacing={2} sx={{ px: 3, pt: 2 }}>
+            <Stack direction={{ xs: "column", md: "row" }} gap="16px" sx={{ px: 3, pt: 2 }}>
               <Box sx={{ ...cardSx, flex: 1 }}>
                 <Stack direction="row" alignItems="center" gap={1} sx={{ mb: 1 }}>
                   <Typography sx={sectionTitleSx}>Top 10 tools by calls</Typography>

--- a/Clients/src/presentation/pages/AIGateway/MCPGuardrails/index.tsx
+++ b/Clients/src/presentation/pages/AIGateway/MCPGuardrails/index.tsx
@@ -465,9 +465,10 @@ export default function MCPGuardrailsPage() {
 
           <Field
             label="Config (JSON)"
-            placeholder='{"entities": {"EMAIL_ADDRESS": "mask"}}'
+            placeholder={'{\n  "entities": {\n    "EMAIL_ADDRESS": "mask"\n  }\n}'}
             value={form.config}
             onChange={(e) => setForm((p) => ({ ...p, config: e.target.value }))}
+            rows={4}
             isOptional
           />
           <Typography sx={{ fontSize: 11, color: palette.text.disabled, mt: "-12px" }}>

--- a/Clients/src/presentation/pages/AIGateway/MCPInvocationDrawer.tsx
+++ b/Clients/src/presentation/pages/AIGateway/MCPInvocationDrawer.tsx
@@ -1,4 +1,4 @@
-import { Box, Drawer, Typography, Stack, IconButton } from "@mui/material";
+import { Box, Drawer, Typography, Stack, IconButton, Divider } from "@mui/material";
 import { X } from "lucide-react";
 import { useState, useEffect } from "react";
 import Chip from "../../components/Chip";
@@ -62,6 +62,17 @@ export default function MCPInvocationDrawer({ logId, open, onClose }: Invocation
     fontWeight: 600,
     color: palette.text.tertiary,
     letterSpacing: "0.5px",
+    mb: "6px",
+  };
+  const codeBlockSx = {
+    fontSize: 12,
+    fontFamily: "monospace",
+    whiteSpace: "pre-wrap" as const,
+    bgcolor: KEY_DISPLAY_BG,
+    p: "12px",
+    borderRadius: "4px",
+    overflow: "auto",
+    m: 0,
   };
 
   return (
@@ -69,73 +80,61 @@ export default function MCPInvocationDrawer({ logId, open, onClose }: Invocation
       anchor="right"
       open={open}
       onClose={onClose}
-      sx={{ "& .MuiDrawer-paper": { width: 520, p: 3 } }}
+      sx={{ "& .MuiDrawer-paper": { width: 520, px: "16px", py: "20px" } }}
     >
       {!row ? (
         <Typography sx={{ fontSize: 13, color: palette.text.tertiary }}>Loading…</Typography>
       ) : (
-        <Stack gap="16px">
-          <Stack direction="row" justifyContent="space-between" alignItems="flex-start">
-            <Box>
-              <Typography sx={{ fontSize: 16, fontWeight: 600, fontFamily: "monospace" }}>
-                {row.tool_name}
-              </Typography>
+        <Stack gap="20px">
+          {/* Header */}
+          <Stack direction="row" justifyContent="space-between" alignItems="flex-start" gap="8px">
+            <Stack gap="6px" sx={{ minWidth: 0 }}>
+              <Stack direction="row" alignItems="center" gap="8px" flexWrap="wrap">
+                <Typography sx={{ fontSize: 16, fontWeight: 600, fontFamily: "monospace" }}>
+                  {row.tool_name}
+                </Typography>
+                <Chip
+                  label={row.result_status}
+                  backgroundColor={colors.bg}
+                  textColor={colors.text}
+                />
+              </Stack>
               <Typography sx={{ fontSize: 12, color: palette.text.tertiary }}>
                 {displayFormattedDate(row.created_at)}
               </Typography>
               <Typography sx={{ fontSize: 12, color: palette.text.tertiary }}>
                 {(row.agent_key_name || "—") + " · " + (row.session_id || "—")}
               </Typography>
-            </Box>
-            <IconButton size="small" onClick={onClose} aria-label="Close">
+            </Stack>
+            <IconButton size="small" onClick={onClose} aria-label="Close" sx={{ flexShrink: 0 }}>
               <X size={16} />
             </IconButton>
           </Stack>
 
-          <Chip label={row.result_status} backgroundColor={colors.bg} textColor={colors.text} />
+          <Divider />
 
           <Box>
             <Typography sx={labelSx}>TOOL USE ID</Typography>
-            <Typography sx={{ fontSize: 12, fontFamily: "monospace" }}>
+            <Typography sx={{ fontSize: 12, fontFamily: "monospace", wordBreak: "break-all" }}>
               {row.tool_use_id || "—"}
             </Typography>
           </Box>
 
+          <Divider />
+
           <Box>
             <Typography sx={labelSx}>ARGUMENTS</Typography>
-            <Box
-              component="pre"
-              sx={{
-                fontSize: 12,
-                fontFamily: "monospace",
-                whiteSpace: "pre-wrap",
-                bgcolor: KEY_DISPLAY_BG,
-                p: "8px",
-                borderRadius: "4px",
-                overflow: "auto",
-                maxHeight: 200,
-              }}
-            >
+            <Box component="pre" sx={{ ...codeBlockSx, maxHeight: 200 }}>
               {JSON.stringify(row.arguments ?? {}, null, 2)}
             </Box>
           </Box>
 
+          <Divider />
+
           <Box>
             <Typography sx={labelSx}>RESULT</Typography>
             {row.result_response ? (
-              <Box
-                component="pre"
-                sx={{
-                  fontSize: 12,
-                  fontFamily: "monospace",
-                  whiteSpace: "pre-wrap",
-                  bgcolor: KEY_DISPLAY_BG,
-                  p: "8px",
-                  borderRadius: "4px",
-                  overflow: "auto",
-                  maxHeight: 280,
-                }}
-              >
+              <Box component="pre" sx={{ ...codeBlockSx, maxHeight: 280 }}>
                 {JSON.stringify(row.result_response, null, 2)}
                 {row.result_truncated ? "\n… (truncated)" : ""}
               </Box>
@@ -146,22 +145,28 @@ export default function MCPInvocationDrawer({ logId, open, onClose }: Invocation
             )}
           </Box>
 
+          <Divider />
+
           <Box>
             <Typography sx={labelSx}>EVENTS</Typography>
-            <Stack gap="4px" sx={{ mt: "4px" }}>
+            <Stack gap="6px">
               {(row.events || []).map((e: InvocationEvent, i: number) => (
-                <Stack key={i} direction="row" justifyContent="space-between">
+                <Stack key={i} direction="row" justifyContent="space-between" gap="12px">
                   <Typography sx={{ fontSize: 12 }}>
                     {e.type}
                     {e.detail ? ` · ${e.detail}` : ""}
                   </Typography>
-                  <Typography sx={{ fontSize: 12, color: palette.text.tertiary }}>
+                  <Typography
+                    sx={{ fontSize: 12, color: palette.text.tertiary, whiteSpace: "nowrap" }}
+                  >
                     {displayFormattedDate(e.at)}
                   </Typography>
                 </Stack>
               ))}
             </Stack>
           </Box>
+
+          <Divider />
 
           <Box>
             <Box
@@ -183,14 +188,10 @@ export default function MCPInvocationDrawer({ logId, open, onClose }: Invocation
               <Box
                 component="pre"
                 sx={{
-                  fontSize: 11,
-                  fontFamily: "monospace",
-                  whiteSpace: "pre-wrap",
+                  ...codeBlockSx,
+                  mt: "8px",
                   bgcolor: CODE_BLOCK_BG,
                   color: CODE_BLOCK_TEXT,
-                  p: "8px",
-                  borderRadius: "4px",
-                  overflow: "auto",
                   maxHeight: 320,
                 }}
               >

--- a/Clients/src/presentation/pages/AIGateway/MCPTable.tsx
+++ b/Clients/src/presentation/pages/AIGateway/MCPTable.tsx
@@ -82,7 +82,14 @@ export default function MCPTable<T>({
                 key={rowKey(row)}
                 sx={{
                   ...singleTheme.tableStyles.primary.body.row,
-                  cursor: onRowClick ? "pointer" : "default",
+                  // The shared row style sets cursor:pointer on hover (for clickable
+                  // tables). When this table has no row click, keep the hover
+                  // background but override the cursor so rows don't look clickable.
+                  "cursor": onRowClick ? "pointer" : "default",
+                  "&:hover": {
+                    ...(singleTheme.tableStyles.primary.body.row as Record<string, any>)["&:hover"],
+                    cursor: onRowClick ? "pointer" : "default",
+                  },
                   ...(rowSx ? rowSx(row) : {}),
                 }}
                 onClick={onRowClick ? () => onRowClick(row) : undefined}


### PR DESCRIPTION
## Summary

UI polish across the Agent Control screens, from review feedback.

## Changes

- **Tables:** non-clickable rows (tables with no row click, e.g. Agent keys) no longer show a pointer cursor on hover. The shared row style set `cursor: pointer` in its `:hover`; `MCPTable` now overrides it to default when there's no `onRowClick`.
- **Form labels:** removed `cursor: pointer` from the shared `Field` and `Select` labels — a label pointer read as "clickable" across every modal. Clicking a label still focuses its input; only the visual cursor changes.
- **Create agent key modal:** added helper text explaining Allowed/Blocked tools, accurately scoped to MCP proxy calls (they don't gate native tools).
- **Guardrail modal:** Config (JSON) is now a 4-line textarea instead of a single line.
- **Invocation drawer:** 16px side padding, dividers between sections, header groups tool name + status chip, consistent spacing.
- **Activity charts:** explicit 16px gap between the two chart blocks.
- **i18n:** de/fr/es for the new helper string.

## Notes

Verified in the running app: agent-keys rows no longer look clickable, the drawer layout is cleanly separated, the guardrail modal labels and Config field render correctly.