### PR TITLE
feat(ui): add table skeleton loading to Use cases page

### DIFF
--- a/Clients/src/application/config/routes.tsx
+++ b/Clients/src/application/config/routes.tsx
@@ -2,9 +2,10 @@ import { Suspense } from "react";
 import { Route, Navigate } from "react-router-dom";
 import { lazyRoute, LazyFallback } from "../utils/lazyRoute";
 
-// Eager imports — only the app shell and route guard
+// Eager imports — app shell, route guard, and Use cases page (mounts with layout for table skeleton UX)
 import Dashboard from "../../presentation/containers/Dashboard";
 import ProtectedRoute from "../../presentation/components/ProtectedRoute";
+import VWHome from "../../presentation/pages/Home/1.0Home";
 
 // ── Authentication routes ─────────────────────────────────────────────
 const Login = lazyRoute(() => import("../../presentation/pages/Authentication/Login"));
@@ -37,7 +38,6 @@ const IntegratedDashboard = lazyRoute(
   () => import("../../presentation/pages/DashboardOverview/IntegratedDashboard"),
 );
 const StartHere = lazyRoute(() => import("../../presentation/pages/StartHere"));
-const VWHome = lazyRoute(() => import("../../presentation/pages/Home/1.0Home"));
 const VWProjectView = lazyRoute(
   () => import("../../presentation/pages/ProjectView/V1.0ProjectView"),
 );
@@ -350,14 +350,7 @@ export const createRoutes = (
         </Suspense>
       }
     />
-    <Route
-      path="/overview"
-      element={
-        <Suspense fallback={<LazyFallback />}>
-          <VWHome />
-        </Suspense>
-      }
-    />
+    <Route path="/overview" element={<VWHome />} />
     <Route
       path="/framework/:tab?"
       element={

--- a/Clients/src/application/hooks/useDashboard.ts
+++ b/Clients/src/application/hooks/useDashboard.ts
@@ -7,7 +7,11 @@ const DASHBOARD_QUERY_KEY = ["dashboard"] as const;
 export const useDashboard = () => {
   const queryClient = useQueryClient();
 
-  const { data: dashboard = null, isLoading: loading } = useQuery({
+  const {
+    data: dashboard = null,
+    isLoading: loading,
+    isPending,
+  } = useQuery({
     queryKey: DASHBOARD_QUERY_KEY,
     queryFn: async () => {
       const response = await getAllEntities({ routeUrl: "/dashboard" });
@@ -21,5 +25,5 @@ export const useDashboard = () => {
     await queryClient.invalidateQueries({ queryKey: DASHBOARD_QUERY_KEY });
   };
 
-  return { dashboard, loading, fetchDashboard };
+  return { dashboard, loading, isPending, fetchDashboard };
 };

--- a/Clients/src/domain/interfaces/i.project.ts
+++ b/Clients/src/domain/interfaces/i.project.ts
@@ -12,6 +12,7 @@ import { ProjectRiskMitigation } from "../types/ProjectRisk";
 export interface IProjectListProps {
   projects: Project[];
   newProjectButton?: unknown;
+  isLoading?: boolean;
   onFilterChange?: (filteredProjects: Project[], filters: any) => void;
   onProjectDeleted?: () => void;
 }

--- a/Clients/src/presentation/components/ProjectsList/ProjectsList.tsx
+++ b/Clients/src/presentation/components/ProjectsList/ProjectsList.tsx
@@ -18,10 +18,16 @@ import { FilterBy, FilterColumn } from "../Table/FilterBy";
 import { useFilterBy } from "../../../application/hooks/useFilterBy";
 import { ColumnSelector } from "../Table/ColumnSelector";
 import { useColumnVisibility, ColumnConfig } from "../../../application/hooks/useColumnVisibility";
+import CustomizableSkeleton from "../Skeletons";
 
 import { projectWrapperStyle, noProjectsTextStyle, vwhomeBodyProjectsGrid } from "./style";
 
-const ProjectList = ({ projects, newProjectButton, onProjectDeleted }: IProjectListProps) => {
+const ProjectList = ({
+  projects,
+  newProjectButton,
+  onProjectDeleted,
+  isLoading = false,
+}: IProjectListProps) => {
   const [searchTerm, setSearchTerm] = useState("");
   const [viewMode, setViewMode] = usePersistedViewMode("projects-view-mode", "table");
 
@@ -223,6 +229,14 @@ const ProjectList = ({ projects, newProjectButton, onProjectDeleted }: IProjectL
 
   // Extracted render logic
   const renderProjects = () => {
+    if (isLoading) {
+      return (
+        <Stack spacing={2}>
+          <CustomizableSkeleton variant="rectangular" width="100%" height={400} />
+        </Stack>
+      );
+    }
+
     if (!projects || projects.length === 0) {
       return viewMode === "table" ? (
         <ProjectTableView projects={[]} />
@@ -323,39 +337,35 @@ const ProjectList = ({ projects, newProjectButton, onProjectDeleted }: IProjectL
         }}
       >
         <Stack direction="row" spacing={2} alignItems="center" sx={{ flex: 1 }}>
-          {projects && projects.length > 0 && (
+          <FilterBy columns={projectFilterColumns} onFilterChange={handleProjectFilterChange} />
+
+          {viewMode === "table" && (
             <>
-              <FilterBy columns={projectFilterColumns} onFilterChange={handleProjectFilterChange} />
-
-              {viewMode === "table" && (
-                <>
-                  <GroupBy
-                    options={[
-                      { id: "risk_level", label: "Risk level" },
-                      { id: "role", label: "Role" },
-                      { id: "owner", label: "Owner" },
-                      { id: "status", label: "Status" },
-                    ]}
-                    onGroupChange={handleGroupChange}
-                  />
-                  <ColumnSelector
-                    columns={allColumns}
-                    visibleColumns={visibleColumns}
-                    onToggleColumn={toggleColumn}
-                    onResetToDefaults={resetToDefaults}
-                  />
-                </>
-              )}
-
-              <SearchBox
-                placeholder="Search use cases..."
-                value={searchTerm}
-                onChange={setSearchTerm}
-                inputProps={{ "aria-label": "Search use cases" }}
-                fullWidth={false}
+              <GroupBy
+                options={[
+                  { id: "risk_level", label: "Risk level" },
+                  { id: "role", label: "Role" },
+                  { id: "owner", label: "Owner" },
+                  { id: "status", label: "Status" },
+                ]}
+                onGroupChange={handleGroupChange}
+              />
+              <ColumnSelector
+                columns={allColumns}
+                visibleColumns={visibleColumns}
+                onToggleColumn={toggleColumn}
+                onResetToDefaults={resetToDefaults}
               />
             </>
           )}
+
+          <SearchBox
+            placeholder="Search use cases..."
+            value={searchTerm}
+            onChange={setSearchTerm}
+            inputProps={{ "aria-label": "Search use cases" }}
+            fullWidth={false}
+          />
         </Stack>
 
         <Box
@@ -365,18 +375,14 @@ const ProjectList = ({ projects, newProjectButton, onProjectDeleted }: IProjectL
             gap: "8px",
           }}
         >
-          {projects && projects.length > 0 && (
-            <ExportMenu
-              data={exportData}
-              columns={exportColumns}
-              filename="use-cases"
-              title="Use Cases"
-            />
-          )}
+          <ExportMenu
+            data={exportData}
+            columns={exportColumns}
+            filename="use-cases"
+            title="Use Cases"
+          />
           {newProjectButton as React.ReactNode}
-          {projects && projects.length > 0 && (
-            <ViewToggle viewMode={viewMode} onViewChange={setViewMode} />
-          )}
+          <ViewToggle viewMode={viewMode} onViewChange={setViewMode} />
         </Box>
       </Box>
 

--- a/Clients/src/presentation/components/ProtectedRoute/index.tsx
+++ b/Clients/src/presentation/components/ProtectedRoute/index.tsx
@@ -4,7 +4,6 @@ import { useEffect, useState, useRef } from "react";
 import { useDispatch } from "react-redux";
 import { setUserExists, clearAuthState } from "../../../application/redux/auth/authSlice";
 import { getAllEntities } from "../../../application/repository/entity.repository";
-import CustomizableToast from "../Toast";
 import { extractUserToken } from "../../../application/tools/extractToken";
 import { IProtectedRouteProps } from "../../types/widget.types";
 
@@ -83,7 +82,10 @@ const ProtectedRoute = ({ Component, ...rest }: IProtectedRouteProps) => {
   }, [dispatch, authState.authToken, isPublicRoute]);
 
   if (loading) {
-    return <CustomizableToast title="Loading..." />; // Show a loading indicator while checking user existence
+    if (authState.authToken) {
+      return <Component {...rest} />;
+    }
+    return null;
   }
 
   // Always allow access to login route

--- a/Clients/src/presentation/pages/Home/1.0Home/index.tsx
+++ b/Clients/src/presentation/pages/Home/1.0Home/index.tsx
@@ -1,4 +1,4 @@
-import { useContext, useEffect, useState, useRef } from "react";
+import { useContext, useEffect, useState, useRef, useMemo } from "react";
 import { useLocation, useNavigate } from "react-router-dom";
 import { VerifyWiseContext } from "../../../../application/contexts/VerifyWise.context";
 import { FrameworkTypeEnum } from "../../../components/Forms/ProjectForm/constants";
@@ -7,7 +7,6 @@ import PageTour from "../../../components/PageTour";
 import HomeSteps from "./HomeSteps";
 import useMultipleOnScreen from "../../../../application/hooks/useMultipleOnScreen";
 import { useDashboard } from "../../../../application/hooks/useDashboard";
-import { Project } from "../../../../domain/types/Project";
 import ProjectList from "../../../components/ProjectsList/ProjectsList";
 import { CustomizableButton } from "../../../components/button/customizable-button";
 import allowedRoles from "../../../../application/constants/permissions";
@@ -20,24 +19,17 @@ import { brand } from "../../../themes/palette";
 const Home = () => {
   const location = useLocation();
   const navigate = useNavigate();
-  const {
-    setDashboardValues,
-    componentsVisible,
-    changeComponentVisibility,
-    refreshUsers,
-    userRoleName,
-  } = useContext(VerifyWiseContext);
+  const { componentsVisible, changeComponentVisibility, refreshUsers, userRoleName } =
+    useContext(VerifyWiseContext);
   const [isProjectFormModalOpen, setIsProjectFormModalOpen] = useState<boolean>(false);
   const [isScreeningOpen, setIsScreeningOpen] = useState<boolean>(false);
   const [refreshProjectsFlag, setRefreshProjectsFlag] = useState<boolean>(false);
 
-  const [projects, setProjects] = useState<Project[]>([]);
-  const { dashboard, fetchDashboard } = useDashboard();
+  const { dashboard, isPending, fetchDashboard } = useDashboard();
 
-  useEffect(() => {
-    if (dashboard) {
-      setProjects(dashboard.projects_list.filter((p) => !p.is_organizational));
-    }
+  const projects = useMemo(() => {
+    if (!dashboard) return [];
+    return dashboard.projects_list.filter((p) => !p.is_organizational);
   }, [dashboard]);
 
   const [runHomeTour, setRunHomeTour] = useState(false);
@@ -58,14 +50,9 @@ const Home = () => {
   }, [componentsVisible]);
 
   useEffect(() => {
-    const fetchProgressData = async () => {
-      await refreshUsers();
-
-      await fetchDashboard();
-    };
-
-    fetchProgressData();
-  }, [setDashboardValues, fetchDashboard, refreshProjectsFlag]);
+    void refreshUsers();
+    void fetchDashboard();
+  }, [fetchDashboard, refreshProjectsFlag, refreshUsers]);
 
   const submitFormRef = useRef<(() => void) | undefined>(undefined);
 
@@ -94,6 +81,7 @@ const Home = () => {
       {/* Projects List */}
       <ProjectList
         projects={projects}
+        isLoading={isPending}
         onProjectDeleted={() => setRefreshProjectsFlag((prev) => !prev)}
         newProjectButton={
           <div data-joyride-id="new-project-button" ref={newProjectButtonRef}>


### PR DESCRIPTION
## Describe your changes

Show CustomizableSkeleton in the table slot while dashboard data is pending, keep filters and toolbar visible, eager-load the page with the layout for correct loading order, and skip the auth Loading overlay when a token exists.

## Write your issue number after "Fixes "

Fixes #4110 

## Please ensure all items are checked off before requesting a review:

- [x] I deployed the code locally.
- [x] I have performed a self-review of my code.
- [x] I have included the issue # in the PR.
- [x] I have labelled the PR correctly.
- [x] The issue I am working on is assigned to me.
- [x] I have avoided using hardcoded values to ensure scalability and maintain consistency across the application.
- [x] I have ensured that font sizes, color choices, and other UI elements are referenced from the theme.
- [x] My pull request is focused and addresses a single, specific feature.
- [x] If there are UI changes, I have attached a screenshot or video to this PR.

<img width="800" height="600" alt="Screenshot 2026-06-17 at 4 36 58 PM" src="https://github.com/user-attachments/assets/f00201b7-0485-474e-950e-e5c0a6ec43b5" />
