### PR TITLE
Refresh Agent Control docs after run correlation merge

### DIFF
--- a/AIGateway/CLAUDE.md
+++ b/AIGateway/CLAUDE.md
@@ -1,6 +1,6 @@
 # AIGateway — LLM Gateway Service
 
-> **Last Updated:** 2026-06-16
+> **Last Updated:** 2026-06-18
 
 ---
 
@@ -84,7 +84,8 @@ Express backend at `Servers/routes/aiGateway.route.ts` proxies `/api/ai-gateway/
 
 | When working on... | Read this file |
 |---------------------|---------------|
-| Agent Control (native tool-call hook, file-write gating, approval) | `docs/technical/domains/agent-control.md` |
+| Agent Control (native tool-call hook, file-write gating, approval, result capture, run correlation) | `docs/technical/domains/agent-control.md` |
+| Agent Control developer/integrator guide (connect any agent: Claude Code, Cursor, generic) | `shared/user-guide-content/content/developers/` |
 | AI Advisor | `docs/technical/infrastructure/ai-advisor.md` |
 | Integrations (Slack, GitHub) | `docs/technical/infrastructure/integrations.md` |
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,6 @@
 # VerifyWise - Development Guide
 
-> **Last Updated:** 2026-06-16
+> **Last Updated:** 2026-06-18
 
 This document contains cross-cutting rules for the VerifyWise codebase. Directory-scoped guides load automatically when working in each area:
 
@@ -172,7 +172,8 @@ Read the relevant file BEFORE implementing changes in that area:
 | Detailed coding standards (TS, React, backend, security, testing) | `CodeRules/README.md` |
 | Plugin system | `docs/technical/infrastructure/plugin-system.md` |
 | Approval workflows | `docs/technical/domains/approvals.md` |
-| Agent Control (AI Gateway native tool-call hook + file-write gating) | `docs/technical/domains/agent-control.md` |
+| Agent Control (AI Gateway native tool-call hook, file-write gating, approval, result capture, run correlation, multi-agent wiring) | `docs/technical/domains/agent-control.md` |
+| Agent Control integrator/developer docs (connect an agent, Claude Code + Cursor, generic contract, API ref) | `shared/user-guide-content/content/developers/` |
 | AI Detection | `docs/technical/domains/ai-detection.md` |
 | Risk management | `docs/technical/domains/risk-management.md` |
 | Vendors | `docs/technical/domains/vendors.md` |

--- a/docs/technical/domains/agent-control.md
+++ b/docs/technical/domains/agent-control.md
@@ -1,8 +1,8 @@
 # Agent Control — native tool-call governance
 
-> **Status:** Core shipped to `develop` (PRs #4078, #4083, #4084). Tool result capture +
-> events timeline + invocation drawer in PR #4103 (open). Run correlation on
-> `feat/agent-run-correlation`. Last updated 2026-06-17.
+> **Status:** Shipped to `develop`. Core governance (PRs #4078, #4083, #4084); tool result
+> capture + events timeline + invocation drawer (PR #4103); run correlation, multi-agent
+> wiring (Claude Code + Cursor) and the developer guide (PR #4112). Last updated 2026-06-18.
 
 Agent Control gates a coding agent's tool calls through the AI Gateway's guardrails,
 human-approval and audit machinery. It covers two entry paths that share one governance
@@ -193,13 +193,25 @@ shows the conversation and the tool calls interleaved.
   repo). Genuinely new matching logic.
 - **Decision provenance** — record which rule matched each call (the "RULE" badge and "Create
   rule from this" in comparable products); Server/Decision columns on Activity depend on it.
-- Cursor / non-Claude-Code adapter; an Agent Control overview/landing page; a priority rule
-  engine; tamper-evident audit; metering MCP calls into the existing budgets; an LLM
-  "summarize" for captured results.
+- An Agent Control overview/landing page; a priority rule engine; tamper-evident audit;
+  metering MCP calls into the existing budgets; an LLM "summarize" for captured results.
+- Adapters for agents without a pre-tool hook (Codex CLI, Aider, Gemini CLI). The integration
+  contract is documented (see the developer guide) so users can wire these themselves; no
+  bundled adapter ships yet. Cursor and Claude Code both work today via `scripts/vw-tool-hook.sh`.
 
 ## Design history
 
 The spec/plan trail for each increment lives under `docs/superpowers/`:
 `2026-06-15-mcp-bash-hook-*` (Phase 1), `2026-06-15-mcp-hook-approval-*` (Phase 2),
 `2026-06-16-mcp-hook-filewrite-*` (Phase 3), `2026-06-16-agent-control-rename-*` (rename),
-`2026-06-16-agent-control-tool-results-*` (result capture + events + drawer).
+`2026-06-16-agent-control-tool-results-*` (result capture + events + drawer),
+`2026-06-17-agent-run-correlation-*` (run correlation),
+`2026-06-17-agent-control-developer-docs-*` (developer guide + multi-agent support).
+
+## Integrator-facing docs
+
+Customer developers connecting their own agent use the **Developer guide** collection in the
+in-app user guide (`shared/user-guide-content/content/developers/`): overview, connect your
+agent (Claude Code + Cursor wiring), connect any agent (the generic hook contract + MCP proxy +
+bring-your-own), governing tool calls, and an API reference. Keep that collection in sync when
+the hook request/response shape, the `x-vw-agent-run-id` header, or the endpoints change.


### PR DESCRIPTION
## Summary

Documentation refresh after the agent run correlation work merged (PR #4112). Brings the internal Agent Control docs in line with what shipped.

## Changes

- `docs/technical/domains/agent-control.md`: updated the status line to reflect the merged state; removed the Cursor adapter from "not yet built" (Cursor is supported now via the same hook script); added an integrator-facing docs section pointing at the developer guide; extended the design-history trail.
- `CLAUDE.md` and `AIGateway/CLAUDE.md`: updated the Agent Control reference rows to mention run correlation and multi-agent wiring, added a row pointing to the developer guide content, and bumped the "Last Updated" date.
