### PR TITLE
fix(auth): make API tokens revocable and validated against the database

### DIFF
--- a/Clients/src/application/repository/tokens.repository.ts
+++ b/Clients/src/application/repository/tokens.repository.ts
@@ -15,3 +15,8 @@ export async function deleteApiToken({ routeUrl }: RequestParams): Promise<any> 
   const response = await apiServices.delete(routeUrl);
   return response;
 }
+
+export async function revokeApiToken({ routeUrl }: RequestParams): Promise<any> {
+  const response = await apiServices.post(routeUrl, {});
+  return response;
+}

--- a/Clients/src/domain/models/Common/apiToken/apiToken.model.ts
+++ b/Clients/src/domain/models/Common/apiToken/apiToken.model.ts
@@ -6,6 +6,8 @@ export class ApiTokenModel {
   created_at!: string;
   created_by!: number;
   is_demo?: boolean;
+  revoked?: boolean;
+  last_used_at?: string | null;
 
   constructor(data: ApiTokenModel) {
     this.id = data.id;
@@ -15,6 +17,8 @@ export class ApiTokenModel {
     this.created_at = data.created_at;
     this.created_by = data.created_by;
     this.is_demo = data.is_demo;
+    this.revoked = data.revoked;
+    this.last_used_at = data.last_used_at;
   }
 
   static createNewApiToken(data: ApiTokenModel): ApiTokenModel {
@@ -48,15 +52,31 @@ export class ApiTokenModel {
     });
   }
 
-  getStatus(): "Active" | "Expired" {
+  isRevoked(): boolean {
+    return this.revoked === true;
+  }
+
+  getStatus(): "Active" | "Expired" | "Revoked" {
+    if (this.isRevoked()) return "Revoked";
     return this.isExpired() ? "Expired" : "Active";
   }
 
   getStatusColor(): string {
+    if (this.isRevoked()) return "#f2f4f7";
     return this.isExpired() ? "#ffebee" : "#c8e6c9";
   }
 
   getStatusTextColor(): string {
+    if (this.isRevoked()) return "#667085";
     return this.isExpired() ? "#d32f2f" : "#388e3c";
+  }
+
+  getFormattedLastUsed(): string {
+    if (!this.last_used_at) return "Never";
+    return new Date(this.last_used_at).toLocaleDateString("en-US", {
+      year: "numeric",
+      month: "short",
+      day: "numeric",
+    });
   }
 }

--- a/Clients/src/i18n/translations.ts
+++ b/Clients/src/i18n/translations.ts
@@ -1477,6 +1477,7 @@ export const translations: Record<string, Record<string, string>> = {
     "Delete account": "Konto löschen",
     "Delete API key": "API-Schlüssel löschen",
     "Delete API Key": "API-Schlüssel löschen",
+    "Revoke API Key": "API-Schlüssel widerrufen",
     "Delete Arena Battle": "Arena-Vergleich löschen",
     "Delete automation": "Automatisierung löschen",
     "Delete bias audit": "Verzerrungs-Audit löschen",
@@ -10229,6 +10230,7 @@ export const translations: Record<string, Record<string, string>> = {
     "Delete account": "Supprimer le compte",
     "Delete API key": "Supprimer la clé API",
     "Delete API Key": "Supprimer la clé API",
+    "Revoke API Key": "Révoquer la clé API",
     "Delete Arena Battle": "Supprimer la comparaison d'arène",
     "Delete automation": "Supprimer l'automatisation",
 
@@ -18186,6 +18188,7 @@ export const translations: Record<string, Record<string, string>> = {
     "Delete account": "Eliminar cuenta",
     "Delete API key": "Eliminar clave de API",
     "Delete API Key": "Eliminar clave de API",
+    "Revoke API Key": "Revocar clave de API",
     "Delete Arena Battle": "Eliminar batalla de arena",
     "Delete automation": "Eliminar automatización",
     "Delete bias audit": "Eliminar auditoría de sesgo",

--- a/Clients/src/presentation/pages/SettingsPage/ApiKeys/index.tsx
+++ b/Clients/src/presentation/pages/SettingsPage/ApiKeys/index.tsx
@@ -12,7 +12,12 @@ import {
 } from "@mui/material";
 import { useState, useCallback, useEffect } from "react";
 import { CustomizableButton } from "../../../components/button/customizable-button";
-import { Plus as PlusIcon, Trash2 as DeleteIcon, Copy as CopyIcon } from "lucide-react";
+import {
+  Plus as PlusIcon,
+  Trash2 as DeleteIcon,
+  Copy as CopyIcon,
+  Ban as RevokeIcon,
+} from "lucide-react";
 import Alert from "../../../components/Alert";
 import ConfirmationModal from "../../../components/Dialogs/ConfirmationModal";
 import Field from "../../../components/Inputs/Field";
@@ -21,6 +26,7 @@ import {
   createApiToken,
   deleteApiToken,
   getApiTokens,
+  revokeApiToken,
 } from "../../../../application/repository/tokens.repository";
 import allowedRoles from "../../../../application/constants/permissions";
 import { useAuth } from "../../../../application/hooks/useAuth";
@@ -55,6 +61,8 @@ const ApiKeys = () => {
   const [isCreateModalOpen, setIsCreateModalOpen] = useState(false);
   const [isDeleteModalOpen, setIsDeleteModalOpen] = useState(false);
   const [tokenToDelete, setTokenToDelete] = useState<ApiTokenModel | null>(null);
+  const [isRevokeModalOpen, setIsRevokeModalOpen] = useState(false);
+  const [tokenToRevoke, setTokenToRevoke] = useState<ApiTokenModel | null>(null);
   const [newTokenName, setNewTokenName] = useState("");
   const [newTokenNameError, setNewTokenNameError] = useState<string | null>(null);
   const [selectedExpiry, setSelectedExpiry] = useState<number>(30);
@@ -198,6 +206,25 @@ const ApiKeys = () => {
       setIsLoading(false);
     }
   }, [tokenToDelete, fetchTokens, showAlert]);
+
+  const handleRevokeToken = useCallback(async () => {
+    if (!tokenToRevoke) return;
+
+    setIsRevokeModalOpen(false);
+    setIsLoading(true);
+    try {
+      await revokeApiToken({
+        routeUrl: `/tokens/${tokenToRevoke.id}/revoke`,
+      });
+      showAlert("success", "Token revoked", "API key revoked successfully");
+      await fetchTokens();
+      setTokenToRevoke(null);
+    } catch (_error) {
+      showAlert("error", "Error", "Failed to revoke API key");
+    } finally {
+      setIsLoading(false);
+    }
+  }, [tokenToRevoke, fetchTokens, showAlert]);
 
   const handleCopyToken = useCallback((token: string, tokenId: number) => {
     navigator.clipboard.writeText(token);
@@ -386,9 +413,48 @@ const ApiKeys = () => {
                           {token.getFormattedExpiryDate()}
                         </Typography>
                       </Typography>
+                      <Typography sx={{ fontSize: 12, color: "#999999" }}>•</Typography>
+                      <Typography sx={{ fontSize: 12, color: "#999999" }}>
+                        Last used{" "}
+                        <Typography
+                          component="span"
+                          sx={{
+                            fontSize: 12,
+                            fontWeight: 600,
+                            color: "text.black",
+                          }}
+                        >
+                          {token.getFormattedLastUsed()}
+                        </Typography>
+                      </Typography>
                     </Box>
                   </Box>
                   <Box sx={{ display: "flex", gap: 1 }}>
+                    {!token.isRevoked() && (
+                      <IconButton
+                        onClick={() => {
+                          setTokenToRevoke(token);
+                          setIsRevokeModalOpen(true);
+                        }}
+                        disableRipple
+                        disabled={isDisabled}
+                        title="Revoke key"
+                        aria-label="Revoke key"
+                        sx={{
+                          "color": "#B54708",
+                          "opacity": hoveredTokenId === token.id ? 1 : 0.6,
+                          "transition": "opacity 0.2s ease-in-out",
+                          "&:hover": {
+                            backgroundColor: "#FFFAEB",
+                          },
+                          "&:disabled": {
+                            opacity: 0.3,
+                          },
+                        }}
+                      >
+                        <RevokeIcon size={18} />
+                      </IconButton>
+                    )}
                     <IconButton
                       onClick={() => {
                         setTokenToDelete(token);
@@ -396,6 +462,8 @@ const ApiKeys = () => {
                       }}
                       disableRipple
                       disabled={isDisabled}
+                      title="Delete key"
+                      aria-label="Delete key"
                       sx={{
                         "color": "#DC2626",
                         "opacity": hoveredTokenId === token.id ? 1 : 0.6,
@@ -626,6 +694,30 @@ const ApiKeys = () => {
             setTokenToDelete(null);
           }}
           onProceed={handleDeleteToken}
+          proceedButtonColor="error"
+          proceedButtonVariant="contained"
+          TitleFontSize={0}
+        />
+      )}
+
+      {/* Revoke Token Modal */}
+      {isRevokeModalOpen && tokenToRevoke && (
+        <ConfirmationModal
+          title="Revoke API Key"
+          body={
+            <Typography fontSize={13}>
+              Are you sure you want to revoke the API key "{tokenToRevoke.name}"? It will stop
+              working immediately and any applications using it will lose access. The key stays
+              listed as revoked for your records.
+            </Typography>
+          }
+          cancelText="Cancel"
+          proceedText={isLoading ? "Revoking..." : "Revoke"}
+          onCancel={() => {
+            setIsRevokeModalOpen(false);
+            setTokenToRevoke(null);
+          }}
+          onProceed={handleRevokeToken}
           proceedButtonColor="error"
           proceedButtonVariant="contained"
           TitleFontSize={0}

--- a/Servers/controllers/tokens.ctrl.ts
+++ b/Servers/controllers/tokens.ctrl.ts
@@ -6,7 +6,14 @@ import { logEvent } from "../utils/logger/dbLogger";
 import { STATUS_CODE } from "../utils/statusCode.utils";
 import { generateApiToken } from "../utils/jwt.utils";
 import { getUserByIdQuery } from "../utils/user.utils";
-import { createApiTokenQuery, deleteApiTokenQuery, getApiTokensQuery } from "../utils/tokens.utils";
+import {
+  createApiTokenQuery,
+  deleteApiTokenQuery,
+  getApiTokensQuery,
+  hashApiToken,
+  revokeApiTokenQuery,
+} from "../utils/tokens.utils";
+import { roleMap } from "../middleware/auth.middleware";
 
 import { translateError } from "../utils/i18n.utils";
 export const createApiToken = async (req: Request, res: Response) => {
@@ -35,14 +42,23 @@ export const createApiToken = async (req: Request, res: Response) => {
     );
     logger.debug(`🔍 Fetched user: ${user.id}`);
 
-    // Generate API token with user-defined expiry
+    // The token inherits the creator's actual role (least privilege), not a
+    // hardcoded Admin. The auth middleware re-checks this role against the
+    // user's current role on every request, so the token cannot outlive a
+    // demotion.
+    const roleName = roleMap.get(user.role_id!);
+    if (!roleName) {
+      throw new ValidationException("Unable to resolve the creating user's role.");
+    }
+
+    // Generate API token with user-defined expiry.
     // Note: tenantId is no longer included in the token payload.
     // The auth middleware reconstructs tenantHash from organizationId.
     const apiToken = generateApiToken(
       {
         id: user.id!,
         email: user.email!,
-        roleName: "Admin",
+        roleName,
         organizationId: req.organizationId!,
       },
       expiryDays,
@@ -55,10 +71,12 @@ export const createApiToken = async (req: Request, res: Response) => {
     );
     logger.debug(`🔐 Generated API token for user: ${user.id}`);
 
+    // Only the SHA-256 hash of the token is persisted. The raw token is
+    // returned to the caller once, below, and never stored.
     const tokenResponse = await createApiTokenQuery(
       {
         name: name,
-        token: apiToken,
+        token: hashApiToken(apiToken),
         expires_at: new Date(Date.now() + expiryDays * 24 * 60 * 60 * 1000),
         created_by: req.userId!,
       },
@@ -74,7 +92,8 @@ export const createApiToken = async (req: Request, res: Response) => {
     logger.debug(`✅ Created API token: ${tokenResponse.id} for user: ${user.id}`);
 
     await transaction.commit();
-    return res.status(201).json(STATUS_CODE[201](tokenResponse));
+    // Return the raw token exactly once — it cannot be retrieved again.
+    return res.status(201).json(STATUS_CODE[201]({ ...tokenResponse, token: apiToken }));
   } catch (error) {
     await transaction.rollback();
     if (error instanceof ValidationException) {
@@ -173,6 +192,49 @@ export const deleteApiToken = async (req: Request, res: Response) => {
       req.organizationId!,
     );
     logger.error("❌ Error in deleteApiToken:", error);
+    return res.status(500).json(STATUS_CODE[500](translateError(req, error)));
+  }
+};
+
+export const revokeApiToken = async (req: Request, res: Response) => {
+  const { id } = req.params;
+  logger.debug(`🛠️ Revoking API token: ${id}`);
+  logStructured(
+    "processing",
+    `starting API token revocation for ${id}`,
+    "revokeApiToken",
+    "tokens.ctrl.ts",
+  );
+  try {
+    const success = await revokeApiTokenQuery(
+      parseInt(Array.isArray(id) ? id[0] : id),
+      req.organizationId!,
+    );
+    if (!success) {
+      logStructured(
+        "error",
+        `API token not found or already revoked: ${id}`,
+        "revokeApiToken",
+        "tokens.ctrl.ts",
+      );
+      return res
+        .status(404)
+        .json(STATUS_CODE[404]({ message: req.t!("API token not found or already revoked") }));
+    }
+    logStructured("successful", `revoked API token: ${id}`, "revokeApiToken", "tokens.ctrl.ts");
+    logger.debug(`✅ Revoked API token: ${id}`);
+    return res
+      .status(200)
+      .json(STATUS_CODE[200]({ message: req.t!("API token revoked successfully") }));
+  } catch (error) {
+    logStructured("error", `unexpected error: ${id}`, "revokeApiToken", "tokens.ctrl.ts");
+    await logEvent(
+      "Error",
+      `Unexpected error during API token revocation: ${(error as Error).message}`,
+      req.userId!,
+      req.organizationId!,
+    );
+    logger.error("❌ Error in revokeApiToken:", error);
     return res.status(500).json(STATUS_CODE[500](translateError(req, error)));
   }
 };

--- a/Servers/database/migrations/20260618093804-api-tokens-revocation.js
+++ b/Servers/database/migrations/20260618093804-api-tokens-revocation.js
@@ -21,33 +21,51 @@
  */
 module.exports = {
   async up(queryInterface) {
-    await queryInterface.sequelize.query(`
-      ALTER TABLE verifywise.api_tokens
-        ADD COLUMN IF NOT EXISTS revoked BOOLEAN NOT NULL DEFAULT false,
-        ADD COLUMN IF NOT EXISTS last_used_at TIMESTAMP;
-    `);
+    // Run all three statements in one transaction so a partial failure (e.g. a
+    // lock timeout on CREATE INDEX) rolls back the destructive UPDATE below
+    // rather than leaving a half-migrated table.
+    await queryInterface.sequelize.transaction(async (transaction) => {
+      await queryInterface.sequelize.query(
+        `
+        ALTER TABLE verifywise.api_tokens
+          ADD COLUMN IF NOT EXISTS revoked BOOLEAN NOT NULL DEFAULT false,
+          ADD COLUMN IF NOT EXISTS last_used_at TIMESTAMP;
+      `,
+        { transaction },
+      );
 
-    // Every row that exists before this migration holds a plaintext JWT in the
-    // `token` column, not a hash. Those tokens never authenticated against this
-    // table, so retire them: revoke the row and null out the plaintext secret.
-    await queryInterface.sequelize.query(`
-      UPDATE verifywise.api_tokens SET revoked = true, token = NULL;
-    `);
+      // Every row that exists before this migration holds a plaintext JWT in the
+      // `token` column, not a hash. Those tokens never authenticated against this
+      // table, so retire them: revoke the row and null out the plaintext secret.
+      await queryInterface.sequelize.query(
+        `UPDATE verifywise.api_tokens SET revoked = true, token = NULL;`,
+        { transaction },
+      );
 
-    await queryInterface.sequelize.query(`
-      CREATE INDEX IF NOT EXISTS idx_api_tokens_org_token
-        ON verifywise.api_tokens (organization_id, token);
-    `);
+      await queryInterface.sequelize.query(
+        `
+        CREATE INDEX IF NOT EXISTS idx_api_tokens_org_token
+          ON verifywise.api_tokens (organization_id, token);
+      `,
+        { transaction },
+      );
+    });
   },
 
   async down(queryInterface) {
-    await queryInterface.sequelize.query(`
-      DROP INDEX IF EXISTS verifywise.idx_api_tokens_org_token;
-    `);
-    await queryInterface.sequelize.query(`
-      ALTER TABLE verifywise.api_tokens
-        DROP COLUMN IF EXISTS revoked,
-        DROP COLUMN IF EXISTS last_used_at;
-    `);
+    await queryInterface.sequelize.transaction(async (transaction) => {
+      await queryInterface.sequelize.query(
+        `DROP INDEX IF EXISTS verifywise.idx_api_tokens_org_token;`,
+        { transaction },
+      );
+      await queryInterface.sequelize.query(
+        `
+        ALTER TABLE verifywise.api_tokens
+          DROP COLUMN IF EXISTS revoked,
+          DROP COLUMN IF EXISTS last_used_at;
+      `,
+        { transaction },
+      );
+    });
   },
 };

--- a/Servers/database/migrations/20260618093804-api-tokens-revocation.js
+++ b/Servers/database/migrations/20260618093804-api-tokens-revocation.js
@@ -1,0 +1,53 @@
+"use strict";
+
+/**
+ * Make api_tokens a first-class, revocable credential.
+ *
+ * Before this migration the api_tokens table stored the full signed JWT in
+ * plaintext and was never consulted by the auth middleware, so tokens could
+ * not be revoked and the stored value leaked usable credentials.
+ *
+ * Changes:
+ *   - revoked       BOOLEAN — soft-revoke flag (keeps an audit trail)
+ *   - last_used_at  TIMESTAMP — touched on each authenticated request
+ *   - the `token` column now stores a SHA-256 hash of the JWT, not the JWT
+ *     itself. Any rows created before this migration hold a plaintext JWT and
+ *     can no longer authenticate; that is acceptable because those tokens were
+ *     never validated against this table and therefore never worked as API
+ *     tokens in the first place. They are cleared so stale plaintext secrets
+ *     are not left at rest.
+ *   - index on (organization_id, token) to make hash lookups on the auth hot
+ *     path efficient.
+ */
+module.exports = {
+  async up(queryInterface) {
+    await queryInterface.sequelize.query(`
+      ALTER TABLE verifywise.api_tokens
+        ADD COLUMN IF NOT EXISTS revoked BOOLEAN NOT NULL DEFAULT false,
+        ADD COLUMN IF NOT EXISTS last_used_at TIMESTAMP;
+    `);
+
+    // Every row that exists before this migration holds a plaintext JWT in the
+    // `token` column, not a hash. Those tokens never authenticated against this
+    // table, so retire them: revoke the row and null out the plaintext secret.
+    await queryInterface.sequelize.query(`
+      UPDATE verifywise.api_tokens SET revoked = true, token = NULL;
+    `);
+
+    await queryInterface.sequelize.query(`
+      CREATE INDEX IF NOT EXISTS idx_api_tokens_org_token
+        ON verifywise.api_tokens (organization_id, token);
+    `);
+  },
+
+  async down(queryInterface) {
+    await queryInterface.sequelize.query(`
+      DROP INDEX IF EXISTS verifywise.idx_api_tokens_org_token;
+    `);
+    await queryInterface.sequelize.query(`
+      ALTER TABLE verifywise.api_tokens
+        DROP COLUMN IF EXISTS revoked,
+        DROP COLUMN IF EXISTS last_used_at;
+    `);
+  },
+};

--- a/Servers/database/migrations/20260618120801-api-tokens-timestamptz.js
+++ b/Servers/database/migrations/20260618120801-api-tokens-timestamptz.js
@@ -1,0 +1,48 @@
+"use strict";
+
+/**
+ * Convert `api_tokens.expires_at`, `created_at`, and `last_used_at` from naive
+ * `TIMESTAMP` to `TIMESTAMPTZ`.
+ *
+ * Why: the columns were created as bare `TIMESTAMP` (no time zone). The auth
+ * hot path compares `expires_at > NOW()` in getActiveApiTokenByHashQuery, and
+ * `NOW()` is `timestamptz`. Comparing a naive `TIMESTAMP` against `NOW()`
+ * forces Postgres to reinterpret the stored value in the *session* timezone,
+ * so the effective expiry shifts by the session's UTC offset (and across DST).
+ * A negative-offset session would let an expired token authenticate longer —
+ * a security-relevant drift. Values are written as JS `Date` (UTC instants),
+ * so making the columns timezone-aware is the correct fix.
+ *
+ * This mirrors 20260409010003-advisor-conversations-timestamptz.js, which
+ * fixed the same column-type class on another table.
+ *
+ * Conversion semantics: existing naive values were written as UTC instants, so
+ * the explicit `USING ... AT TIME ZONE 'UTC'` reinterprets them as UTC
+ * deterministically, independent of the migration session's timezone.
+ */
+
+module.exports = {
+  async up(queryInterface) {
+    await queryInterface.sequelize.query(`
+      ALTER TABLE verifywise.api_tokens
+        ALTER COLUMN expires_at TYPE TIMESTAMPTZ
+          USING expires_at AT TIME ZONE 'UTC',
+        ALTER COLUMN created_at TYPE TIMESTAMPTZ
+          USING created_at AT TIME ZONE 'UTC',
+        ALTER COLUMN last_used_at TYPE TIMESTAMPTZ
+          USING last_used_at AT TIME ZONE 'UTC';
+    `);
+  },
+
+  async down(queryInterface) {
+    await queryInterface.sequelize.query(`
+      ALTER TABLE verifywise.api_tokens
+        ALTER COLUMN expires_at TYPE TIMESTAMP
+          USING expires_at AT TIME ZONE 'UTC',
+        ALTER COLUMN created_at TYPE TIMESTAMP
+          USING created_at AT TIME ZONE 'UTC',
+        ALTER COLUMN last_used_at TYPE TIMESTAMP
+          USING last_used_at AT TIME ZONE 'UTC';
+    `);
+  },
+};

--- a/Servers/middleware/__tests__/auth.middleware.test.ts
+++ b/Servers/middleware/__tests__/auth.middleware.test.ts
@@ -15,6 +15,13 @@ jest.mock("../../tools/getTenantHash", () => ({
 jest.mock("../../utils/security.utils", () => ({
   isValidTenantHash: jest.fn(),
 }));
+jest.mock("../../utils/tokens.utils", () => ({
+  // Keep the real, deterministic hash so the middleware computes a genuine
+  // sha256 of the incoming token; only the DB-touching functions are mocked.
+  hashApiToken: jest.requireActual("../../utils/tokens.utils").hashApiToken,
+  getActiveApiTokenByHashQuery: jest.fn(),
+  touchApiTokenLastUsedQuery: jest.fn(),
+}));
 jest.mock("../../utils/context/context", () => ({
   asyncLocalStorage: {
     run: jest.fn((_ctx: any, cb: () => void) => cb()),
@@ -26,6 +33,7 @@ import { getTokenPayload } from "../../utils/jwt.utils";
 import { doesUserBelongsToOrganizationQuery, getUserByIdQuery } from "../../utils/user.utils";
 import { getTenantHash } from "../../tools/getTenantHash";
 import { isValidTenantHash } from "../../utils/security.utils";
+import { getActiveApiTokenByHashQuery, touchApiTokenLastUsedQuery } from "../../utils/tokens.utils";
 
 // Cast mocks for type safety
 const mockGetTokenPayload = getTokenPayload as jest.MockedFunction<typeof getTokenPayload>;
@@ -35,6 +43,12 @@ const mockBelongsToOrg = doesUserBelongsToOrganizationQuery as jest.MockedFuncti
 const mockGetUserById = getUserByIdQuery as jest.MockedFunction<typeof getUserByIdQuery>;
 const mockGetTenantHash = getTenantHash as jest.MockedFunction<typeof getTenantHash>;
 const mockIsValidTenantHash = isValidTenantHash as jest.MockedFunction<typeof isValidTenantHash>;
+const mockGetActiveApiToken = getActiveApiTokenByHashQuery as jest.MockedFunction<
+  typeof getActiveApiTokenByHashQuery
+>;
+const mockTouchApiToken = touchApiTokenLastUsedQuery as jest.MockedFunction<
+  typeof touchApiTokenLastUsedQuery
+>;
 
 function createReq(authHeader?: string): Partial<Request> {
   return {
@@ -232,6 +246,98 @@ describe("authenticateJWT middleware", () => {
       expect(req.tenantId).toBe(10);
       expect(req.organizationId).toBe(10);
       expect(next).toHaveBeenCalled();
+    });
+  });
+
+  describe("API token validation", () => {
+    const apiTokenPayload = {
+      ...validPayload,
+      type: "api_token",
+    };
+
+    it("should NOT perform a DB lookup for normal session JWTs", async () => {
+      setupValidMocks(); // validPayload has no `type` claim
+      const req = createReq("Bearer session-jwt");
+      const res = createRes();
+
+      await authenticateJWT(req as Request, res as Response, next);
+
+      expect(mockGetActiveApiToken).not.toHaveBeenCalled();
+      expect(next).toHaveBeenCalled();
+    });
+
+    it("should authenticate when the api_token hash is found and active", async () => {
+      mockGetTokenPayload.mockReturnValue(apiTokenPayload as any);
+      mockGetUserById.mockResolvedValue({ role_id: 1 } as any);
+      mockBelongsToOrg.mockResolvedValue({ belongs: true } as any);
+      mockGetTenantHash.mockReturnValue("a1b2c3d4e5");
+      // Token row exists, not revoked
+      mockGetActiveApiToken.mockResolvedValue({ id: 7, revoked: false } as any);
+      mockTouchApiToken.mockResolvedValue(undefined as any);
+
+      const req = createReq("Bearer api-token-value") as any;
+      const res = createRes();
+
+      await authenticateJWT(req as Request, res as Response, next);
+
+      expect(mockGetActiveApiToken).toHaveBeenCalledTimes(1);
+      // looked up by org + hash of the raw token, never the raw token itself
+      const [orgArg, hashArg] = mockGetActiveApiToken.mock.calls[0];
+      expect(orgArg).toBe(10);
+      expect(hashArg).not.toBe("api-token-value");
+      expect(typeof hashArg).toBe("string");
+      expect((hashArg as string).length).toBe(64); // sha256 hex
+      expect(next).toHaveBeenCalled();
+    });
+
+    it("should touch last_used_at on a successful api_token request", async () => {
+      mockGetTokenPayload.mockReturnValue(apiTokenPayload as any);
+      mockGetUserById.mockResolvedValue({ role_id: 1 } as any);
+      mockBelongsToOrg.mockResolvedValue({ belongs: true } as any);
+      mockGetTenantHash.mockReturnValue("a1b2c3d4e5");
+      mockGetActiveApiToken.mockResolvedValue({ id: 7, revoked: false } as any);
+      mockTouchApiToken.mockResolvedValue(undefined as any);
+
+      const req = createReq("Bearer api-token-value");
+      const res = createRes();
+
+      await authenticateJWT(req as Request, res as Response, next);
+
+      expect(mockTouchApiToken).toHaveBeenCalledWith(7, 10);
+      expect(next).toHaveBeenCalled();
+    });
+
+    it("should return 401 when the api_token hash is not found (revoked or deleted)", async () => {
+      mockGetTokenPayload.mockReturnValue(apiTokenPayload as any);
+      mockGetUserById.mockResolvedValue({ role_id: 1 } as any);
+      // No active row for this hash
+      mockGetActiveApiToken.mockResolvedValue(null as any);
+
+      const req = createReq("Bearer revoked-token");
+      const res = createRes();
+
+      await authenticateJWT(req as Request, res as Response, next);
+
+      expect(res.status).toHaveBeenCalledWith(401);
+      expect(next).not.toHaveBeenCalled();
+      expect(mockTouchApiToken).not.toHaveBeenCalled();
+    });
+
+    it("should return 401 for an api_token even with a valid signature when the row is gone", async () => {
+      // This is the core regression: a correctly-signed, unexpired JWT must
+      // still be rejected once its api_tokens row no longer exists.
+      mockGetTokenPayload.mockReturnValue(apiTokenPayload as any);
+      mockGetUserById.mockResolvedValue({ role_id: 1 } as any);
+      mockBelongsToOrg.mockResolvedValue({ belongs: true } as any);
+      mockGetActiveApiToken.mockResolvedValue(null as any);
+
+      const req = createReq("Bearer signed-but-revoked") as any;
+      const res = createRes();
+
+      await authenticateJWT(req as Request, res as Response, next);
+
+      expect(res.status).toHaveBeenCalledWith(401);
+      expect(next).not.toHaveBeenCalled();
     });
   });
 

--- a/Servers/middleware/auth.middleware.ts
+++ b/Servers/middleware/auth.middleware.ts
@@ -34,6 +34,11 @@ import { getTokenPayload } from "../utils/jwt.utils";
 import { STATUS_CODE } from "../utils/statusCode.utils";
 import { doesUserBelongsToOrganizationQuery, getUserByIdQuery } from "../utils/user.utils";
 import { asyncLocalStorage } from "../utils/context/context";
+import {
+  getActiveApiTokenByHashQuery,
+  hashApiToken,
+  touchApiTokenLastUsedQuery,
+} from "../utils/tokens.utils";
 
 /**
  * Role ID to role name mapping for validation
@@ -152,6 +157,25 @@ const authenticateJWT = async (
       return res.status(400).json({ message: req.t!("Invalid token") });
     }
 
+    // API tokens carry a `type: "api_token"` claim and must additionally exist
+    // as an active row in the api_tokens table. This is what makes them
+    // revocable: a correctly-signed, unexpired JWT is still rejected once its
+    // row is revoked or deleted. Session JWTs have no `type` claim and skip
+    // this database round-trip entirely.
+    let apiTokenRowId: number | null = null;
+    if (decoded.type === "api_token") {
+      const tokenHash = hashApiToken(token);
+      const tokenRow = await getActiveApiTokenByHashQuery(decoded.organizationId, tokenHash);
+      if (!tokenRow) {
+        return res.status(401).json(
+          STATUS_CODE[401]({
+            message: req.t!("API token is invalid or has been revoked"),
+          }),
+        );
+      }
+      apiTokenRowId = tokenRow.id;
+    }
+
     // Validate role hasn't changed since token was issued
     const user = await getUserByIdQuery(decoded.id);
     if (decoded.roleName !== roleMap.get(user.role_id)) {
@@ -213,6 +237,17 @@ const authenticateJWT = async (
               req.t!("Super-admin has read-only access when viewing an organization"),
             ),
           );
+      }
+    }
+
+    // Record API token usage on the fully-authenticated path. Best-effort:
+    // a failure to update last_used_at must not block an otherwise valid
+    // request.
+    if (apiTokenRowId !== null) {
+      try {
+        await touchApiTokenLastUsedQuery(apiTokenRowId, decoded.organizationId);
+      } catch {
+        // swallow — usage tracking is non-critical
       }
     }
 

--- a/Servers/routes/tokens.route.ts
+++ b/Servers/routes/tokens.route.ts
@@ -3,10 +3,16 @@ const router = express.Router();
 
 import authenticateJWT from "../middleware/auth.middleware";
 import { validateTokenCreation, validateTokenDeletion } from "../middleware/tokens.middleware";
-import { createApiToken, deleteApiToken, getApiTokens } from "../controllers/tokens.ctrl";
+import {
+  createApiToken,
+  deleteApiToken,
+  getApiTokens,
+  revokeApiToken,
+} from "../controllers/tokens.ctrl";
 
 router.get("/", authenticateJWT, getApiTokens);
 router.post("/", authenticateJWT, validateTokenCreation, createApiToken);
+router.post("/:id/revoke", authenticateJWT, validateTokenDeletion, revokeApiToken);
 router.delete("/:id", authenticateJWT, validateTokenDeletion, deleteApiToken);
 
 export default router;

--- a/Servers/utils/__tests__/tokens.utils.test.ts
+++ b/Servers/utils/__tests__/tokens.utils.test.ts
@@ -1,0 +1,154 @@
+/**
+ * Tests for the API-token query layer.
+ *
+ * These exercise the REAL query builders (not mocks of them) against a mocked
+ * `sequelize.query`, asserting that each query carries the predicates the auth
+ * and limit logic depends on. The middleware unit tests mock
+ * getActiveApiTokenByHashQuery wholesale, so without these the actual SQL —
+ * the revocation filter, the expiry filter, the org scoping, the active-only
+ * token count — would be untested and could silently regress.
+ */
+
+import { describe, it, expect, beforeEach, jest } from "@jest/globals";
+
+jest.mock("../../database/db", () => ({
+  __esModule: true,
+  sequelize: {
+    query: jest.fn(),
+  },
+}));
+
+import {
+  hashApiToken,
+  getActiveApiTokenByHashQuery,
+  getNumberOfApiTokensQuery,
+  revokeApiTokenQuery,
+  touchApiTokenLastUsedQuery,
+  getApiTokensQuery,
+} from "../tokens.utils";
+import { sequelize } from "../../database/db";
+
+const mockQuery = sequelize.query as jest.MockedFunction<typeof sequelize.query>;
+
+// Collapse whitespace so assertions are robust to formatting/indentation.
+const normalize = (sql: string) => sql.replace(/\s+/g, " ").trim().toLowerCase();
+
+beforeEach(() => {
+  mockQuery.mockReset();
+});
+
+describe("hashApiToken", () => {
+  it("produces a stable 64-char sha256 hex digest and is not the raw token", () => {
+    const token = "eyJhbGciOi.JIUzI1Ni.signature";
+    const hash = hashApiToken(token);
+    expect(hash).toMatch(/^[0-9a-f]{64}$/);
+    expect(hash).not.toBe(token);
+    // Deterministic: same input → same hash (so write-side and read-side match).
+    expect(hashApiToken(token)).toBe(hash);
+  });
+});
+
+describe("getActiveApiTokenByHashQuery", () => {
+  it("filters by org, hash, NOT revoked, and unexpired", async () => {
+    mockQuery.mockResolvedValueOnce([[{ id: 7, revoked: false }], 1] as any);
+
+    await getActiveApiTokenByHashQuery(42, "deadbeef");
+
+    const [sql, opts] = mockQuery.mock.calls[0];
+    const normalized = normalize(sql as string);
+    // The four predicates that make a token valid. If any is dropped, a revoked
+    // or expired token could authenticate.
+    expect(normalized).toContain("organization_id = :organizationid");
+    expect(normalized).toContain("token = :tokenhash");
+    expect(normalized).toContain("revoked = false");
+    expect(normalized).toContain("expires_at > now()");
+    expect((opts as any).replacements).toEqual({
+      organizationId: 42,
+      tokenHash: "deadbeef",
+    });
+  });
+
+  it("returns null when no active row matches (revoked/expired/deleted)", async () => {
+    mockQuery.mockResolvedValueOnce([[], 0] as any);
+    const result = await getActiveApiTokenByHashQuery(42, "deadbeef");
+    expect(result).toBeNull();
+  });
+
+  it("returns the row when an active token matches", async () => {
+    mockQuery.mockResolvedValueOnce([[{ id: 9, revoked: false }], 1] as any);
+    const result = await getActiveApiTokenByHashQuery(1, "abc");
+    expect(result).toEqual({ id: 9, revoked: false });
+  });
+});
+
+describe("getNumberOfApiTokensQuery", () => {
+  it("counts only non-revoked tokens so revoked rows do not consume the limit", async () => {
+    mockQuery.mockResolvedValueOnce([[{ count: "3" }], 1] as any);
+
+    const count = await getNumberOfApiTokensQuery(42);
+
+    const [sql, opts] = mockQuery.mock.calls[0];
+    const normalized = normalize(sql as string);
+    expect(normalized).toContain("count(*)");
+    expect(normalized).toContain("organization_id = :organizationid");
+    // The critical filter: without this, revoking a token (or the migration
+    // retiring all legacy rows) would permanently consume slots toward the cap.
+    expect(normalized).toContain("revoked = false");
+    expect((opts as any).replacements).toEqual({ organizationId: 42 });
+    expect(count).toBe(3);
+  });
+});
+
+describe("revokeApiTokenQuery", () => {
+  it("soft-revokes a still-active row scoped to the org and reports success", async () => {
+    mockQuery.mockResolvedValueOnce([[{ id: 5 }], 1] as any);
+
+    const ok = await revokeApiTokenQuery(5, 42);
+
+    const [sql, opts] = mockQuery.mock.calls[0];
+    const normalized = normalize(sql as string);
+    expect(normalized).toContain("set revoked = true");
+    expect(normalized).toContain("organization_id = :organizationid");
+    // Idempotency guard: only an already-active row can be revoked.
+    expect(normalized).toContain("revoked = false");
+    expect((opts as any).replacements).toEqual({ id: 5, organizationId: 42 });
+    expect(ok).toBe(true);
+  });
+
+  it("reports failure when no active row matches (already revoked or absent)", async () => {
+    mockQuery.mockResolvedValueOnce([[], 0] as any);
+    const ok = await revokeApiTokenQuery(5, 42);
+    expect(ok).toBe(false);
+  });
+});
+
+describe("touchApiTokenLastUsedQuery", () => {
+  it("updates last_used_at scoped by id and org", async () => {
+    mockQuery.mockResolvedValueOnce([[], 0] as any);
+
+    await touchApiTokenLastUsedQuery(7, 42);
+
+    const [sql, opts] = mockQuery.mock.calls[0];
+    const normalized = normalize(sql as string);
+    expect(normalized).toContain("set last_used_at = now()");
+    expect(normalized).toContain("id = :id");
+    expect(normalized).toContain("organization_id = :organizationid");
+    expect((opts as any).replacements).toEqual({ id: 7, organizationId: 42 });
+  });
+});
+
+describe("getApiTokensQuery", () => {
+  it("never selects the token (hash) column, so no secret leaves the database", async () => {
+    mockQuery.mockResolvedValueOnce([[], 0] as any);
+
+    await getApiTokensQuery(42);
+
+    const [sql] = mockQuery.mock.calls[0];
+    const normalized = normalize(sql as string);
+    // Status fields are exposed to the UI...
+    expect(normalized).toContain("revoked");
+    expect(normalized).toContain("last_used_at");
+    // ...but the stored hash must never be selected back to the client.
+    expect(normalized).not.toMatch(/select[^;]*\btoken\b/);
+  });
+});

--- a/Servers/utils/jwt.utils.ts
+++ b/Servers/utils/jwt.utils.ts
@@ -144,13 +144,23 @@ const generateRefreshToken = (payload: Object) => {
 
 /**
  * Generates a JWT API token with configurable expiration
- * For programmatic API access by integrations and scripts
- * @param payload - Token payload (user info, tenant, etc.)
+ * For programmatic API access by integrations and scripts.
+ *
+ * The token carries a `type: "api_token"` claim. The auth middleware uses this
+ * claim to branch into a database-backed check against the api_tokens table, so
+ * that API tokens can be revoked independently of their JWT expiry. Session
+ * tokens have no `type` claim and skip that lookup.
+ *
+ * @param payload - Token payload (user info, organization, role, etc.)
  * @param expiresInDays - Optional expiration in days (default: 30 days)
  */
 const generateApiToken = (payload: Object, expiresInDays?: number) => {
   const expiresInMs = expiresInDays ? expiresInDays * 24 * 60 * 60 * 1000 : THIRTY_DAYS_MS;
-  return signToken(payload, expiresInMs, process.env.JWT_SECRET as string);
+  return signToken(
+    { ...payload, type: "api_token" },
+    expiresInMs,
+    process.env.JWT_SECRET as string,
+  );
 };
 
 export {

--- a/Servers/utils/tokens.utils.ts
+++ b/Servers/utils/tokens.utils.ts
@@ -1,8 +1,17 @@
 import { QueryTypes, Transaction } from "sequelize";
+import crypto from "crypto";
 import { sequelize } from "../database/db";
 import { IToken } from "../domain.layer/interfaces/i.tokens";
 import { TokenModel } from "../domain.layer/models/tokens/tokens.model";
 import { ValidationException } from "../domain.layer/exceptions/custom.exception";
+
+/**
+ * Hash an API token (the signed JWT string) for storage and lookup.
+ * Only the SHA-256 hash is persisted; the raw token is shown to the creator
+ * once and never stored. Mirrors the Shadow AI API key pattern.
+ */
+export const hashApiToken = (token: string): string =>
+  crypto.createHash("sha256").update(token).digest("hex");
 
 export const getNumberOfApiTokensQuery = async (organizationId: number) => {
   const numberOfTokens = (await sequelize.query(
@@ -17,9 +26,11 @@ export const createApiTokenQuery = async (
   organizationId: number,
   transaction: Transaction,
 ) => {
-  // Check if a token with this name already exists
+  // Check if an active (non-revoked) token with this name already exists.
+  // A revoked token frees up its name for reuse.
   const existingToken = (await sequelize.query(
-    `SELECT id FROM api_tokens WHERE organization_id = :organizationId AND name = :name;`,
+    `SELECT id FROM api_tokens
+       WHERE organization_id = :organizationId AND name = :name AND revoked = false;`,
     {
       replacements: { organizationId, name: tokenPayload.name },
       transaction,
@@ -32,12 +43,16 @@ export const createApiTokenQuery = async (
     );
   }
 
+  // `tokenPayload.token` is the SHA-256 hash of the JWT, not the JWT itself.
+  // The raw token is returned to the caller by the controller and never stored.
+  // The hash column is intentionally excluded from RETURNING so it never leaves
+  // the database.
   const result = (await sequelize.query(
     `INSERT INTO api_tokens (
       organization_id, token, name, expires_at, created_by
     ) VALUES (
       :organizationId, :token, :name, :expires_at, :created_by
-    ) RETURNING *;`,
+    ) RETURNING id, organization_id, name, expires_at, created_by, created_at, revoked;`,
     {
       replacements: {
         organizationId,
@@ -52,9 +67,64 @@ export const createApiTokenQuery = async (
   return result[0][0];
 };
 
+/**
+ * Look up an active API token by the hash of its raw value.
+ *
+ * Returns the row only when it exists, is not revoked, and has not expired.
+ * This is the database-backed check that makes API tokens revocable: the auth
+ * middleware calls it for every request that carries a `type: "api_token"` JWT.
+ * Scoped by organization to keep the lookup tenant-isolated.
+ */
+export const getActiveApiTokenByHashQuery = async (
+  organizationId: number,
+  tokenHash: string,
+): Promise<{ id: number; revoked: boolean; expires_at: Date } | null> => {
+  const result = (await sequelize.query(
+    `SELECT id, revoked, expires_at FROM api_tokens
+       WHERE organization_id = :organizationId
+         AND token = :tokenHash
+         AND revoked = false
+         AND expires_at > NOW()
+       LIMIT 1;`,
+    { replacements: { organizationId, tokenHash } },
+  )) as [{ id: number; revoked: boolean; expires_at: Date }[], number];
+  return result[0][0] ?? null;
+};
+
+/**
+ * Record the moment an API token was last used to authenticate.
+ * Best-effort: a failure here must not block the request.
+ */
+export const touchApiTokenLastUsedQuery = async (
+  id: number,
+  organizationId: number,
+): Promise<void> => {
+  await sequelize.query(
+    `UPDATE api_tokens SET last_used_at = NOW()
+       WHERE id = :id AND organization_id = :organizationId;`,
+    { replacements: { id, organizationId } },
+  );
+};
+
+/**
+ * Soft-revoke an API token. The row is kept (so it stays visible as revoked in
+ * the UI and audit trail) but can no longer authenticate. Returns false when no
+ * matching active token exists.
+ */
+export const revokeApiTokenQuery = async (id: number, organizationId: number): Promise<boolean> => {
+  const result = (await sequelize.query(
+    `UPDATE api_tokens SET revoked = true
+       WHERE id = :id AND organization_id = :organizationId AND revoked = false
+       RETURNING id;`,
+    { replacements: { id, organizationId } },
+  )) as [{ id: number }[], number];
+  return result[0].length > 0;
+};
+
 export const getApiTokensQuery = async (organizationId: number) => {
   const result = (await sequelize.query(
-    `SELECT id, name, expires_at, created_by, created_at FROM api_tokens WHERE organization_id = :organizationId ORDER BY created_at DESC;`,
+    `SELECT id, name, expires_at, created_by, created_at, revoked, last_used_at
+       FROM api_tokens WHERE organization_id = :organizationId ORDER BY created_at DESC;`,
     { replacements: { organizationId } },
   )) as [TokenModel[], number];
   return result[0];

--- a/Servers/utils/tokens.utils.ts
+++ b/Servers/utils/tokens.utils.ts
@@ -14,8 +14,11 @@ export const hashApiToken = (token: string): string =>
   crypto.createHash("sha256").update(token).digest("hex");
 
 export const getNumberOfApiTokensQuery = async (organizationId: number) => {
+  // Only active (non-revoked) tokens count toward the per-organization limit.
+  // Revoked rows are retained for audit but must not consume a slot, otherwise
+  // revoking a token would permanently reduce the org's creation capacity.
   const numberOfTokens = (await sequelize.query(
-    `SELECT COUNT(*) FROM api_tokens WHERE organization_id = :organizationId;`,
+    `SELECT COUNT(*) FROM api_tokens WHERE organization_id = :organizationId AND revoked = false;`,
     { replacements: { organizationId } },
   )) as [{ count: string }[], number];
   return parseInt(numberOfTokens[0][0].count, 10);


### PR DESCRIPTION
## Summary

Personal API tokens (created via Settings → API keys) were stored but never validated against the `api_tokens` table. The auth middleware only ran `jwt.verify()`, so a token authenticated purely because it was a self-signed JWT. As a result, deleting or revoking a token did nothing — it kept working until its JWT expiry — and the full signed JWT was stored in plaintext.

## Changes

- API tokens now carry a `type: "api_token"` claim. When present, the auth middleware hashes the incoming token and looks it up in `api_tokens`, rejecting any token whose row is revoked, deleted, or expired. Session tokens have no claim and skip the lookup, so the existing sign-in path is unchanged.
- Only a SHA-256 hash of the token is stored, not the JWT. The raw token is returned once on creation and never persisted (mirrors the Shadow AI key pattern).
- Tokens inherit the creator's actual role instead of a hardcoded `Admin`.
- Added soft-revoke: `POST /api/tokens/:id/revoke` marks the row revoked while keeping it visible for audit. `last_used_at` is recorded on each authenticated request.
- Migration adds `revoked` and `last_used_at` columns plus an index on `(organization_id, token)`; pre-existing plaintext rows are retired.
- Settings UI: shows token status (Active / Expired / Revoked) and last-used date, and adds a Revoke action with a confirmation modal. Added de/fr/es translations for the new modal title.

## Benefits

- Revocation works: a revoked or deleted token is rejected immediately.
- Stored secrets are hashed, so a database leak no longer exposes usable tokens.
- Tokens follow least privilege by carrying the creator's real role.
- Token usage is auditable via `last_used_at` and the retained revoked rows.

Closes the API-token validation gap.