### PR TITLE
docs(developers): add Platform REST API article and refresh API keys guide

### DIFF
--- a/shared/user-guide-content/content/developers/overview.ts
+++ b/shared/user-guide-content/content/developers/overview.ts
@@ -10,13 +10,13 @@ export const developersOverviewContent: ArticleContent = {
     { type: 'heading', id: 'whats-here', level: 2, text: "What's covered today" },
     {
       type: 'paragraph',
-      text: 'Right now the guide covers Agent Control: how to connect any terminal agent so its tool calls are checked before they run. Claude Code and Cursor have ready-made wiring, and any other agent can use the generic contract.',
+      text: 'The guide covers two areas. Agent Control is how you connect a terminal agent so its tool calls are checked before they run. Claude Code and Cursor have ready-made wiring, and any other agent can use the generic contract. The platform REST API is how you read and write your governance data programmatically with a bearer token.',
     },
     {
       type: 'callout',
       variant: 'info',
       title: 'More guides are coming',
-      text: 'This section will grow to cover other developer topics, such as routing model calls through the LLM proxy and the public API. For now, start with Agent Control below.',
+      text: 'This section will grow to cover other developer topics, such as routing model calls through the LLM proxy. For now, start with Agent Control or the platform REST API below.',
     },
     { type: 'heading', id: 'agent-control', level: 2, text: 'Agent Control' },
     {
@@ -31,6 +31,17 @@ export const developersOverviewContent: ArticleContent = {
         { bold: 'Connect any agent', text: 'The generic contract and the MCP proxy path for any other terminal agent.' },
         { bold: 'Governing tool calls', text: 'The four decisions, approval polling, run correlation and fail-modes.' },
         { bold: 'API reference', text: 'Endpoints, headers, auth and error codes for the tool-call hook.' },
+      ],
+    },
+    { type: 'heading', id: 'platform-api', level: 2, text: 'Platform REST API' },
+    {
+      type: 'paragraph',
+      text: 'Read and write your governance data (projects, risks, vendors, models and more) over REST. Authenticate with a token you create in the app, then call the endpoints listed in the interactive API reference.',
+    },
+    {
+      type: 'bullet-list',
+      items: [
+        { bold: 'Platform REST API', text: 'The base URL, authentication, response shape, status codes and the current limits that apply to every endpoint.' },
       ],
     },
     {
@@ -48,6 +59,12 @@ export const developersOverviewContent: ArticleContent = {
           articleId: 'connect-your-agent',
           title: 'Connect your agent',
           description: 'The 5-minute quickstart.',
+        },
+        {
+          collectionId: 'developers',
+          articleId: 'platform-rest-api',
+          title: 'Platform REST API',
+          description: 'Authenticate and call the platform endpoints.',
         },
       ],
     },

--- a/shared/user-guide-content/content/developers/platform-rest-api.ts
+++ b/shared/user-guide-content/content/developers/platform-rest-api.ts
@@ -1,0 +1,76 @@
+import type { ArticleContent } from '../../contentTypes';
+
+export const platformRestApiContent: ArticleContent = {
+  blocks: [
+    { type: 'heading', id: 'overview', level: 2, text: 'Platform REST API' },
+    { type: 'paragraph', text: 'The VerifyWise platform exposes a REST API for reading and writing your governance data: projects, risks, vendors, models, tasks, evidence, policies and more. Every endpoint lives under /api and authenticates with a bearer token you create in the app.' },
+    { type: 'paragraph', text: 'This article covers the basics that apply to every endpoint: the base URL, how to authenticate, the response shape and the current limits. For the full endpoint catalog, use the interactive API reference described below.' },
+    { type: 'callout', variant: 'info', title: 'Agent Control has its own API', text: 'If you are governing an AI agent’s tool calls, you want the Agent Control hook API instead, not these endpoints. See the API reference in this guide.' },
+
+    { type: 'heading', id: 'base-url', level: 2, text: 'Base URL' },
+    { type: 'paragraph', text: 'All endpoints are mounted under the /api prefix. The host depends on where VerifyWise runs. For a local install the default is:' },
+    { type: 'code', language: 'bash', code: 'http://localhost:3000/api' },
+    { type: 'paragraph', text: 'On a hosted deployment, replace the host with your own domain. Endpoint paths keep their casing exactly as defined. For example, project risks are served at /api/projectRisks, not /api/project-risks.' },
+
+    { type: 'heading', id: 'reference', level: 2, text: 'Interactive API reference' },
+    { type: 'paragraph', text: 'VerifyWise serves a live OpenAPI (Swagger) reference that lists every endpoint, its parameters and its response schema. Open it in a browser at:' },
+    { type: 'code', language: 'bash', code: 'http://localhost:3000/api/docs' },
+    { type: 'paragraph', text: 'The spec is OpenAPI 3.0. Use it as the source of truth for the full endpoint list; this article only covers the cross-cutting rules.' },
+
+    { type: 'heading', id: 'auth', level: 2, text: 'Authentication' },
+    { type: 'paragraph', text: 'Every request must carry a bearer token in the Authorization header.' },
+    { type: 'code', language: 'bash', code: 'Authorization: Bearer <your-token>' },
+    { type: 'paragraph', text: 'You create tokens in the app under Settings → API keys. Only Admin users can create them, and an organization may hold up to 10 active tokens at a time. A token carries the role of the user who created it.' },
+
+    { type: 'heading', id: 'create-token', level: 3, text: 'Create a token' },
+    { type: 'paragraph', text: 'Tokens can also be created through the API itself (Admin only). Send a name and an expiry in days:' },
+    { type: 'code', language: 'bash', code: 'curl -X POST "http://localhost:3000/api/tokens" \\\n  -H "Authorization: Bearer <admin-token>" \\\n  -H "Content-Type: application/json" \\\n  -d \'{"name":"ci-pipeline","expires_in_days":90}\'' },
+    { type: 'callout', variant: 'warning', title: 'The raw token is shown once', text: 'The full token is returned only in the create response, in the data.token field. It is stored as a hash and can never be retrieved again. Copy it immediately; if you lose it, create a new one.' },
+
+    { type: 'heading', id: 'manage-tokens', level: 3, text: 'List, revoke and delete tokens' },
+    { type: 'table', columns: [
+      { key: 'method', label: 'Method & path', width: '45%' },
+      { key: 'desc', label: 'Description', width: '55%' },
+    ], rows: [
+      { method: 'GET /api/tokens', desc: 'List the organization’s tokens with status and last-used time. The token value itself is never returned.' },
+      { method: 'POST /api/tokens', desc: 'Create a token (Admin only). Returns the raw token once.' },
+      { method: 'POST /api/tokens/:id/revoke', desc: 'Revoke a token. It stops working immediately and is kept, marked revoked, for your records.' },
+      { method: 'DELETE /api/tokens/:id', desc: 'Permanently delete a token row.' },
+    ]},
+    { type: 'callout', variant: 'tip', title: 'Revoking takes effect immediately', text: 'A revoked token is rejected on its next request, before its expiry date. Revoke a token the moment it may be compromised rather than waiting for it to expire.' },
+
+    { type: 'heading', id: 'response-shape', level: 2, text: 'Response shape' },
+    { type: 'paragraph', text: 'Responses use a consistent envelope: a short message and a data field that holds the payload.' },
+    { type: 'code', language: 'json', code: '{\n  "message": "OK",\n  "data": {\n    "id": 1,\n    "name": "ci-pipeline",\n    "expires_at": "2027-06-18T00:00:00.000Z"\n  }\n}' },
+    { type: 'paragraph', text: 'Client errors (4xx) use the same envelope, with data carrying the detail:' },
+    { type: 'code', language: 'json', code: '{\n  "message": "Bad Request",\n  "data": "expires_in_days is required"\n}' },
+    { type: 'paragraph', text: 'Server errors (5xx) use an error field instead of data:' },
+    { type: 'code', language: 'json', code: '{\n  "message": "Internal Server Error",\n  "error": "..."\n}' },
+
+    { type: 'heading', id: 'status-codes', level: 2, text: 'Status codes' },
+    { type: 'table', columns: [
+      { key: 'code', label: 'Code', width: '20%' },
+      { key: 'meaning', label: 'Meaning', width: '80%' },
+    ], rows: [
+      { code: '200 / 201', meaning: 'Success. 201 is returned when a resource is created.' },
+      { code: '400', meaning: 'Bad request: missing or invalid input.' },
+      { code: '401', meaning: 'Missing, invalid, expired or revoked token.' },
+      { code: '403', meaning: 'Authenticated, but the token’s role is not allowed to perform this action.' },
+      { code: '404', meaning: 'Resource not found.' },
+      { code: '500', meaning: 'Server error.' },
+    ]},
+
+    { type: 'heading', id: 'limits', level: 2, text: 'Limits to know about' },
+    { type: 'paragraph', text: 'Two things work differently from what you might expect. Both are easy to design around once you know about them.' },
+    { type: 'callout', variant: 'warning', title: 'List endpoints are not paginated', text: 'List endpoints (for example GET /api/projectRisks, GET /api/vendors) return every matching row for your organization. There are no limit, offset or page parameters. Some lists accept a filter parameter (for example active, deleted or all on risks), but expect to receive the full set and handle large responses on your side.' },
+    { type: 'callout', variant: 'warning', title: 'Most CRUD routes are not rate limited', text: 'Rate limiting is applied to some route groups, such as authentication, file, intake-form and detection-scan routes, but not to the main resource (CRUD) routes. Do not treat the absence of a limit as a licence to hammer the API; keep request volumes reasonable, as limits may be added later.' },
+
+    { type: 'heading', id: 'tenancy', level: 2, text: 'Multi-tenancy' },
+    { type: 'paragraph', text: 'Every request is scoped to the organization of the token that made it. You only ever see and modify your own organization’s data; there is no cross-organization access through these endpoints.' },
+
+    { type: 'article-links', title: 'Related articles', items: [
+      { collectionId: 'developers', articleId: 'overview', title: 'Developer guide', description: 'What the developer guide covers today.' },
+      { collectionId: 'developers', articleId: 'agent-control-api', title: 'API reference', description: 'The separate hook API for governing an agent’s tool calls.' },
+    ]},
+  ],
+};

--- a/shared/user-guide-content/content/index.ts
+++ b/shared/user-guide-content/content/index.ts
@@ -99,6 +99,7 @@ import { connectYourAgentContent } from './developers/connect-your-agent';
 import { connectAnyAgentContent } from './developers/connect-any-agent';
 import { governingToolCallsContent } from './developers/governing-tool-calls';
 import { agentControlApiContent } from './developers/agent-control-api';
+import { platformRestApiContent } from './developers/platform-rest-api';
 
 // Map of article IDs to their content
 // Format: 'collectionId/articleId': ArticleContent
@@ -218,6 +219,7 @@ export const articleContentMap: Record<string, ArticleContent> = {
   'developers/connect-any-agent': connectAnyAgentContent,
   'developers/governing-tool-calls': governingToolCallsContent,
   'developers/agent-control-api': agentControlApiContent,
+  'developers/platform-rest-api': platformRestApiContent,
 };
 
 // Helper to get article content

--- a/shared/user-guide-content/content/integrations/api-access.ts
+++ b/shared/user-guide-content/content/integrations/api-access.ts
@@ -107,9 +107,10 @@ export const apiAccessContent: ArticleContent = {
       type: 'bullet-list',
       items: [
         { bold: 'Name', text: 'The descriptive name you gave the key' },
-        { bold: 'Status', text: 'Whether the key is Active or Expired' },
+        { bold: 'Status', text: 'Whether the key is Active, Expired or Revoked' },
         { bold: 'Created', text: 'When the key was created' },
         { bold: 'Expires', text: 'When the key will expire' },
+        { bold: 'Last used', text: 'When the key last authenticated a request, or Never if it has not been used yet' },
       ],
     },
     {
@@ -120,7 +121,30 @@ export const apiAccessContent: ArticleContent = {
     },
     {
       type: 'paragraph',
-      text: 'Active keys have a green status badge. Expired keys show a warning indicator and can no longer be used.',
+      text: 'Active keys have a green badge. Expired keys can no longer be used. Revoked keys were turned off manually and are kept in the list for your records.',
+    },
+    {
+      type: 'heading',
+      id: 'revoking-keys',
+      level: 2,
+      text: 'Revoking API keys',
+    },
+    {
+      type: 'paragraph',
+      text: 'Revoking a key turns it off straight away while keeping it in the list, marked as revoked, for your records. This is the best way to retire a key you no longer trust.',
+    },
+    {
+      type: 'ordered-list',
+      items: [
+        { text: 'Find the key in the API keys list' },
+        { text: 'Click the revoke icon for that key' },
+        { text: 'Confirm when prompted' },
+      ],
+    },
+    {
+      type: 'callout',
+      variant: 'tip',
+      text: 'A revoked key is rejected on its very next request, before its expiry date. If a key might be compromised, revoke it rather than waiting for it to expire.',
     },
     {
       type: 'heading',
@@ -130,7 +154,7 @@ export const apiAccessContent: ArticleContent = {
     },
     {
       type: 'paragraph',
-      text: 'To delete an API key:',
+      text: 'Deleting removes a key from the list entirely. If you want to keep a record that the key existed, revoke it instead. To delete a key:',
     },
     {
       type: 'ordered-list',
@@ -163,6 +187,10 @@ export const apiAccessContent: ArticleContent = {
       ],
     },
     {
+      type: 'paragraph',
+      text: 'For the base URL, the response shape, the full list of endpoints and the current limits, see the Platform REST API article in the developer guide. You can also browse the live endpoint reference in your browser at /api/docs.',
+    },
+    {
       type: 'heading',
       id: 'security-best-practices',
       level: 2,
@@ -173,9 +201,9 @@ export const apiAccessContent: ArticleContent = {
       items: [
         { bold: 'Never share keys', text: 'Keep API keys confidential. Don\'t share them in emails, chat or version control.' },
         { bold: 'Use environment variables', text: 'Store keys in environment variables rather than hard-coding them.' },
-        { bold: 'Rotate regularly', text: 'Create new keys periodically and delete old ones to limit exposure.' },
+        { bold: 'Rotate regularly', text: 'Create new keys periodically and revoke old ones to limit exposure.' },
         { bold: 'Use separate keys', text: 'Create different keys for different environments and purposes.' },
-        { bold: 'Act on compromises', text: 'If you suspect a key has been compromised, delete it right away and create a new one.' },
+        { bold: 'Act on compromises', text: 'If you suspect a key has been compromised, revoke it right away and create a new one.' },
         { bold: 'Limit access', text: 'Only admins should manage API keys.' },
       ],
     },
@@ -219,7 +247,7 @@ export const apiAccessContent: ArticleContent = {
         { text: 'Check that the API key is correct and complete' },
         { text: 'Verify the key hasn\'t expired' },
         { text: 'Make sure the Authorization header is formatted properly' },
-        { text: 'Confirm the key hasn\'t been deleted' },
+        { text: 'Confirm the key hasn\'t been revoked or deleted' },
       ],
     },
     {
@@ -266,7 +294,7 @@ export const apiAccessContent: ArticleContent = {
     },
     {
       type: 'paragraph',
-      text: 'API keys give access to VerifyWise API endpoints based on your organization\'s permissions. The specific endpoints and operations available are documented in the API reference.',
+      text: 'A key carries the role of the Admin who created it and is scoped to your organization, so it can only read and write your own organization\'s data. The endpoints and operations available are listed in the Platform REST API article and the live reference at /api/docs.',
     },
     {
       type: 'heading',
@@ -276,12 +304,18 @@ export const apiAccessContent: ArticleContent = {
     },
     {
       type: 'paragraph',
-      text: 'API requests may be rate-limited to keep the platform stable. If you run into rate limit errors, reduce request frequency or contact support.',
+      text: 'Some route groups, such as login and file uploads, are rate-limited, but the main data (CRUD) endpoints currently are not. Keep your request volume reasonable anyway, since limits may be added later. The Platform REST API article covers this in more detail.',
     },
     {
       type: 'article-links',
       title: 'Related articles',
       items: [
+        {
+          collectionId: 'developers',
+          articleId: 'platform-rest-api',
+          title: 'Platform REST API',
+          description: 'Base URL, authentication, response shape and limits for the API',
+        },
         {
           collectionId: 'integrations',
           articleId: 'integration-overview',

--- a/shared/user-guide-content/userGuideConfig.ts
+++ b/shared/user-guide-content/userGuideConfig.ts
@@ -723,9 +723,9 @@ export const collections: Collection[] = [
   {
     id: 'developers',
     title: 'Developer guide',
-    description: 'Build on VerifyWise. Today the guide covers Agent Control: connect any terminal agent, see how decisions work and use the API reference. More developer topics are coming.',
+    description: 'Build on VerifyWise. The guide covers Agent Control — connect any terminal agent, see how decisions work and use the hook API reference — and the platform REST API for reading and writing your governance data. More developer topics are coming.',
     icon: 'Plug',
-    articleCount: 6,
+    articleCount: 7,
     articles: [
       {
         id: 'overview',
@@ -762,6 +762,12 @@ export const collections: Collection[] = [
         title: 'API reference',
         description: 'Endpoints, headers, auth and error codes for the tool-call hook.',
         keywords: ['developer', 'api', 'reference', 'endpoint', 'hook', 'curl', 'json-rpc', 'authentication', 'agent key'],
+      },
+      {
+        id: 'platform-rest-api',
+        title: 'Platform REST API',
+        description: 'Authenticate with a token and read or write your governance data over REST.',
+        keywords: ['developer', 'api', 'rest', 'platform', 'token', 'bearer', 'authentication', 'endpoint', 'swagger', 'openapi', 'pagination', 'integration', 'curl'],
       },
     ],
   },


### PR DESCRIPTION
## Summary

Adds a developer-guide article for the platform REST API and brings the integrations API keys guide in line with how token authentication now works (per the changes merged in #4122).

## Changes

- New article: Platform REST API (developers collection). Covers the base URL, the live OpenAPI reference at /api/docs, bearer-token authentication, the create/list/revoke/delete token endpoints, the response envelope, status codes and the current limits (no pagination on list endpoints; most CRUD routes are not rate limited). Registered in the content map and the developers collection (articleCount 6 to 7).
- Developer guide overview: now introduces both Agent Control and the platform REST API, with the REST API listed under "Start here".
- API keys guide (integrations): documents the Revoking action, adds Revoked status and Last used to the key list, corrects the rate-limit and permissions answers to match reality, updates the 401 troubleshooting and security tips to mention revoke, and links the new Platform REST API article and /api/docs.

Every API claim was verified against the backend (routes, middleware, status-code helper, rate-limit middleware) so the docs match the running code. Typecheck and the strict i18n audit both pass.