### PR TITLE
docs(developers): add resource, integration and reporting guides; expand super admin

### DIFF
--- a/shared/user-guide-content/content/developers/automations-api.ts
+++ b/shared/user-guide-content/content/developers/automations-api.ts
@@ -1,0 +1,57 @@
+import type { ArticleContent } from '../../contentTypes';
+
+export const automationsApiContent: ArticleContent = {
+  blocks: [
+    { type: 'heading', id: 'overview', level: 2, text: 'Automations API' },
+    { type: 'paragraph', text: 'An automation runs an action when something happens in VerifyWise: a vendor is added, a risk is updated, a policy is deleted and so on. You can create and manage automations through the REST API as well as in the app, which is useful for provisioning the same rules across environments from a script.' },
+    { type: 'callout', variant: 'info', title: 'What automations can do today', text: 'Triggers cover the create, update and delete events for the main resource types, plus scheduled reports. The only action available right now is sending an email. There is no action that calls an external URL, so automations notify people; they do not push events to other systems.' },
+
+    { type: 'heading', id: 'shape', level: 2, text: 'How a rule is shaped' },
+    { type: 'paragraph', text: 'An automation links one trigger to one or more actions. Each piece is identified by an id you look up from the discovery endpoints below.' },
+    { type: 'bullet-list', items: [
+      { bold: 'Trigger', text: 'The event that starts the automation, identified by a triggerId.' },
+      { bold: 'Actions', text: 'What to do when the trigger fires. Each action has an action_type_id and a params object holding its configuration, such as the email recipients and body.' },
+    ]},
+
+    { type: 'heading', id: 'discover', level: 2, text: 'Discover triggers and actions' },
+    { type: 'paragraph', text: 'Before creating a rule, fetch the available triggers and the actions each trigger supports. Both return the standard envelope with the list in data.' },
+    { type: 'table', columns: [
+      { key: 'method', label: 'Method & path', width: '50%' },
+      { key: 'desc', label: 'Returns', width: '50%' },
+    ], rows: [
+      { method: 'GET /api/automations/triggers', desc: 'The trigger types you can use, each with its id, key and label.' },
+      { method: 'GET /api/automations/actions/by-triggerId/:triggerId', desc: 'The actions available for a given trigger.' },
+    ]},
+    { type: 'code', language: 'bash', code: 'curl "http://localhost:3000/api/automations/triggers" \\\n  -H "Authorization: Bearer <your-token>"' },
+
+    { type: 'heading', id: 'manage', level: 2, text: 'Create, update and delete' },
+    { type: 'table', columns: [
+      { key: 'method', label: 'Method & path', width: '45%' },
+      { key: 'desc', label: 'Description', width: '55%' },
+    ], rows: [
+      { method: 'GET /api/automations', desc: 'List the automations in your organization.' },
+      { method: 'GET /api/automations/:id', desc: 'Fetch one automation.' },
+      { method: 'POST /api/automations', desc: 'Create an automation.' },
+      { method: 'PUT /api/automations/:id', desc: 'Update an automation (trigger, name, actions, active state).' },
+      { method: 'DELETE /api/automations/:id', desc: 'Delete an automation.' },
+      { method: 'GET /api/automations/:id/history', desc: 'The execution history for an automation.' },
+      { method: 'GET /api/automations/:id/stats', desc: 'Execution stats for an automation.' },
+    ]},
+
+    { type: 'heading', id: 'create', level: 3, text: 'Creating an automation' },
+    { type: 'paragraph', text: 'Send the triggerId, a name and a non-empty actions array. Each action carries its action_type_id and a params object. The top-level params is a JSON string for automation-level settings.' },
+    { type: 'code', language: 'bash', code: 'curl -X POST "http://localhost:3000/api/automations" \\\n  -H "Authorization: Bearer <your-token>" \\\n  -H "Content-Type: application/json" \\\n  -d \'{\n    "triggerId": 6,\n    "name": "Email the team when a risk is added",\n    "actions": [\n      {\n        "action_type_id": 1,\n        "params": { "to": "team@example.com", "subject": "New risk added" }\n      }\n    ],\n    "params": "{}"\n  }\'' },
+    { type: 'callout', variant: 'warning', title: 'Required fields', text: 'triggerId, name and a non-empty actions array are required. Leaving any of them out returns a 400 with the message "Missing required fields: triggerId, name, actions".' },
+
+    { type: 'heading', id: 'execution', level: 2, text: 'How automations run' },
+    { type: 'paragraph', text: 'When a matching event happens, VerifyWise queues the automation\'s actions and runs them in the background. Each run is recorded, so the history and stats endpoints show what fired, whether it succeeded and how long it took. Because runs are queued rather than immediate, an action may complete a moment after the triggering event.' },
+
+    { type: 'heading', id: 'access', level: 2, text: 'Access' },
+    { type: 'paragraph', text: 'Every automations endpoint requires a valid token and is scoped to your organization. You only see and manage your own organization\'s automations.' },
+
+    { type: 'article-links', title: 'Related articles', items: [
+      { collectionId: 'developers', articleId: 'platform-rest-api', title: 'Platform REST API', description: 'Auth, base URL, response shape and limits.' },
+      { collectionId: 'integrations', articleId: 'automations', title: 'Automations', description: 'Setting up automations in the app.' },
+    ]},
+  ],
+};

--- a/shared/user-guide-content/content/developers/bulk-import-datasets.ts
+++ b/shared/user-guide-content/content/developers/bulk-import-datasets.ts
@@ -1,0 +1,63 @@
+import type { ArticleContent } from '../../contentTypes';
+
+export const bulkImportDatasetsContent: ArticleContent = {
+  blocks: [
+    { type: 'heading', id: 'overview', level: 2, text: 'Bulk importing datasets' },
+    { type: 'paragraph', text: 'You can register a dataset by uploading its file directly through the API. This is the same upload the Datasets page uses, exposed for scripts and data pipelines. The endpoint stores the file and creates a dataset record from the metadata you send with it.' },
+    { type: 'callout', variant: 'info', title: 'This needs a plugin', text: 'Bulk upload is gated behind the dataset-bulk-upload plugin. If the plugin is not installed for your organization, the endpoint returns 403. An Admin can install it from the plugins marketplace.' },
+
+    { type: 'heading', id: 'endpoint', level: 2, text: 'The endpoint' },
+    { type: 'table', columns: [
+      { key: 'k', label: '', width: '30%' },
+      { key: 'v', label: '', width: '70%' },
+    ], rows: [
+      { k: 'Method and path', v: 'POST /api/dataset-bulk-upload/upload' },
+      { k: 'Content type', v: 'multipart/form-data' },
+      { k: 'Access', v: 'Admin or Editor, with the dataset-bulk-upload plugin installed' },
+    ]},
+    { type: 'paragraph', text: 'The request has two parts: the file itself in a form field named file, and an optional metadata field carrying a JSON object that describes the dataset.' },
+
+    { type: 'heading', id: 'formats', level: 2, text: 'Accepted files' },
+    { type: 'paragraph', text: 'The upload accepts CSV, XLS and XLSX files, up to 30 MB. The file is stored as-is. The endpoint does not parse rows or require particular column headers, so any valid CSV or spreadsheet is accepted; you organize the contents however your downstream process expects.' },
+
+    { type: 'heading', id: 'request', level: 2, text: 'Making the request' },
+    { type: 'paragraph', text: 'Send the file in the file field. Put the dataset details in the metadata field as a JSON string.' },
+    { type: 'code', language: 'bash', code: 'curl -X POST "http://localhost:3000/api/dataset-bulk-upload/upload" \\\n  -H "Authorization: Bearer <your-token>" \\\n  -F "file=@training-data.csv" \\\n  -F \'metadata={"name":"Training data Q2","type":"Training","classification":"Internal","contains_pii":false}\'' },
+    { type: 'paragraph', text: 'Every metadata field is optional and has a default. The common ones:' },
+    { type: 'table', columns: [
+      { key: 'field', label: 'Field', width: '28%' },
+      { key: 'desc', label: 'Description', width: '52%' },
+      { key: 'def', label: 'Default', width: '20%' },
+    ], rows: [
+      { field: 'name', desc: 'Display name for the dataset.', def: 'The file name' },
+      { field: 'type', desc: 'What the dataset is used for, for example Training.', def: 'Training' },
+      { field: 'classification', desc: 'Sensitivity classification.', def: 'Internal' },
+      { field: 'contains_pii', desc: 'Whether the dataset holds personal data (boolean).', def: 'false' },
+      { field: 'description', desc: 'Free-text description.', def: 'Empty' },
+      { field: 'version', desc: 'Dataset version string.', def: '1.0' },
+      { field: 'projects', desc: 'Array of project ids to link the dataset to.', def: 'Empty' },
+      { field: 'models', desc: 'Array of model inventory ids to link the dataset to.', def: 'Empty' },
+    ]},
+
+    { type: 'heading', id: 'response', level: 2, text: 'Response' },
+    { type: 'paragraph', text: 'A successful upload returns 201 with the new dataset id and the stored file id:' },
+    { type: 'code', language: 'json', code: '{\n  "message": "Created",\n  "data": {\n    "datasetId": 42,\n    "fileId": 108\n  }\n}' },
+
+    { type: 'heading', id: 'errors', level: 2, text: 'Errors' },
+    { type: 'table', columns: [
+      { key: 'code', label: 'Code', width: '15%' },
+      { key: 'when', label: 'When', width: '85%' },
+    ], rows: [
+      { code: '400', when: 'No file was sent, or the metadata field was not valid JSON.' },
+      { code: '401', when: 'Missing or invalid token.' },
+      { code: '403', when: 'The dataset-bulk-upload plugin is not installed, or your role is not Admin or Editor.' },
+      { code: '413', when: 'The file is larger than 30 MB.' },
+      { code: '415', when: 'The file is not a CSV, XLS or XLSX.' },
+    ]},
+
+    { type: 'article-links', title: 'Related articles', items: [
+      { collectionId: 'developers', articleId: 'platform-rest-api', title: 'Platform REST API', description: 'Auth, base URL, response shape and limits.' },
+      { collectionId: 'ai-governance', articleId: 'datasets', title: 'Datasets', description: 'Managing datasets in the app.' },
+    ]},
+  ],
+};

--- a/shared/user-guide-content/content/developers/compliance-and-reports.ts
+++ b/shared/user-guide-content/content/developers/compliance-and-reports.ts
@@ -1,0 +1,57 @@
+import type { ArticleContent } from '../../contentTypes';
+
+export const complianceAndReportsContent: ArticleContent = {
+  blocks: [
+    { type: 'heading', id: 'overview', level: 2, text: 'Compliance, reports and exports' },
+    { type: 'paragraph', text: 'If you run a separate GRC or reporting tool, you can pull governance data out of VerifyWise over the API: live compliance progress, generated reports and a handful of document exports. This article covers what is available and what is not.' },
+
+    { type: 'heading', id: 'progress', level: 2, text: 'Compliance and assessment progress' },
+    { type: 'paragraph', text: 'Progress endpoints return how far a project has come on its controls and assessment questions, as plain JSON. Use these to mirror compliance state in another system.' },
+    { type: 'table', columns: [
+      { key: 'method', label: 'Method & path', width: '55%' },
+      { key: 'desc', label: 'Returns', width: '45%' },
+    ], rows: [
+      { method: 'GET /api/projects/compliance/progress/:id', desc: 'Control progress for a project.' },
+      { method: 'GET /api/projects/assessment/progress/:id', desc: 'Assessment question progress for a project.' },
+      { method: 'GET /api/projects/all/compliance/progress', desc: 'Control progress across all projects.' },
+      { method: 'GET /api/projects/all/assessment/progress', desc: 'Assessment progress across all projects.' },
+    ]},
+    { type: 'code', language: 'bash', code: 'curl "http://localhost:3000/api/projects/compliance/progress/1" \\\n  -H "Authorization: Bearer <your-token>"' },
+    { type: 'paragraph', text: 'The compliance response counts subcontrols; the assessment response counts questions:' },
+    { type: 'code', language: 'json', code: '{ "message": "OK", "data": { "allsubControls": 45, "allDonesubControls": 23 } }\n\n{ "message": "OK", "data": { "totalQuestions": 120, "answeredQuestions": 87 } }' },
+    { type: 'paragraph', text: 'Framework-specific progress is available under each framework, for example /api/eu-ai-act/compliances/progress/:id and /api/iso-27001/clauses/progress/:id, with matching all/... variants. The frameworks also expose their control structure (control categories, controls, ISO clauses and annexes) as JSON, so you can map VerifyWise controls onto your own framework model.' },
+
+    { type: 'heading', id: 'reports', level: 2, text: 'Generating reports' },
+    { type: 'paragraph', text: 'You can generate a report document on demand and stream it back. This is the same report the Reporting page produces.' },
+    { type: 'table', columns: [
+      { key: 'method', label: 'Method & path', width: '50%' },
+      { key: 'desc', label: 'Description', width: '50%' },
+    ], rows: [
+      { method: 'POST /api/reporting/v2/generate-report', desc: 'Generate and download a report. Admin only.' },
+      { method: 'GET /api/reporting/generate-report', desc: 'List previously generated reports.' },
+      { method: 'DELETE /api/reporting/:id', desc: 'Delete a generated report.' },
+    ]},
+    { type: 'paragraph', text: 'The generate call takes the project, a report type and a format (pdf or docx), and responds with the document as a file attachment.' },
+    { type: 'code', language: 'bash', code: 'curl -X POST "http://localhost:3000/api/reporting/v2/generate-report" \\\n  -H "Authorization: Bearer <admin-token>" \\\n  -H "Content-Type: application/json" \\\n  -d \'{ "projectId": 1, "reportType": "compliance", "format": "pdf" }\' \\\n  --output report.pdf' },
+    { type: 'callout', variant: 'info', title: 'Report types', text: 'reportType selects the sections, for example compliance, assessment, projectRisks, vendorRisks, modelRisks, trainingRegistry, policyManager or all. Some report types also expect a framework id; check the Reporting page or /api/docs for the exact combination you want.' },
+
+    { type: 'heading', id: 'exports', level: 2, text: 'Document exports' },
+    { type: 'paragraph', text: 'A few resources can be exported as a file. These are targeted exports, not a general dump of your data.' },
+    { type: 'table', columns: [
+      { key: 'method', label: 'Method & path', width: '55%' },
+      { key: 'fmt', label: 'Format', width: '45%' },
+    ], rows: [
+      { method: 'GET /api/policies/:id/export/pdf', fmt: 'Policy as PDF.' },
+      { method: 'GET /api/policies/:id/export/docx', fmt: 'Policy as DOCX.' },
+      { method: 'GET /api/ai-detection/scans/:scanId/export/ai-bom', fmt: 'AI bill of materials as JSON.' },
+      { method: 'GET /api/ai-audit/export?format=csv', fmt: 'Agent Control audit log as CSV (or JSON without the param).' },
+    ]},
+
+    { type: 'callout', variant: 'warning', title: 'No general CSV export', text: 'There is no single endpoint that dumps all risks, models or evidence as CSV or JSON. To pull those, list each resource through its own endpoint (see Working with resources) and shape the data yourself. The exports above are the only file exports available today.' },
+
+    { type: 'article-links', title: 'Related articles', items: [
+      { collectionId: 'developers', articleId: 'working-with-resources', title: 'Working with resources', description: 'List and read resources over the API.' },
+      { collectionId: 'developers', articleId: 'platform-rest-api', title: 'Platform REST API', description: 'Auth, base URL, response shape and limits.' },
+    ]},
+  ],
+};

--- a/shared/user-guide-content/content/developers/inbound-integrations.ts
+++ b/shared/user-guide-content/content/developers/inbound-integrations.ts
@@ -1,0 +1,46 @@
+import type { ArticleContent } from '../../contentTypes';
+
+export const inboundIntegrationsContent: ArticleContent = {
+  blocks: [
+    { type: 'heading', id: 'overview', level: 2, text: 'Inbound integrations' },
+    { type: 'paragraph', text: 'Two parts of VerifyWise are built to receive data from outside systems: incidents and intake forms. You can raise an incident from your own monitoring stack, and you can submit an intake form from a public website without a login.' },
+
+    { type: 'heading', id: 'incidents', level: 2, text: 'Creating incidents from another system' },
+    { type: 'paragraph', text: 'If your monitoring or observability tooling detects an AI problem, it can record an incident in VerifyWise through the API. Incidents have full CRUD, all behind a token.' },
+    { type: 'table', columns: [
+      { key: 'method', label: 'Method & path', width: '55%' },
+      { key: 'desc', label: 'Description', width: '45%' },
+    ], rows: [
+      { method: 'GET /api/ai-incident-managements', desc: 'List incidents.' },
+      { method: 'GET /api/ai-incident-managements/:id', desc: 'Fetch one incident.' },
+      { method: 'POST /api/ai-incident-managements', desc: 'Create an incident.' },
+      { method: 'PATCH /api/ai-incident-managements/:id', desc: 'Update an incident.' },
+      { method: 'DELETE /api/ai-incident-managements/:id', desc: 'Delete an incident.' },
+    ]},
+    { type: 'paragraph', text: 'A create needs at least the affected project, a type, a severity, a status, a reporter and a description. Many more fields are accepted for a fuller record.' },
+    { type: 'code', language: 'bash', code: 'curl -X POST "http://localhost:3000/api/ai-incident-managements" \\\n  -H "Authorization: Bearer <your-token>" \\\n  -H "Content-Type: application/json" \\\n  -d \'{\n    "ai_project": 1,\n    "type": "Performance degradation",\n    "severity": "High",\n    "status": "Open",\n    "reporter": "monitoring-bot",\n    "description": "Model accuracy dropped below the alert threshold."\n  }\'' },
+    { type: 'paragraph', text: 'The response is the standard envelope with the created incident in data. From there your team picks it up in the app.' },
+
+    { type: 'heading', id: 'intake', level: 2, text: 'Submitting public intake forms' },
+    { type: 'paragraph', text: 'Intake forms collect AI project requests. Their public endpoints let an external site fetch a form and submit answers with no login, identified by the form\'s public id. These routes are rate-limited and protected by a CAPTCHA.' },
+    { type: 'table', columns: [
+      { key: 'method', label: 'Method & path', width: '55%' },
+      { key: 'desc', label: 'Description', width: '45%' },
+    ], rows: [
+      { method: 'GET /api/intake/public/by-id/:publicId', desc: 'Fetch the form definition, including its fields.' },
+      { method: 'POST /api/intake/public/by-id/:publicId', desc: 'Submit a completed form.' },
+      { method: 'GET /api/intake/public/captcha', desc: 'Get a CAPTCHA challenge to include with a submission.' },
+    ]},
+    { type: 'paragraph', text: 'Fetch the form to learn its fields, then post the answers. The submitter email, the answers as formData and a CAPTCHA token and answer are required.' },
+    { type: 'code', language: 'bash', code: 'curl "http://localhost:3000/api/intake/public/by-id/<public-id>"\n\ncurl -X POST "http://localhost:3000/api/intake/public/by-id/<public-id>" \\\n  -H "Content-Type: application/json" \\\n  -d \'{\n    "submitterEmail": "requester@example.com",\n    "submitterName": "Jane Doe",\n    "formData": { "field-1": "New chatbot", "field-2": "Customer support" },\n    "captchaToken": "<token-from-captcha-endpoint>",\n    "captchaAnswer": 7\n  }\'' },
+    { type: 'callout', variant: 'info', title: 'No token needed here', text: 'The public intake routes are the one part of the platform that does not use a bearer token, because forms are meant to be filled in by people outside your organization. They are rate-limited and CAPTCHA-gated instead. Everything else in the developer guide needs a token.' },
+
+    { type: 'heading', id: 'what-is-missing', level: 2, text: 'What is not available' },
+    { type: 'paragraph', text: 'VerifyWise does not send outbound webhooks for these events. Nothing calls your systems when an incident changes or a form is submitted; your side initiates every request. Automations can send email on events, but there is no action that posts to an external URL.' },
+
+    { type: 'article-links', title: 'Related articles', items: [
+      { collectionId: 'developers', articleId: 'platform-rest-api', title: 'Platform REST API', description: 'Auth, base URL, response shape and limits.' },
+      { collectionId: 'developers', articleId: 'automations-api', title: 'Automations API', description: 'Run an email action when an event happens.' },
+    ]},
+  ],
+};

--- a/shared/user-guide-content/content/developers/overview.ts
+++ b/shared/user-guide-content/content/developers/overview.ts
@@ -42,6 +42,11 @@ export const developersOverviewContent: ArticleContent = {
       type: 'bullet-list',
       items: [
         { bold: 'Platform REST API', text: 'The base URL, authentication, response shape, status codes and the current limits that apply to every endpoint.' },
+        { bold: 'Working with resources', text: 'The CRUD pattern for projects, risks, vendors and more, with the few places they differ.' },
+        { bold: 'Bulk importing datasets', text: 'Upload a CSV or spreadsheet to register a dataset through the API.' },
+        { bold: 'Automations API', text: 'Create and manage automations programmatically.' },
+        { bold: 'Compliance, reports and exports', text: 'Pull compliance progress, generate reports and use the document exports.' },
+        { bold: 'Inbound integrations', text: 'Create incidents from another system and submit public intake forms.' },
       ],
     },
     {

--- a/shared/user-guide-content/content/developers/platform-rest-api.ts
+++ b/shared/user-guide-content/content/developers/platform-rest-api.ts
@@ -69,6 +69,7 @@ export const platformRestApiContent: ArticleContent = {
     { type: 'paragraph', text: 'Every request is scoped to the organization of the token that made it. You only ever see and modify your own organization’s data; there is no cross-organization access through these endpoints.' },
 
     { type: 'article-links', title: 'Related articles', items: [
+      { collectionId: 'developers', articleId: 'working-with-resources', title: 'Working with resources', description: 'The CRUD pattern for projects, risks, vendors and more.' },
       { collectionId: 'developers', articleId: 'overview', title: 'Developer guide', description: 'What the developer guide covers today.' },
       { collectionId: 'developers', articleId: 'agent-control-api', title: 'API reference', description: 'The separate hook API for governing an agent’s tool calls.' },
     ]},

--- a/shared/user-guide-content/content/developers/working-with-resources.ts
+++ b/shared/user-guide-content/content/developers/working-with-resources.ts
@@ -1,0 +1,73 @@
+import type { ArticleContent } from '../../contentTypes';
+
+export const workingWithResourcesContent: ArticleContent = {
+  blocks: [
+    { type: 'heading', id: 'overview', level: 2, text: 'Working with resources' },
+    { type: 'paragraph', text: 'Most VerifyWise resources (projects, risks, vendors, models, tasks and more) follow the same REST pattern: list them, fetch one by id, create, update and delete. Once you know the pattern, every resource works the same way. The few places where they differ are listed at the end.' },
+    { type: 'paragraph', text: 'This article assumes you already have a token and know the base URL. If not, read the Platform REST API article first.' },
+
+    { type: 'heading', id: 'pattern', level: 2, text: 'The CRUD pattern' },
+    { type: 'paragraph', text: 'Using vendors as the example, here is the full set of operations. Every request carries your bearer token.' },
+    { type: 'table', columns: [
+      { key: 'op', label: 'Operation', width: '25%' },
+      { key: 'method', label: 'Method & path', width: '40%' },
+      { key: 'desc', label: 'Returns', width: '35%' },
+    ], rows: [
+      { op: 'List', method: 'GET /api/vendors', desc: 'Every vendor in your organization.' },
+      { op: 'Get one', method: 'GET /api/vendors/:id', desc: 'A single vendor by id.' },
+      { op: 'Create', method: 'POST /api/vendors', desc: 'The created vendor, with its new id.' },
+      { op: 'Update', method: 'PATCH /api/vendors/:id', desc: 'The updated vendor.' },
+      { op: 'Delete', method: 'DELETE /api/vendors/:id', desc: 'A confirmation message.' },
+    ]},
+
+    { type: 'heading', id: 'list', level: 3, text: 'List and get' },
+    { type: 'code', language: 'bash', code: 'curl "http://localhost:3000/api/vendors" \\\n  -H "Authorization: Bearer <your-token>"' },
+    { type: 'paragraph', text: 'The response is the standard envelope. The list lives in the data field:' },
+    { type: 'code', language: 'json', code: '{\n  "message": "OK",\n  "data": [\n    { "id": 1, "vendor_name": "Acme AI", "website": "https://acme.example" }\n  ]\n}' },
+    { type: 'paragraph', text: 'Fetch a single vendor by adding its id to the path:' },
+    { type: 'code', language: 'bash', code: 'curl "http://localhost:3000/api/vendors/1" \\\n  -H "Authorization: Bearer <your-token>"' },
+
+    { type: 'heading', id: 'create', level: 3, text: 'Create' },
+    { type: 'paragraph', text: 'Send the resource fields as a JSON body. For a vendor, the common fields are:' },
+    { type: 'code', language: 'bash', code: 'curl -X POST "http://localhost:3000/api/vendors" \\\n  -H "Authorization: Bearer <your-token>" \\\n  -H "Content-Type: application/json" \\\n  -d \'{\n    "vendor_name": "Acme AI",\n    "vendor_provides": "LLM hosting",\n    "website": "https://acme.example",\n    "vendor_contact_person": "Jane Doe",\n    "review_status": "Not started"\n  }\'' },
+    { type: 'paragraph', text: 'The response returns the created vendor with its assigned id. Each resource has its own set of fields, so check the resource in the live reference at /api/docs to see exactly what it accepts.' },
+
+    { type: 'heading', id: 'update-delete', level: 3, text: 'Update and delete' },
+    { type: 'paragraph', text: 'Update sends only the fields you want to change. Delete needs no body.' },
+    { type: 'code', language: 'bash', code: 'curl -X PATCH "http://localhost:3000/api/vendors/1" \\\n  -H "Authorization: Bearer <your-token>" \\\n  -H "Content-Type: application/json" \\\n  -d \'{ "review_status": "In review" }\'\n\ncurl -X DELETE "http://localhost:3000/api/vendors/1" \\\n  -H "Authorization: Bearer <your-token>"' },
+
+    { type: 'heading', id: 'differences', level: 2, text: 'Where resources differ' },
+    { type: 'paragraph', text: 'The pattern is consistent, but three details vary by resource. Always confirm them per resource in /api/docs before you wire up an integration.' },
+
+    { type: 'heading', id: 'path-casing', level: 3, text: 'Path casing' },
+    { type: 'paragraph', text: 'Most paths are lowercase (/api/vendors, /api/projects), but some keep camelCase. Project risks are served at /api/projectRisks, not /api/project-risks. Use the path exactly as the reference shows it.' },
+
+    { type: 'heading', id: 'update-verb', level: 3, text: 'Update verb (PATCH vs PUT)' },
+    { type: 'paragraph', text: 'The update verb is not the same for every resource. Sending the wrong one returns a 404 or 405.' },
+    { type: 'table', columns: [
+      { key: 'resource', label: 'Resource', width: '40%' },
+      { key: 'verb', label: 'Update verb', width: '30%' },
+      { key: 'path', label: 'Path', width: '30%' },
+    ], rows: [
+      { resource: 'Projects', verb: 'PATCH', path: '/api/projects/:id' },
+      { resource: 'Vendors', verb: 'PATCH', path: '/api/vendors/:id' },
+      { resource: 'Project risks', verb: 'PUT', path: '/api/projectRisks/:id' },
+    ]},
+
+    { type: 'heading', id: 'filter-param', level: 3, text: 'The filter parameter' },
+    { type: 'paragraph', text: 'Some list endpoints accept a filter query parameter, and some do not. Project risks support it; projects and vendors do not. When supported, the values are active (the default), deleted or all.' },
+    { type: 'code', language: 'bash', code: 'curl "http://localhost:3000/api/projectRisks?filter=all" \\\n  -H "Authorization: Bearer <your-token>"' },
+
+    { type: 'heading', id: 'roles', level: 2, text: 'Roles and access' },
+    { type: 'paragraph', text: 'Every resource endpoint requires a valid token. Most read and write operations are open to any role within your organization, but some actions are restricted. For example, the bulk update of project risks (PATCH /api/projectRisks/bulk) is limited to Admin and Editor. A token carries the role of the user who created it, so an integration that needs to bulk-update risks must use a key created by an Admin or Editor.' },
+
+    { type: 'heading', id: 'reminders', level: 2, text: 'Two reminders' },
+    { type: 'callout', variant: 'warning', title: 'List endpoints return everything', text: 'No resource list is paginated. A list call returns every matching row for your organization, so fetch and cache rather than polling in a tight loop, and be ready to handle large responses.' },
+    { type: 'callout', variant: 'info', title: 'Check each resource in the reference', text: 'Field names, the update verb and filter support all vary by resource. The live reference at /api/docs is the source of truth for any resource you have not used before.' },
+
+    { type: 'article-links', title: 'Related articles', items: [
+      { collectionId: 'developers', articleId: 'platform-rest-api', title: 'Platform REST API', description: 'Auth, base URL, response shape and limits.' },
+      { collectionId: 'developers', articleId: 'overview', title: 'Developer guide', description: 'What the developer guide covers today.' },
+    ]},
+  ],
+};

--- a/shared/user-guide-content/content/index.ts
+++ b/shared/user-guide-content/content/index.ts
@@ -100,6 +100,11 @@ import { connectAnyAgentContent } from './developers/connect-any-agent';
 import { governingToolCallsContent } from './developers/governing-tool-calls';
 import { agentControlApiContent } from './developers/agent-control-api';
 import { platformRestApiContent } from './developers/platform-rest-api';
+import { workingWithResourcesContent } from './developers/working-with-resources';
+import { bulkImportDatasetsContent } from './developers/bulk-import-datasets';
+import { automationsApiContent } from './developers/automations-api';
+import { complianceAndReportsContent } from './developers/compliance-and-reports';
+import { inboundIntegrationsContent } from './developers/inbound-integrations';
 
 // Map of article IDs to their content
 // Format: 'collectionId/articleId': ArticleContent
@@ -220,6 +225,11 @@ export const articleContentMap: Record<string, ArticleContent> = {
   'developers/governing-tool-calls': governingToolCallsContent,
   'developers/agent-control-api': agentControlApiContent,
   'developers/platform-rest-api': platformRestApiContent,
+  'developers/working-with-resources': workingWithResourcesContent,
+  'developers/bulk-import-datasets': bulkImportDatasetsContent,
+  'developers/automations-api': automationsApiContent,
+  'developers/compliance-and-reports': complianceAndReportsContent,
+  'developers/inbound-integrations': inboundIntegrationsContent,
 };
 
 // Helper to get article content

--- a/shared/user-guide-content/content/settings/super-admin.ts
+++ b/shared/user-guide-content/content/settings/super-admin.ts
@@ -20,6 +20,22 @@ export const superAdminContent: ArticleContent = {
     },
     {
       type: 'heading',
+      id: 'setup',
+      level: 2,
+      text: 'Setting up the super admin',
+    },
+    {
+      type: 'paragraph',
+      text: 'There is no sign-up for the super admin. The account is created once, when the installation is first set up, from two environment variables: SUPERADMIN_EMAIL and SUPERADMIN_PASSWORD. The password must be at least 8 characters. On first run these seed the single super admin account, and you log in with those credentials.',
+    },
+    {
+      type: 'callout',
+      variant: 'info',
+      title: 'There is only one super admin',
+      text: 'An installation has exactly one super admin account, enforced at the database level. You cannot create a second one, and the super admin role cannot be assigned through the invite flow.',
+    },
+    {
+      type: 'heading',
       id: 'organizations',
       level: 2,
       text: 'Managing organizations',
@@ -27,6 +43,12 @@ export const superAdminContent: ArticleContent = {
     {
       type: 'paragraph',
       text: 'The Organizations page lists all organizations in the system. For each one, you can see the name, number of users and creation date. Click "View users" to see everyone in that organization.',
+    },
+    {
+      type: 'callout',
+      variant: 'info',
+      title: 'Read-only inside an organization',
+      text: 'When the super admin views an organization\'s data, access is read-only. You can see everything but cannot change an organization\'s records from inside it. Managing organizations and users is done from the super admin panel itself, where these actions are allowed.',
     },
     {
       type: 'heading',
@@ -59,9 +81,8 @@ export const superAdminContent: ArticleContent = {
         { text: 'Click **Invite user** on the Users page.' },
         { text: 'Enter the user\'s name, surname and email.' },
         { text: 'Select the organization they belong to.' },
-        { text: 'Choose a role: Admin, Reviewer, Editor or Auditor.' },
-        { text: 'Set a temporary password.' },
-        { text: 'Click **Invite**.' },
+        { text: 'Choose a role: Admin, Reviewer, Editor or Auditor. The super admin role cannot be assigned here.' },
+        { text: 'Click **Invite**. The user receives an invitation to set their own password.' },
       ],
     },
     {

--- a/shared/user-guide-content/userGuideConfig.ts
+++ b/shared/user-guide-content/userGuideConfig.ts
@@ -723,9 +723,9 @@ export const collections: Collection[] = [
   {
     id: 'developers',
     title: 'Developer guide',
-    description: 'Build on VerifyWise. The guide covers Agent Control — connect any terminal agent, see how decisions work and use the hook API reference — and the platform REST API for reading and writing your governance data. More developer topics are coming.',
+    description: 'Build on VerifyWise. The guide covers Agent Control (connect any terminal agent and govern its tool calls) and the platform REST API for reading and writing your governance data. More developer topics are coming.',
     icon: 'Plug',
-    articleCount: 7,
+    articleCount: 12,
     articles: [
       {
         id: 'overview',
@@ -768,6 +768,36 @@ export const collections: Collection[] = [
         title: 'Platform REST API',
         description: 'Authenticate with a token and read or write your governance data over REST.',
         keywords: ['developer', 'api', 'rest', 'platform', 'token', 'bearer', 'authentication', 'endpoint', 'swagger', 'openapi', 'pagination', 'integration', 'curl'],
+      },
+      {
+        id: 'working-with-resources',
+        title: 'Working with resources',
+        description: 'The CRUD pattern for projects, risks, vendors and other resources, with the few places they differ.',
+        keywords: ['developer', 'api', 'rest', 'crud', 'create', 'update', 'delete', 'list', 'resources', 'projects', 'risks', 'vendors', 'patch', 'put', 'filter', 'curl', 'integration'],
+      },
+      {
+        id: 'bulk-import-datasets',
+        title: 'Bulk importing datasets',
+        description: 'Upload a CSV or spreadsheet to register a dataset through the API.',
+        keywords: ['developer', 'api', 'dataset', 'bulk', 'upload', 'import', 'csv', 'xlsx', 'multipart', 'file', 'plugin', 'metadata', 'integration'],
+      },
+      {
+        id: 'automations-api',
+        title: 'Automations API',
+        description: 'Create and manage automations programmatically, with the list of triggers and actions.',
+        keywords: ['developer', 'api', 'automation', 'trigger', 'action', 'rule', 'email', 'event', 'crud', 'integration'],
+      },
+      {
+        id: 'compliance-and-reports',
+        title: 'Compliance, reports and exports',
+        description: 'Fetch compliance progress, generate reports and use the document export endpoints.',
+        keywords: ['developer', 'api', 'compliance', 'progress', 'report', 'export', 'pdf', 'docx', 'csv', 'grc', 'assessment', 'framework', 'integration'],
+      },
+      {
+        id: 'inbound-integrations',
+        title: 'Inbound integrations',
+        description: 'Create incidents from another system and submit public intake forms.',
+        keywords: ['developer', 'api', 'incident', 'intake', 'form', 'public', 'submission', 'webhook', 'integration', 'monitoring'],
       },
     ],
   },


### PR DESCRIPTION
## Summary

Adds five developer-guide articles covering the rest of the platform's programmatic surface, and fills gaps in the super admin guide. Every endpoint, field and limit was verified against the backend before writing.

## New developer articles

- **Working with resources** — the CRUD pattern for projects, risks, vendors and other resources, including where they differ (path casing, PATCH vs PUT, the filter parameter) and the no-pagination caveat.
- **Bulk importing datasets** — the multipart upload endpoint, its plugin and role gating, accepted formats and size limit, metadata fields and error codes.
- **Automations API** — full CRUD plus trigger and action discovery, the rule shape, and an honest note that email is the only action and there are no outbound webhooks.
- **Compliance, reports and exports** — compliance and assessment progress endpoints, report generation, and the document export endpoints, with a clear note that there is no general CSV export.
- **Inbound integrations** — creating incidents from another system, and the public intake-form endpoints (the one part of the API that needs no token).

## Super admin guide

- Documents how the super admin is created (seeded from `SUPERADMIN_EMAIL` and `SUPERADMIN_PASSWORD` at install) and that there is only one.
- Adds the read-only behaviour when a super admin views an organization.
- Corrects the invite flow (no temporary password; super admin cannot be invited).

Features that were checked and found not to exist (SCIM/LDAP provisioning, custom roles, a policy-template API) were deliberately left undocumented. Typecheck and the strict i18n audit both pass.