### PR TITLE
Add v2.4 release entry to What's new

### DIFF
--- a/Clients/src/i18n/translations.ts
+++ b/Clients/src/i18n/translations.ts
@@ -5331,6 +5331,8 @@ export const translations: Record<string, Record<string, string>> = {
     "AI Chatbot for Customer Support": "KI-Chatbot für den Kundensupport",
     "AI Gateway": "AI Gateway",
     "AI Gateway, Policy Radar, and CI/CD scanning": "AI Gateway, Policy Radar und CI/CD-Scanning",
+    "AI Trust Index, AI Apps inventory, and Agent Control":
+      "AI Trust Index, AI Apps inventory und Agent Control",
     "EU AI Act control workflow, clearable selects, and AI advisor fix":
       "EU-KI-Verordnungs-Kontroll-Workflow, löschbare Auswahlfelder und KI-Berater-Fix",
     "Training evidence uploads, governance score helper, and policy ownership":
@@ -13961,6 +13963,8 @@ export const translations: Record<string, Record<string, string>> = {
     "AI Chatbot for Customer Support": "Chatbot IA pour le support client",
     "AI Gateway": "AI Gateway",
     "AI Gateway, Policy Radar, and CI/CD scanning": "AI Gateway, Policy Radar et analyse CI/CD",
+    "AI Trust Index, AI Apps inventory, and Agent Control":
+      "AI Trust Index, AI Apps inventory et Agent Control",
     "EU AI Act control workflow, clearable selects, and AI advisor fix":
       "Workflow des contrôles du Règlement IA de l'UE, sélections effaçables et correctif de l'assistant IA",
     "Training evidence uploads, governance score helper, and policy ownership":
@@ -20583,6 +20587,8 @@ export const translations: Record<string, Record<string, string>> = {
     "AI Chatbot for Customer Support": "Chatbot de IA para atención al cliente",
     "AI Gateway": "AI Gateway",
     "AI Gateway, Policy Radar, and CI/CD scanning": "AI Gateway, Policy Radar y análisis de CI/CD",
+    "AI Trust Index, AI Apps inventory, and Agent Control":
+      "AI Trust Index, AI Apps inventory y Agent Control",
     "AI Lifecycle Risk Management": "Gestión de riesgos del ciclo de vida de la IA",
     "AI Literacy and Responsible AI Training": "Alfabetización en IA y formación en IA responsable",
     "AI Management System": "Sistema de gestión de IA",

--- a/Clients/src/presentation/components/UserGuide/WhatsNewSection.tsx
+++ b/Clients/src/presentation/components/UserGuide/WhatsNewSection.tsx
@@ -11,6 +11,24 @@ interface ChangelogEntry {
 
 const CHANGELOG: ChangelogEntry[] = [
   {
+    version: "v2.4",
+    date: "June 22, 2026",
+    title: "AI Trust Index, AI Apps inventory, and Agent Control",
+    summary:
+      "Major release with three new modules. The AI Trust Index grades and tracks third-party AI apps, the AI Apps inventory governs the AI tools your teams use, and Agent Control governs what AI agents do. This release also adds AI Agents that suggest risks and review content, custom fields, a deadline warning banner, Microsoft Entra ID single sign-on, and design system updates.",
+    items: [
+      "AI Trust Index — browse a curated catalog of AI apps with letter-grade trust scores and per-domain breakdowns, open app pages with verdicts and watch-outs, track the apps you care about, and get a weekly digest email of what changed",
+      "AI Apps inventory — keep a register of the AI applications your teams use, with detail pages, an approval center, policy and model dependency mapping, and risk assessment templates; you can also promote a discovered Shadow AI tool into a governed app",
+      "Agent Control — govern what AI agents do with tool-call approval and file-write content gating. Run correlation joins an agent's model calls and tool calls into one run on the new Runs page, and it works with Claude Code and Cursor",
+      "AI Agents — agents that suggest model risks, draft tasks, and review evidence and AI-generated content, so the platform does more of the analysis for you",
+      "Custom fields — define your own fields to capture the data your organization needs",
+      "Deadline warning banner — see upcoming deadlines across the dashboard and tasks, with configurable thresholds and per-user snooze",
+      "Microsoft Entra ID single sign-on — sign in with your organization's Microsoft identity",
+      "Design system updates — unified chip component, icon-only and small button sizes, table skeleton loaders on more pages, and a consistent empty state",
+      "Added Spanish (es) language coverage across the application",
+    ],
+  },
+  {
     version: "v2.3.4",
     date: "May 19, 2026",
     title: "Training evidence uploads, governance score helper, and policy ownership",


### PR DESCRIPTION
## Changes

Adds the v2.4 entry to the top of the changelog in the What's new sidebar block (`Clients/src/presentation/components/UserGuide/WhatsNewSection.tsx`). Previously the latest entry was v2.3.4.

The entry covers everything in the v2.4 GitHub release:

- **AI Trust Index** — browse a curated catalog of AI apps with letter-grade trust scores, app detail pages, tracking, and a weekly digest of what changed
- **AI Apps inventory** — register the AI applications teams use, with approval center, policy and model mapping, risk templates, and Shadow AI promotion
- **Agent Control** — tool-call approval, file-write gating, and run correlation on the new Runs page; works with Claude Code and Cursor
- **AI Agents** — agents that suggest model risks, draft tasks, and review evidence and AI-generated content
- **Custom fields** — user-definable fields
- **Deadline warning banner** — upcoming deadlines with thresholds and snooze
- **Microsoft Entra ID single sign-on**
- **Design system updates** — unified chip, icon-only/small buttons, table skeleton loaders, consistent empty states
- **Spanish (es) language** coverage

## Benefits

Users opening the What's new panel now see an accurate summary of the latest release. Every claim was verified against the merged PRs in the v2.4 release notes.

## Notes

- Sentence case and the existing `Name — explanation` bullet format kept for consistency with prior entries.
- Frontend-only, content-only change to a single file.