### PR TITLE
Hide AI Agent dashboard tabs from end users

### DIFF
--- a/Clients/src/presentation/pages/DashboardOverview/IntegratedDashboard.tsx
+++ b/Clients/src/presentation/pages/DashboardOverview/IntegratedDashboard.tsx
@@ -100,7 +100,15 @@ const AVAILABLE_DASHBOARD_TABS: DashboardTabConfig[] = [
   },
 ];
 
-const DEFAULT_TABS = ["overview", "readiness", "ai-content", "ai-audit"];
+// Feature flag: the AI Agent dashboard tabs (Audit readiness, AI content review,
+// AI audit) and the customizable tab bar are hidden from end users for now. The
+// underlying pages, hooks, and APIs stay in the codebase; flip this to true to
+// surface them again.
+const SHOW_AI_AGENT_DASHBOARD_TABS = false;
+
+const DEFAULT_TABS = SHOW_AI_AGENT_DASHBOARD_TABS
+  ? ["overview", "readiness", "ai-content", "ai-audit"]
+  : ["overview"];
 
 const IntegratedDashboard: React.FC = () => {
   const navigateSearch = useNavigateSearch();
@@ -423,17 +431,19 @@ const IntegratedDashboard: React.FC = () => {
         </Stack>
 
         {/* Dashboard Tab Bar */}
-        <TabContext value={dashboardTab}>
-          <Box sx={{ mb: 1 }}>
-            <DashboardTabs
-              availableTabs={AVAILABLE_DASHBOARD_TABS}
-              activeTabs={activeTabs}
-              activeTab={dashboardTab}
-              onTabChange={handleDashboardTabChange}
-              onTabsChange={handleActiveTabsChange}
-            />
-          </Box>
-        </TabContext>
+        {SHOW_AI_AGENT_DASHBOARD_TABS && (
+          <TabContext value={dashboardTab}>
+            <Box sx={{ mb: 1 }}>
+              <DashboardTabs
+                availableTabs={AVAILABLE_DASHBOARD_TABS}
+                activeTabs={activeTabs}
+                activeTab={dashboardTab}
+                onTabChange={handleDashboardTabChange}
+                onTabsChange={handleActiveTabsChange}
+              />
+            </Box>
+          </TabContext>
+        )}
 
         {/* Tab: Readiness Dashboard */}
         {dashboardTab === "readiness" && <ReadinessDashboard />}


### PR DESCRIPTION
## Changes

Hides the customizable dashboard tab system and its three AI Agent tabs (Audit readiness, AI content review, AI audit) from end users. The dashboard now shows only the Overview tab, with no tab bar and no add-tab (+) control.

This is done with a single `SHOW_AI_AGENT_DASHBOARD_TABS` flag in `IntegratedDashboard.tsx`, defaulted to `false`:

- `DEFAULT_TABS` collapses to `["overview"]` when the flag is off.
- The `DashboardTabs` bar (tabs + "+" button) is not rendered.
- The readiness / ai-content / ai-audit render branches become unreachable.

## Benefits

- The underlying pages, components, hooks, and APIs stay in the codebase, so none of the work is lost. Setting the flag to `true` restores the full tab experience.
- Users who previously selected one of the now-hidden tabs fall back to Overview, because the selected-tab initializer validates the saved value against the active tab list.
- No routes or sidebar entries were involved, so this fully removes the user-facing surface for the feature.

## Notes

- Frontend-only change to a single file.
- Build, typecheck, and format-check all pass locally.