### PR TITLE
feat(frontend): add CustomizableSkeleton loading to Frameworks, Approval Workflows, and AI Trust Center

### DIFF
--- a/Clients/src/presentation/pages/AITrustCenter/Overview/__tests__/AITrustCenterOverview.test.tsx
+++ b/Clients/src/presentation/pages/AITrustCenter/Overview/__tests__/AITrustCenterOverview.test.tsx
@@ -81,11 +81,11 @@ describe("AITrustCenterOverview", () => {
     mockMutateAsync.mockResolvedValue({});
   });
 
-  it("renders loading spinner while data is loading", () => {
+  it("renders loading skeleton while data is loading", () => {
     mockQueryLoading = true;
     mockQueryData = null;
     renderWithProviders(<AITrustCenterOverview />);
-    expect(screen.getByRole("progressbar")).toBeInTheDocument();
+    expect(document.querySelector(".MuiSkeleton-root")).toBeInTheDocument();
     expect(screen.queryByText("Introduction")).not.toBeInTheDocument();
   });
 

--- a/Clients/src/presentation/pages/AITrustCenter/Overview/index.tsx
+++ b/Clients/src/presentation/pages/AITrustCenter/Overview/index.tsx
@@ -1,13 +1,7 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import React, { Suspense } from "react";
-import {
-  Box,
-  Typography,
-  Stack,
-  FormControlLabel,
-  useTheme,
-  CircularProgress,
-} from "@mui/material";
+import { Box, Typography, Stack, FormControlLabel, useTheme } from "@mui/material";
+import CustomizableSkeleton from "../../../components/Skeletons";
 import Alert from "../../../components/Alert";
 import Toggle from "../../../components/Inputs/Toggle";
 import ToggleCard from "../../../components/Inputs/ToggleCard";
@@ -200,11 +194,7 @@ const AITrustCenterOverview: React.FC = () => {
   };
 
   if (loading || !localFormData) {
-    return (
-      <Box display="flex" justifyContent="center" alignItems="center" minHeight="400px">
-        <CircularProgress />
-      </Box>
-    );
+    return <CustomizableSkeleton variant="rectangular" width="100%" height={400} />;
   }
 
   return (

--- a/Clients/src/presentation/pages/AITrustCenter/Settings/index.tsx
+++ b/Clients/src/presentation/pages/AITrustCenter/Settings/index.tsx
@@ -1,6 +1,7 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import React, { useRef } from "react";
 import { Box, Stack, Typography, Button as MUIButton, CircularProgress } from "@mui/material";
+import CustomizableSkeleton from "../../../components/Skeletons";
 import Alert from "../../../components/Alert";
 import { handleAlert } from "../../../../application/tools/alertUtils";
 import { AlertProps } from "../../../types/alert.types";
@@ -339,18 +340,7 @@ const AITrustCenterSettings: React.FC = () => {
 
   // Show loading state while data is being fetched
   if (loading || !formData) {
-    return (
-      <Box
-        sx={{
-          display: "flex",
-          justifyContent: "center",
-          alignItems: "center",
-          height: "200px",
-        }}
-      >
-        <CircularProgress />
-      </Box>
-    );
+    return <CustomizableSkeleton variant="rectangular" width="100%" height={400} />;
   }
 
   // Show error state if there's an error

--- a/Clients/src/presentation/pages/ApprovalWorkflows/ApprovalWorkflowsTable.tsx
+++ b/Clients/src/presentation/pages/ApprovalWorkflows/ApprovalWorkflowsTable.tsx
@@ -25,6 +25,7 @@ import { ApprovalWorkflowTableProps } from "src/presentation/types/interfaces/i.
 import { useStandardTable } from "../../../application/hooks/useStandardTable";
 import StandardTableHead from "../../components/Table/StandardTableHead";
 import StandardTablePagination from "../../components/Table/StandardTablePagination";
+import CustomizableSkeleton from "../../components/Skeletons";
 
 const cellStyle = singleTheme.tableStyles.primary.body.cell;
 
@@ -61,6 +62,7 @@ function workflowSortComparator(
 
 const ApprovalWorkflowsTable: React.FC<ApprovalWorkflowTableProps> = ({
   data,
+  isLoading = false,
   onEdit,
   onArchive,
   archivedId,
@@ -96,6 +98,10 @@ const ApprovalWorkflowsTable: React.FC<ApprovalWorkflowTableProps> = ({
     defaultSortDirection: null,
     sortComparator: workflowSortComparator,
   });
+
+  if (isLoading) {
+    return <CustomizableSkeleton variant="rectangular" width="100%" height={400} />;
+  }
 
   if (!sortedRows || sortedRows.length === 0) {
     return (

--- a/Clients/src/presentation/pages/Framework/index.tsx
+++ b/Clients/src/presentation/pages/Framework/index.tsx
@@ -17,6 +17,7 @@ import {
   Pencil as EditIconGrey,
   ChevronDown as WhiteDownArrowIcon,
 } from "lucide-react";
+import CustomizableSkeleton from "../../components/Skeletons";
 import { VerifyWiseContext } from "../../../application/contexts/VerifyWise.context";
 import { usePluginRegistry } from "../../../application/contexts/PluginRegistry.context";
 import useMultipleOnScreen from "../../../application/hooks/useMultipleOnScreen";
@@ -511,13 +512,7 @@ const Framework = () => {
 
   const renderFrameworkContent = () => {
     if (loading) {
-      return (
-        <Box sx={{ textAlign: "center", py: 8 }}>
-          <Typography variant="body1" color="text.secondary">
-            Loading framework information...
-          </Typography>
-        </Box>
-      );
+      return <CustomizableSkeleton variant="rectangular" width="100%" height={400} />;
     }
 
     if (error) {


### PR DESCRIPTION
Replace spinners and text placeholders with consistent table-style skeletons on Frameworks, Approval Workflows, and AI Trust Center.

## Describe your changes

Provide a concise description of the changes made and their intended purpose.

## Write your issue number after "Fixes "

Fixes #4170 

## Please ensure all items are checked off before requesting a review:

- [x] I deployed the code locally.
- [ ] I have performed a self-review of my code.
- [x] I have included the issue # in the PR.
- [x] I have labelled the PR correctly.
- [x] The issue I am working on is assigned to me.
- [x] I have avoided using hardcoded values to ensure scalability and maintain consistency across the application.
- [x] I have ensured that font sizes, color choices, and other UI elements are referenced from the theme.
- [x] My pull request is focused and addresses a single, specific feature.
- [x] If there are UI changes, I have attached a screenshot or video to this PR.
- [ ] If I added or modified an API endpoint, the change is reflected in the generated OpenAPI spec (`npm run generate:swagger`).
- [ ] If the endpoint requires authentication, it uses `authenticateJWT` and the generated spec declares `bearerAuth` security.
- [ ] I ran `npm run check:api-drift` and committed the regenerated `swagger.yaml` and `endpoints.ts`.

<img width="1505" height="831" alt="Screenshot 2026-06-22 at 6 56 09 PM" src="https://github.com/user-attachments/assets/2f3a7aa5-2c6f-47c5-bbd8-3092182db483" />
<img width="1519" height="699" alt="Screenshot 2026-06-22 at 7 16 11 PM" src="https://github.com/user-attachments/assets/97a624c7-4d5f-4fa9-a1d2-4cb632a27821" />

<img width="1571" height="1155" alt="Screenshot 2026-06-22 at 7 10 00 PM" src="https://github.com/user-attachments/assets/e4bc4566-21f4-441c-9ea1-04fbcea075c4" />


