### PR TITLE
Reorder app switcher sidebar modules

### DIFF
--- a/Clients/src/presentation/components/AppSwitcher/index.tsx
+++ b/Clients/src/presentation/components/AppSwitcher/index.tsx
@@ -32,18 +32,6 @@ const modules: ModuleItem[] = [
     description: "Evaluate LLM quality, performance and reliability over time",
   },
   {
-    id: "ai-detection",
-    icon: <ScanSearch size={16} strokeWidth={1.5} />,
-    label: "AI Detection",
-    description: "Scan repositories to detect AI/ML libraries and frameworks",
-  },
-  {
-    id: "shadow-ai",
-    icon: <Eye size={16} strokeWidth={1.5} />,
-    label: "Shadow AI",
-    description: "Detect and govern unauthorized AI tool usage across your organization",
-  },
-  {
     id: "ai-gateway",
     icon: <Router size={16} strokeWidth={1.5} />,
     label: "AI Gateway",
@@ -54,6 +42,18 @@ const modules: ModuleItem[] = [
     icon: <Gauge size={16} strokeWidth={1.5} />,
     label: "AI Trust Index",
     description: "Browse AI app risk scores and track the apps you use",
+  },
+  {
+    id: "shadow-ai",
+    icon: <Eye size={16} strokeWidth={1.5} />,
+    label: "Shadow AI",
+    description: "Detect and govern unauthorized AI tool usage across your organization",
+  },
+  {
+    id: "ai-detection",
+    icon: <ScanSearch size={16} strokeWidth={1.5} />,
+    label: "AI Detection",
+    description: "Scan repositories to detect AI/ML libraries and frameworks",
   },
 ];
 


### PR DESCRIPTION
## Changes

Reorders the dark icon sidebar (app switcher) to:

1. Governance
2. LLM Evals
3. AI Gateway
4. AI Trust Index
5. Shadow AI
6. AI Detection

Super Admin continues to appear last for super-admin users.

## Benefits

Groups the modules in a more intuitive order, with the AI governance and gateway modules surfaced higher.

## Notes

- Pure array reorder in `AppSwitcher/index.tsx`. Module ids, icons, routing, and the conditional super-admin entry are unchanged.
- Build, typecheck, and format-check all pass locally.