### PR TITLE
Bump litellm SDK 1.83.7 to 1.89.3

### DIFF
--- a/AIGateway/requirements.txt
+++ b/AIGateway/requirements.txt
@@ -14,7 +14,7 @@ asyncpg>=0.30.0
 
 # LiteLLM SDK (MIT licensed)
 # Pinned to a specific version — updated per VerifyWise release
-litellm==1.83.7
+litellm==1.89.3
 
 # Database migrations (Alembic)
 sqlalchemy[asyncio]>=2.0.0


### PR DESCRIPTION
## Changes

Updates the pinned LiteLLM SDK in `AIGateway/requirements.txt` from `1.83.7` to the latest stable release `1.89.3`.

## Compatibility

The gateway uses the LiteLLM SDK directly (not the LiteLLM proxy server) across 5 files, with a small, well-contained surface. Every API the code calls was verified against a fresh `1.89.3` install:

- `acompletion`, `aembedding`
- `completion_cost(completion_response=...)`, `cost_per_token(...)`, `token_counter(...)`, `get_model_info(...)`
- `model_cost` iteration (`litellm_provider`, `mode`, cost fields)
- `suppress_debug_info` flag
- Response handling: `ModelResponse.model_dump()`, `.usage.*`, `.choices[0].delta.content`, and the private `._hidden_params` fallback used for non-catalogued models (e.g. OpenRouter)

All are signature-compatible — the affected functions only gained optional parameters. The `cost_service` and `llm_service` modules import cleanly under `1.89.3`.

The "important behavior changes" across 1.84-1.89 are LiteLLM proxy-server concerns (pass-through endpoint auth defaults, MCP header forwarding, client-tag handling, Prometheus bucket cardinality) and do not affect SDK usage.

## Verification

- Offline smoke test against a real `1.89.3` install: token counting, per-token cost, `completion_cost` on a built `ModelResponse`, `get_model_info`, and `model_cost` iteration all return correct values.
- Service module imports succeed under the new version.
- Not run here: the gateway E2E suite under `AIGateway/tests/` requires a live backend, gateway, database, and provider API keys. Recommend running it against the new pin in an environment that has the full stack before release.