### PR TITLE
Feat: Centralize presentation date formatting utilities

### DIFF
--- a/Clients/src/presentation/components/AIContentReviewPanel/index.tsx
+++ b/Clients/src/presentation/components/AIContentReviewPanel/index.tsx
@@ -11,6 +11,10 @@ import {
 import Chip from "../Chip";
 import AIContentBadge from "../AIContentBadge";
 import type { AIContentMetadata, ReviewAction } from "../../../domain/interfaces/i.aiContent";
+import {
+  displayFormattedDate,
+  displayFormattedDateTime,
+} from "src/presentation/tools/isoDateToString";
 
 interface AIContentReviewPanelProps {
   item: AIContentMetadata;
@@ -29,15 +33,7 @@ export default function AIContentReviewPanel({
 }: AIContentReviewPanelProps) {
   const [notes, setNotes] = useState("");
 
-  const createdDate = item.created_at
-    ? new Date(item.created_at).toLocaleDateString("en-US", {
-        month: "short",
-        day: "numeric",
-        year: "numeric",
-        hour: "2-digit",
-        minute: "2-digit",
-      })
-    : "";
+  const createdDate = item.created_at ? displayFormattedDateTime(item.created_at) : "";
 
   return (
     <Box
@@ -225,7 +221,7 @@ export default function AIContentReviewPanel({
             <CheckCircle size={16} style={{ color: accent.primary.text }} />
             <Typography sx={{ fontSize: 13, color: accent.primary.text, fontWeight: 500 }}>
               {item.review_action.charAt(0).toUpperCase() + item.review_action.slice(1)}
-              {item.reviewed_at && ` on ${new Date(item.reviewed_at).toLocaleDateString()}`}
+              {item.reviewed_at && ` on ${displayFormattedDate(item.reviewed_at)}`}
             </Typography>
           </Stack>
         )}

--- a/Clients/src/presentation/components/AIContentReviewPanel/index.tsx
+++ b/Clients/src/presentation/components/AIContentReviewPanel/index.tsx
@@ -11,10 +11,7 @@ import {
 import Chip from "../Chip";
 import AIContentBadge from "../AIContentBadge";
 import type { AIContentMetadata, ReviewAction } from "../../../domain/interfaces/i.aiContent";
-import {
-  displayFormattedDate,
-  displayFormattedDateTime,
-} from "src/presentation/tools/isoDateToString";
+import { displayFormattedDate, displayFormattedDateTime } from "../../tools/isoDateToString";
 
 interface AIContentReviewPanelProps {
   item: AIContentMetadata;

--- a/Clients/src/presentation/components/Common/HistorySidebar/index.tsx
+++ b/Clients/src/presentation/components/Common/HistorySidebar/index.tsx
@@ -11,6 +11,7 @@ import { useProfilePhotoFetch } from "../../../../application/hooks/useProfilePh
 import { EntityType, getEntityHistoryConfig } from "../../../../config/changeHistory.config";
 import dayjs from "dayjs";
 import relativeTime from "dayjs/plugin/relativeTime";
+import { displayFormattedDate, displayFormattedTime } from "../../../tools/isoDateToString";
 
 dayjs.extend(relativeTime);
 
@@ -57,16 +58,16 @@ const formatRelativeTime = (date: string | Date): string => {
   if (diffHours < 24 && targetDate.isSame(now, "day")) {
     if (diffHours === 1) return "An hour ago";
     if (diffHours < 3) return "A few hours ago";
-    return `Today at ${targetDate.format("h:mm A")}`;
+    return `Today at ${displayFormattedTime(date)}`;
   }
 
   // Yesterday
   if (diffDays === 1 || (diffHours < 48 && targetDate.isSame(now.subtract(1, "day"), "day"))) {
-    return `Yesterday at ${targetDate.format("h:mm A")}`;
+    return `Yesterday at ${displayFormattedTime(date)}`;
   }
 
   // Older than yesterday - show full date and time
-  return `${targetDate.format("MMMM D, YYYY")} at ${targetDate.format("h:mm A")}`;
+  return `${displayFormattedDate(date)} at ${displayFormattedTime(date)}`;
 };
 
 export function HistorySidebar({
@@ -183,8 +184,8 @@ export function HistorySidebar({
           ? `${creationEntry.user_name} ${creationEntry.user_surname}`
           : creationEntry.user_email || "an unknown user";
 
-    const creationDate = dayjs(creationEntry.changed_at).format("MMMM D, YYYY");
-    const creationTime = dayjs(creationEntry.changed_at).format("h:mm A");
+    const creationDate = displayFormattedDate(creationEntry.changed_at);
+    const creationTime = displayFormattedTime(creationEntry.changed_at);
 
     return { creatorName, creationDate, creationTime };
   }, [creationEntry, currentUserId]);
@@ -199,8 +200,8 @@ export function HistorySidebar({
     );
     const lastEntry = sortedHistory[0];
 
-    const updateDate = dayjs(lastEntry.changed_at).format("MMMM D, YYYY");
-    const updateTime = dayjs(lastEntry.changed_at).format("h:mm A");
+    const updateDate = displayFormattedDate(lastEntry.changed_at);
+    const updateTime = displayFormattedTime(lastEntry.changed_at);
 
     return { updateDate, updateTime };
   }, [history]);

--- a/Clients/src/presentation/components/FilePickerModal/index.tsx
+++ b/Clients/src/presentation/components/FilePickerModal/index.tsx
@@ -23,6 +23,7 @@ import {
   FileMetadata,
 } from "../../../application/repository/file.repository";
 import { FileData } from "../../../domain/types/File";
+import { displayFormattedDate } from "../../tools/isoDateToString";
 
 interface FilePickerModalProps {
   open: boolean;
@@ -52,12 +53,7 @@ const formatFileSize = (bytes?: number): string => {
 
 const formatDate = (dateStr?: string): string => {
   if (!dateStr) return "";
-  const date = new Date(dateStr);
-  return date.toLocaleDateString(undefined, {
-    month: "short",
-    day: "numeric",
-    year: "numeric",
-  });
+  return displayFormattedDate(dateStr);
 };
 
 export const FilePickerModal: FC<FilePickerModalProps> = ({

--- a/Clients/src/presentation/components/GovernanceOS/ActivationHistory.tsx
+++ b/Clients/src/presentation/components/GovernanceOS/ActivationHistory.tsx
@@ -8,6 +8,7 @@ import {
 import GovernanceTooltip from "./GovernanceTooltip";
 import { CustomizableButton } from "../button/customizable-button";
 import { border as borderPalette, background, text, brand, status } from "../../themes/palette";
+import { displayFormattedDate } from "src/presentation/tools/isoDateToString";
 
 const ActivationHistory: React.FC = () => {
   const { data: activations, isLoading } = useActivationHistory();
@@ -63,7 +64,7 @@ const ActivationHistory: React.FC = () => {
         {activations.slice(0, 5).map((activation: any) => {
           const isActive = activation.status === "active";
           const date = activation.activated_at
-            ? new Date(activation.activated_at).toLocaleDateString()
+            ? displayFormattedDate(activation.activated_at)
             : "—";
 
           return (

--- a/Clients/src/presentation/components/GovernanceOS/ActivationHistory.tsx
+++ b/Clients/src/presentation/components/GovernanceOS/ActivationHistory.tsx
@@ -8,7 +8,7 @@ import {
 import GovernanceTooltip from "./GovernanceTooltip";
 import { CustomizableButton } from "../button/customizable-button";
 import { border as borderPalette, background, text, brand, status } from "../../themes/palette";
-import { displayFormattedDate } from "src/presentation/tools/isoDateToString";
+import { displayFormattedDate } from "../../tools/isoDateToString";
 
 const ActivationHistory: React.FC = () => {
   const { data: activations, isLoading } = useActivationHistory();

--- a/Clients/src/presentation/components/GovernanceOS/ActiveScenarioPanel.tsx
+++ b/Clients/src/presentation/components/GovernanceOS/ActiveScenarioPanel.tsx
@@ -20,7 +20,7 @@ import FrameworkChip from "./FrameworkChip";
 import GovernanceTooltip from "./GovernanceTooltip";
 import { CustomizableButton } from "../button/customizable-button";
 import { border as borderPalette, background, text, brand, status } from "../../themes/palette";
-import { displayFormattedDate } from "src/presentation/tools/isoDateToString";
+import { displayFormattedDate } from "../../tools/isoDateToString";
 
 interface ActiveScenarioPanelProps {
   activeScenario: IGovernanceScenario | null | undefined;

--- a/Clients/src/presentation/components/GovernanceOS/ActiveScenarioPanel.tsx
+++ b/Clients/src/presentation/components/GovernanceOS/ActiveScenarioPanel.tsx
@@ -20,6 +20,7 @@ import FrameworkChip from "./FrameworkChip";
 import GovernanceTooltip from "./GovernanceTooltip";
 import { CustomizableButton } from "../button/customizable-button";
 import { border as borderPalette, background, text, brand, status } from "../../themes/palette";
+import { displayFormattedDate } from "src/presentation/tools/isoDateToString";
 
 interface ActiveScenarioPanelProps {
   activeScenario: IGovernanceScenario | null | undefined;
@@ -89,7 +90,7 @@ const ActiveScenarioPanel: React.FC<ActiveScenarioPanelProps> = ({
   ].filter(Boolean) as number[];
 
   const activationDate = latestActivation?.activated_at
-    ? new Date(latestActivation.activated_at).toLocaleDateString()
+    ? displayFormattedDate(latestActivation.activated_at)
     : null;
 
   return (

--- a/Clients/src/presentation/components/Modals/AgentDiscovery/ReviewAgentModal.tsx
+++ b/Clients/src/presentation/components/Modals/AgentDiscovery/ReviewAgentModal.tsx
@@ -5,7 +5,7 @@ import VWChip from "../../Chip";
 import { CustomizableButton } from "../../button/customizable-button";
 import { apiServices } from "../../../../infrastructure/api/networkServices";
 import { AgentPrimitiveRow } from "../../../../domain/interfaces/i.agentDiscovery";
-import { displayFormattedDateTime } from "src/presentation/tools/isoDateToString";
+import { displayFormattedDateTime } from "../../../tools/isoDateToString";
 import { getAllEntities } from "../../../../application/repository/entity.repository";
 import LinkModelModal from "./LinkModelModal";
 

--- a/Clients/src/presentation/components/Modals/AgentDiscovery/ReviewAgentModal.tsx
+++ b/Clients/src/presentation/components/Modals/AgentDiscovery/ReviewAgentModal.tsx
@@ -5,6 +5,7 @@ import VWChip from "../../Chip";
 import { CustomizableButton } from "../../button/customizable-button";
 import { apiServices } from "../../../../infrastructure/api/networkServices";
 import { AgentPrimitiveRow } from "../../../../domain/interfaces/i.agentDiscovery";
+import { displayFormattedDateTime } from "src/presentation/tools/isoDateToString";
 import { getAllEntities } from "../../../../application/repository/entity.repository";
 import LinkModelModal from "./LinkModelModal";
 
@@ -83,13 +84,7 @@ const ReviewAgentModal: React.FC<ReviewAgentModalProps> = ({
 
   const formatDate = (dateStr: string | null) => {
     if (!dateStr) return "—";
-    return new Date(dateStr).toLocaleDateString("en-US", {
-      year: "numeric",
-      month: "long",
-      day: "numeric",
-      hour: "2-digit",
-      minute: "2-digit",
-    });
+    return displayFormattedDateTime(dateStr);
   };
 
   return (

--- a/Clients/src/presentation/components/Modals/RequestorApprovalModal/entityTypeConfig.tsx
+++ b/Clients/src/presentation/components/Modals/RequestorApprovalModal/entityTypeConfig.tsx
@@ -23,7 +23,7 @@ import {
   AlertTriangle,
   Wrench,
 } from "lucide-react";
-import dayjs from "dayjs";
+import { displayFormattedDate, displayFormattedDateTime } from "../../../tools/isoDateToString";
 
 // Supported entity types
 export type EntityTypeKey =
@@ -60,8 +60,8 @@ export interface EntityTypeConfig {
 }
 
 // Format helpers
-const formatDate = (value: any) => dayjs(value).format("YYYY-MM-DD, HH:mm");
-const formatDateOnly = (value: any) => dayjs(value).format("YYYY-MM-DD");
+const formatDate = (value: any) => displayFormattedDateTime(value);
+const formatDateOnly = (value: any) => displayFormattedDate(value);
 const formatFileSize = (value: any) => {
   if (!value) return "";
   const kb = value / 1024;

--- a/Clients/src/presentation/components/Modals/RequestorApprovalModal/index.tsx
+++ b/Clients/src/presentation/components/Modals/RequestorApprovalModal/index.tsx
@@ -53,9 +53,9 @@ import {
   ApprovalStepStatus,
 } from "../../../../domain/enums/aiApprovalWorkflow.enum";
 import StepDetailsModal from "./StepDetailsModal";
-import dayjs from "dayjs";
 import DualButtonModal from "../../Dialogs/ConfirmationModal";
 import Field from "../../Inputs/Field";
+import { displayFormattedDateTime } from "../../../tools/isoDateToString";
 import {
   IMenuItemExtended,
   IRequestorApprovalProps,
@@ -749,7 +749,7 @@ const RequestorApprovalModal: FC<IRequestorApprovalProps> = ({ isOpen, onClose, 
                         <DetailField
                           icon={<Calendar size={14} />}
                           label="Created"
-                          value={dayjs(requestDetails.dateCreated).format("YYYY-MM-DD, HH:mm")}
+                          value={displayFormattedDateTime(requestDetails.dateCreated)}
                         />
                       )}
                     </Stack>
@@ -793,7 +793,7 @@ const RequestorApprovalModal: FC<IRequestorApprovalProps> = ({ isOpen, onClose, 
                               <Typography sx={stepTitleStyle}>{step.title}</Typography>
                               {step.status === ApprovalStepStatus.Completed && step.date && (
                                 <Typography sx={stepDateStyle}>
-                                  {dayjs(step.date).format("MMM DD, YYYY HH:mm")}
+                                  {displayFormattedDateTime(step.date)}
                                 </Typography>
                               )}
                             </Stack>

--- a/Clients/src/presentation/components/ModelInventoryHistory/HistorySidebar.tsx
+++ b/Clients/src/presentation/components/ModelInventoryHistory/HistorySidebar.tsx
@@ -11,6 +11,7 @@ import { useProfilePhotoFetch } from "../../../application/hooks/useProfilePhoto
 import dayjs from "dayjs";
 import relativeTime from "dayjs/plugin/relativeTime";
 import { brand } from "../../themes/palette";
+import { displayFormattedDate, displayFormattedTime } from "../../tools/isoDateToString";
 
 dayjs.extend(relativeTime);
 
@@ -53,16 +54,16 @@ const formatRelativeTime = (date: string | Date): string => {
   if (diffHours < 24 && targetDate.isSame(now, "day")) {
     if (diffHours === 1) return "An hour ago";
     if (diffHours < 3) return "A few hours ago";
-    return `Today at ${targetDate.format("h:mm A")}`;
+    return `Today at ${displayFormattedTime(date)}`;
   }
 
   // Yesterday
   if (diffDays === 1 || (diffHours < 48 && targetDate.isSame(now.subtract(1, "day"), "day"))) {
-    return `Yesterday at ${targetDate.format("h:mm A")}`;
+    return `Yesterday at ${displayFormattedTime(date)}`;
   }
 
   // Older than yesterday - show full date and time
-  return `${targetDate.format("MMMM D, YYYY")} at ${targetDate.format("h:mm A")}`;
+  return `${displayFormattedDate(date)} at ${displayFormattedTime(date)}`;
 };
 
 const HistorySidebar: React.FC<HistorySidebarProps> = ({ isOpen, modelInventoryId }) => {
@@ -142,8 +143,8 @@ const HistorySidebar: React.FC<HistorySidebarProps> = ({ isOpen, modelInventoryI
         ? `${creationEntry.user_name} ${creationEntry.user_surname}`
         : creationEntry.user_email || "Unknown User";
 
-    const creationDate = dayjs(creationEntry.changed_at).format("MMMM D, YYYY");
-    const creationTime = dayjs(creationEntry.changed_at).format("h:mm A");
+    const creationDate = displayFormattedDate(creationEntry.changed_at);
+    const creationTime = displayFormattedTime(creationEntry.changed_at);
 
     return { creatorName, creationDate, creationTime };
   }, [creationEntry, currentUserId]);
@@ -158,8 +159,8 @@ const HistorySidebar: React.FC<HistorySidebarProps> = ({ isOpen, modelInventoryI
     );
     const lastEntry = sortedHistory[0];
 
-    const updateDate = dayjs(lastEntry.changed_at).format("MMMM D, YYYY");
-    const updateTime = dayjs(lastEntry.changed_at).format("h:mm A");
+    const updateDate = displayFormattedDate(lastEntry.changed_at);
+    const updateTime = displayFormattedTime(lastEntry.changed_at);
 
     return { updateDate, updateTime };
   }, [history]);

--- a/Clients/src/presentation/components/NotificationBell/index.tsx
+++ b/Clients/src/presentation/components/NotificationBell/index.tsx
@@ -16,6 +16,7 @@ import VWTooltip from "../VWTooltip";
 import "../Layout/icon-shake.css";
 
 import { text } from "../../themes/palette";
+import { displayFormattedDate } from "src/presentation/tools/isoDateToString";
 
 /**
  * Rewrite legacy action_url values that were stored in older notifications
@@ -60,7 +61,7 @@ const formatRelativeTime = (dateString: string): string => {
   if (minutes < 60) return `${minutes}m ago`;
   if (hours < 24) return `${hours}h ago`;
   if (days < 7) return `${days}d ago`;
-  return date.toLocaleDateString();
+  return displayFormattedDate(date);
 };
 
 /**

--- a/Clients/src/presentation/components/NotificationBell/index.tsx
+++ b/Clients/src/presentation/components/NotificationBell/index.tsx
@@ -16,7 +16,7 @@ import VWTooltip from "../VWTooltip";
 import "../Layout/icon-shake.css";
 
 import { text } from "../../themes/palette";
-import { displayFormattedDate } from "src/presentation/tools/isoDateToString";
+import { displayFormattedDate } from "../../tools/isoDateToString";
 
 /**
  * Rewrite legacy action_url values that were stored in older notifications

--- a/Clients/src/presentation/components/Policies/LinkEvidenceSelectorModal.tsx
+++ b/Clients/src/presentation/components/Policies/LinkEvidenceSelectorModal.tsx
@@ -35,6 +35,7 @@ import { paginationStyle } from "../Table/styles";
 import { FileIcon } from "../FileIcon";
 import { getUserFilesMetaData } from "../../../application/repository/file.repository";
 import CustomizableToast from "../../components/Toast";
+import { displayFormattedDate } from "src/presentation/tools/isoDateToString";
 
 const SORT_KEY = "vw_link_evidence_selector_sort";
 
@@ -310,9 +311,7 @@ const LinkEvidenceSelectorModal: React.FC<LinkEvidenceSelectorModalProps> = ({
                   <TableCell>{ev.uploader_name}</TableCell>
 
                   <TableCell>
-                    {ev.upload_date !== "-"
-                      ? new Date(ev.upload_date).toLocaleDateString("en-GB")
-                      : "-"}
+                    {ev.upload_date !== "-" ? displayFormattedDate(ev.upload_date) : "-"}
                   </TableCell>
 
                   <TableCell width={50}>

--- a/Clients/src/presentation/components/Policies/LinkEvidenceSelectorModal.tsx
+++ b/Clients/src/presentation/components/Policies/LinkEvidenceSelectorModal.tsx
@@ -35,7 +35,7 @@ import { paginationStyle } from "../Table/styles";
 import { FileIcon } from "../FileIcon";
 import { getUserFilesMetaData } from "../../../application/repository/file.repository";
 import CustomizableToast from "../../components/Toast";
-import { displayFormattedDate } from "src/presentation/tools/isoDateToString";
+import { displayFormattedDate } from "../../tools/isoDateToString";
 
 const SORT_KEY = "vw_link_evidence_selector_sort";
 

--- a/Clients/src/presentation/components/Policies/LinkedPoliciesTable.tsx
+++ b/Clients/src/presentation/components/Policies/LinkedPoliciesTable.tsx
@@ -34,6 +34,7 @@ import {
 import { singleTheme } from "../../themes";
 import { useUserMap } from "../../../presentation/hooks/userMap";
 import { text } from "../../themes/palette";
+import { displayFormattedDate } from "src/presentation/tools/isoDateToString";
 
 interface LinkedObjectsTableProps {
   items: any[];
@@ -327,9 +328,7 @@ const LinkedObjectsTable: React.FC<LinkedObjectsTableProps> = ({
                 </TableCell>
                 {type === "risk" && (
                   <TableCell sx={singleTheme.tableStyles.primary.body.cell}>
-                    {row.due_date !== "-"
-                      ? new Date(row.due_date).toLocaleDateString("en-GB")
-                      : "-"}
+                    {row.due_date !== "-" ? displayFormattedDate(row.due_date) : "-"}
                   </TableCell>
                 )}
 

--- a/Clients/src/presentation/components/Policies/LinkedPoliciesTable.tsx
+++ b/Clients/src/presentation/components/Policies/LinkedPoliciesTable.tsx
@@ -34,7 +34,7 @@ import {
 import { singleTheme } from "../../themes";
 import { useUserMap } from "../../../presentation/hooks/userMap";
 import { text } from "../../themes/palette";
-import { displayFormattedDate } from "src/presentation/tools/isoDateToString";
+import { displayFormattedDate } from "../../tools/isoDateToString";
 
 interface LinkedObjectsTableProps {
   items: any[];

--- a/Clients/src/presentation/components/Policies/PolicyTable.tsx
+++ b/Clients/src/presentation/components/Policies/PolicyTable.tsx
@@ -18,10 +18,7 @@ import { POLICY_TAGS } from "../../../domain/models/Common/policy/policyManager.
 import { store } from "../../../application/redux/store";
 import { useCustomFieldDefinitions } from "../../../application/hooks/useCustomFields";
 import { formatCustomFieldValue } from "../CustomFieldsSection/formatCustomFieldValue";
-import {
-  displayFormattedDate,
-  displayFormattedDateTime,
-} from "src/presentation/tools/isoDateToString";
+import { displayFormattedDate, displayFormattedDateTime } from "../../tools/isoDateToString";
 
 const tableHeaders = [
   { id: "title", name: "Title" },

--- a/Clients/src/presentation/components/Policies/PolicyTable.tsx
+++ b/Clients/src/presentation/components/Policies/PolicyTable.tsx
@@ -18,6 +18,10 @@ import { POLICY_TAGS } from "../../../domain/models/Common/policy/policyManager.
 import { store } from "../../../application/redux/store";
 import { useCustomFieldDefinitions } from "../../../application/hooks/useCustomFields";
 import { formatCustomFieldValue } from "../CustomFieldsSection/formatCustomFieldValue";
+import {
+  displayFormattedDate,
+  displayFormattedDateTime,
+} from "src/presentation/tools/isoDateToString";
 
 const tableHeaders = [
   { id: "title", name: "Title" },
@@ -391,9 +395,7 @@ const PolicyTable: React.FC<PolicyTableProps> = ({
                       : undefined,
                 }}
               >
-                {policy.next_review_date
-                  ? new Date(policy.next_review_date).toLocaleDateString()
-                  : "-"}
+                {policy.next_review_date ? displayFormattedDate(policy.next_review_date) : "-"}
               </TableCell>
             )}
             {isVisible("author") && (
@@ -427,7 +429,7 @@ const PolicyTable: React.FC<PolicyTableProps> = ({
                       : undefined,
                 }}
               >
-                {policy.last_updated_at ? new Date(policy.last_updated_at).toLocaleString() : "-"}
+                {policy.last_updated_at ? displayFormattedDateTime(policy.last_updated_at) : "-"}
               </TableCell>
             )}
             {isVisible("updated_by") && (

--- a/Clients/src/presentation/components/ProjectsList/ProjectTableView.tsx
+++ b/Clients/src/presentation/components/ProjectsList/ProjectTableView.tsx
@@ -33,6 +33,7 @@ import EmptyStateTip from "../EmptyState/EmptyStateTip";
 import { TableEmptyStateLayout } from "../Table/TableEmptyStateLayout";
 import { IProjectTableViewProps } from "../../../domain/interfaces/i.project";
 import { Project } from "../../../domain/types/Project";
+import { displayFormattedDate } from "../../tools/isoDateToString";
 import { deleteProject } from "../../../application/repository/project.repository";
 import { VerifyWiseContext } from "../../../application/contexts/VerifyWise.context";
 import Alert from "../Alert";
@@ -236,11 +237,7 @@ const ProjectTableView: React.FC<IProjectTableViewProps> = ({
   }, []);
 
   const formatDate = (date: Date) => {
-    return new Date(date).toLocaleDateString("en-US", {
-      year: "numeric",
-      month: "short",
-      day: "numeric",
-    });
+    return displayFormattedDate(date);
   };
 
   const handleChangePage = useCallback((_event: unknown, newPage: number) => {

--- a/Clients/src/presentation/components/ProjectsList/ProjectsList.tsx
+++ b/Clients/src/presentation/components/ProjectsList/ProjectsList.tsx
@@ -21,7 +21,7 @@ import { useColumnVisibility, ColumnConfig } from "../../../application/hooks/us
 import CustomizableSkeleton from "../Skeletons";
 
 import { projectWrapperStyle, noProjectsTextStyle, vwhomeBodyProjectsGrid } from "./style";
-import { displayFormattedDate } from "src/presentation/tools/isoDateToString";
+import { displayFormattedDate } from "../../tools/isoDateToString";
 
 const ProjectList = ({
   projects,

--- a/Clients/src/presentation/components/ProjectsList/ProjectsList.tsx
+++ b/Clients/src/presentation/components/ProjectsList/ProjectsList.tsx
@@ -21,6 +21,7 @@ import { useColumnVisibility, ColumnConfig } from "../../../application/hooks/us
 import CustomizableSkeleton from "../Skeletons";
 
 import { projectWrapperStyle, noProjectsTextStyle, vwhomeBodyProjectsGrid } from "./style";
+import { displayFormattedDate } from "src/presentation/tools/isoDateToString";
 
 const ProjectList = ({
   projects,
@@ -316,10 +317,8 @@ const ProjectList = ({
         project_title: project.project_title || "-",
         ai_risk_classification: project.ai_risk_classification || "-",
         type_of_high_risk_role: project.type_of_high_risk_role?.replace(/_/g, " ") || "-",
-        start_date: project.start_date ? new Date(project.start_date).toLocaleDateString() : "-",
-        last_updated: project.last_updated
-          ? new Date(project.last_updated).toLocaleDateString()
-          : "-",
+        start_date: project.start_date ? displayFormattedDate(project.start_date) : "-",
+        last_updated: project.last_updated ? displayFormattedDate(project.last_updated) : "-",
         owner: ownerName,
         status: project.status || "-",
       };

--- a/Clients/src/presentation/components/ReadinessTrend/index.tsx
+++ b/Clients/src/presentation/components/ReadinessTrend/index.tsx
@@ -1,6 +1,7 @@
 import { Box, Typography, LinearProgress } from "@mui/material";
 import { status, accent, text as textColors, background } from "../../themes/palette";
 import type { FrameworkReadinessScore } from "../../../domain/interfaces/i.readiness";
+import { displayFormattedDateTime } from "../../tools/isoDateToString";
 
 interface ReadinessTrendProps {
   data: FrameworkReadinessScore[];
@@ -91,14 +92,7 @@ export default function ReadinessTrend({ data, isLoading }: ReadinessTrendProps)
       >
         {data.map((item, idx) => {
           const score = item.avg_score ?? 0;
-          const date = item.calculated_at
-            ? new Date(item.calculated_at).toLocaleDateString("en-US", {
-                month: "short",
-                day: "numeric",
-                hour: "2-digit",
-                minute: "2-digit",
-              })
-            : "";
+          const date = item.calculated_at ? displayFormattedDateTime(item.calculated_at) : "";
 
           return (
             <Box key={idx} sx={{ mb: 2, px: 0.5 }}>

--- a/Clients/src/presentation/components/RiskVisualization/RiskTimeline.tsx
+++ b/Clients/src/presentation/components/RiskVisualization/RiskTimeline.tsx
@@ -1,7 +1,9 @@
 import React, { useMemo } from "react";
 import { Box, Typography, Stack, Chip } from "@mui/material";
+import { format } from "date-fns";
 import { IRiskTimelineProps } from "../../types/interfaces/i.risk";
 import { ITimelineEvent } from "../../../domain/interfaces/i.widget";
+import { displayFormattedDate } from "../../tools/isoDateToString";
 
 const RiskTimeline: React.FC<IRiskTimelineProps> = ({ risks, onRiskSelect }) => {
   const getRiskLevelFromString = (level: string | number): number => {
@@ -72,10 +74,7 @@ const RiskTimeline: React.FC<IRiskTimelineProps> = ({ risks, onRiskSelect }) => 
   }, [risks]);
 
   const formatTime = (date: Date) => {
-    return date.toLocaleDateString(undefined, {
-      month: "short",
-      day: "numeric",
-    });
+    return displayFormattedDate(date);
   };
 
   // Group events by month for better organization
@@ -83,10 +82,7 @@ const RiskTimeline: React.FC<IRiskTimelineProps> = ({ risks, onRiskSelect }) => 
     const groups: { [key: string]: ITimelineEvent[] } = {};
 
     timelineEvents.forEach((event) => {
-      const monthKey = event.date.toLocaleDateString(undefined, {
-        year: "numeric",
-        month: "long",
-      });
+      const monthKey = format(event.date, "MMMM yyyy");
 
       if (!groups[monthKey]) {
         groups[monthKey] = [];

--- a/Clients/src/presentation/components/ShareViewDropdown/ManageShareLinks.tsx
+++ b/Clients/src/presentation/components/ShareViewDropdown/ManageShareLinks.tsx
@@ -8,7 +8,7 @@ import {
   useDeleteShareLink,
 } from "../../../application/hooks/useShare";
 import { brand, text, background } from "../../themes/palette";
-import { displayFormattedDate } from "src/presentation/tools/isoDateToString";
+import { displayFormattedDate } from "../../tools/isoDateToString";
 
 /**
  * Props for the ManageShareLinks component

--- a/Clients/src/presentation/components/ShareViewDropdown/ManageShareLinks.tsx
+++ b/Clients/src/presentation/components/ShareViewDropdown/ManageShareLinks.tsx
@@ -8,6 +8,7 @@ import {
   useDeleteShareLink,
 } from "../../../application/hooks/useShare";
 import { brand, text, background } from "../../themes/palette";
+import { displayFormattedDate } from "src/presentation/tools/isoDateToString";
 
 /**
  * Props for the ManageShareLinks component
@@ -192,7 +193,7 @@ const ManageShareLinks: React.FC<ManageShareLinksProps> = ({
                     mb: 0.5,
                   }}
                 >
-                  Created: {new Date(shareLink.created_at).toLocaleDateString()}
+                  Created: {displayFormattedDate(shareLink.created_at)}
                 </Typography>
                 <Typography
                   variant="body2"

--- a/Clients/src/presentation/components/Table/ArenaTable/ArenaTableBody.tsx
+++ b/Clients/src/presentation/components/Table/ArenaTable/ArenaTableBody.tsx
@@ -30,6 +30,7 @@ import singleTheme from "../../../themes/v1SingleTheme";
 import { ArenaRow } from "./index";
 import ConfirmationModal from "../../Dialogs/ConfirmationModal";
 import { CustomizableButton } from "../../button/customizable-button";
+import { displayFormattedDateTime } from "../../../tools/isoDateToString";
 
 interface ArenaTableBodyProps {
   rows: ArenaRow[];
@@ -45,19 +46,7 @@ interface ArenaTableBodyProps {
 
 const formatDate = (dateStr?: string | null): string => {
   if (!dateStr) return "-";
-  const date = new Date(dateStr);
-  return (
-    date.toLocaleDateString("en-US", {
-      month: "short",
-      day: "numeric",
-      year: "numeric",
-    }) +
-    ", " +
-    date.toLocaleTimeString("en-US", {
-      hour: "2-digit",
-      minute: "2-digit",
-    })
-  );
+  return displayFormattedDateTime(dateStr);
 };
 
 // Helper to get contestant name from string or object

--- a/Clients/src/presentation/components/Table/DatasetsTable/DatasetsTableBody.tsx
+++ b/Clients/src/presentation/components/Table/DatasetsTable/DatasetsTableBody.tsx
@@ -16,6 +16,7 @@ import Chip from "../../Chip";
 import singleTheme from "../../../themes/v1SingleTheme";
 import { DatasetRow } from "./index";
 import { text, background, status } from "../../../themes/palette";
+import { displayFormattedDateTime } from "../../../tools/isoDateToString";
 
 interface DatasetsTableBodyProps {
   rows: DatasetRow[];
@@ -82,19 +83,7 @@ const DatasetsTableBody: React.FC<DatasetsTableBodyProps> = ({
 
   const formatDate = (dateStr?: string | null): string => {
     if (!dateStr) return "-";
-    const date = new Date(dateStr);
-    return (
-      date.toLocaleDateString(undefined, {
-        month: "short",
-        day: "numeric",
-        year: "numeric",
-      }) +
-      ", " +
-      date.toLocaleTimeString(undefined, {
-        hour: "2-digit",
-        minute: "2-digit",
-      })
-    );
+    return displayFormattedDateTime(dateStr);
   };
 
   return (

--- a/Clients/src/presentation/components/Table/GroupBy.README.md
+++ b/Clients/src/presentation/components/Table/GroupBy.README.md
@@ -71,7 +71,7 @@ const getMyDataGroupKey = (item: MyDataType, field: string): string | string[] =
       return "Unassigned";
 
     case "date":
-      return item.date ? new Date(item.date).toLocaleDateString() : "No Date";
+      return item.date ? displayFormattedDate(item.date) : "No Date";
 
     default:
       return "Other";

--- a/Clients/src/presentation/components/Table/ModelsTable/ModelsTableBody.tsx
+++ b/Clients/src/presentation/components/Table/ModelsTable/ModelsTableBody.tsx
@@ -14,6 +14,7 @@ import singleTheme from "../../../themes/v1SingleTheme";
 import { ModelRow } from "./index";
 import { CustomizableButton } from "../../button/customizable-button";
 import { text, background, border as borderPalette, status } from "../../../themes/palette";
+import { displayFormattedDateTime } from "../../../tools/isoDateToString";
 
 interface ModelsTableBodyProps {
   rows: ModelRow[];
@@ -25,19 +26,7 @@ interface ModelsTableBodyProps {
 
 const formatDate = (dateStr?: string | null): string => {
   if (!dateStr) return "-";
-  const date = new Date(dateStr);
-  return (
-    date.toLocaleDateString("en-US", {
-      month: "short",
-      day: "numeric",
-      year: "numeric",
-    }) +
-    ", " +
-    date.toLocaleTimeString("en-US", {
-      hour: "2-digit",
-      minute: "2-digit",
-    })
-  );
+  return displayFormattedDateTime(dateStr);
 };
 
 // Provider color mapping for chips

--- a/Clients/src/presentation/components/Table/ModelsTable/__tests__/ModelsTableBody.test.tsx
+++ b/Clients/src/presentation/components/Table/ModelsTable/__tests__/ModelsTableBody.test.tsx
@@ -66,7 +66,7 @@ describe("ModelsTableBody", () => {
         <ModelsTableBody {...defaultProps} />
       </table>,
     );
-    expect(screen.getByText(/Jun 1, 2025/)).toBeInTheDocument();
+    expect(screen.getByText(/01-06-2025/)).toBeInTheDocument();
   });
 
   it("calls onRowClick when a row is clicked", async () => {

--- a/Clients/src/presentation/components/Table/PolicyTable/LinkedPolicyObjectTable.tsx
+++ b/Clients/src/presentation/components/Table/PolicyTable/LinkedPolicyObjectTable.tsx
@@ -32,6 +32,7 @@ import TablePaginationActions from "../../TablePagination";
 import { paginationStyle } from "../styles";
 import { useUserMap } from "../../../../../src/presentation/hooks/userMap";
 import { text } from "../../../themes/palette";
+import { displayFormattedDateTime } from "../../../tools/isoDateToString";
 
 interface LinkedPolicyObjectsTableProps {
   policies: any[];
@@ -331,7 +332,7 @@ const LinkedPolicyObjectsTable: React.FC<LinkedPolicyObjectsTableProps> = ({
                         : "inherit",
                   }}
                 >
-                  {row.last_updated_at ? new Date(row.last_updated_at).toLocaleString() : "-"}
+                  {row.last_updated_at ? displayFormattedDateTime(row.last_updated_at) : "-"}
                 </TableCell>
 
                 {/* LAST UPDATED BY */}

--- a/Clients/src/presentation/components/Table/ScorersTable/ScorersTableBody.tsx
+++ b/Clients/src/presentation/components/Table/ScorersTable/ScorersTableBody.tsx
@@ -13,6 +13,7 @@ import singleTheme from "../../../themes/v1SingleTheme";
 import { ScorerRow } from "./index";
 import { CustomizableButton } from "../../button/customizable-button";
 import { brand, text, background, border as borderPalette, status } from "../../../themes/palette";
+import { displayFormattedDateTime } from "../../../tools/isoDateToString";
 
 interface ScorersTableBodyProps {
   rows: ScorerRow[];
@@ -25,19 +26,7 @@ interface ScorersTableBodyProps {
 
 const formatDate = (dateStr?: string | null): string => {
   if (!dateStr) return "-";
-  const date = new Date(dateStr);
-  return (
-    date.toLocaleDateString(undefined, {
-      month: "short",
-      day: "numeric",
-      year: "numeric",
-    }) +
-    ", " +
-    date.toLocaleTimeString(undefined, {
-      hour: "2-digit",
-      minute: "2-digit",
-    })
-  );
+  return displayFormattedDateTime(dateStr);
 };
 
 const ScorersTableBody: React.FC<ScorersTableBodyProps> = ({

--- a/Clients/src/presentation/components/Table/UseCasesTable/index.tsx
+++ b/Clients/src/presentation/components/Table/UseCasesTable/index.tsx
@@ -11,6 +11,7 @@ import {
   LinearProgress,
 } from "@mui/material";
 import Chip from "../../Chip";
+import { displayFormattedDate } from "../../../tools/isoDateToString";
 
 export interface UseCaseRow {
   id: number;
@@ -40,7 +41,7 @@ const defaultFormatDate = (dateString: string): string => {
   if (diffDays === 1) return "Yesterday";
   if (diffDays < 7) return `${diffDays} days ago`;
   if (diffDays < 30) return `${Math.floor(diffDays / 7)} weeks ago`;
-  return date.toLocaleDateString();
+  return displayFormattedDate(date);
 };
 
 const headerCellStyle = {

--- a/Clients/src/presentation/pages/AIDetection/RepositoriesPage.tsx
+++ b/Clients/src/presentation/pages/AIDetection/RepositoriesPage.tsx
@@ -52,10 +52,7 @@ import AddRepositoryModal from "./AddRepositoryModal";
 import { palette } from "../../themes/palette";
 import singleTheme from "../../themes/v1SingleTheme";
 import { keyframes } from "@mui/system";
-import {
-  displayFormattedDate,
-  displayFormattedDateTime,
-} from "src/presentation/tools/isoDateToString";
+import { displayFormattedDate, displayFormattedDateTime } from "../../tools/isoDateToString";
 
 const spin = keyframes`from { transform: rotate(0deg); } to { transform: rotate(360deg); }`;
 

--- a/Clients/src/presentation/pages/AIDetection/RepositoriesPage.tsx
+++ b/Clients/src/presentation/pages/AIDetection/RepositoriesPage.tsx
@@ -52,6 +52,10 @@ import AddRepositoryModal from "./AddRepositoryModal";
 import { palette } from "../../themes/palette";
 import singleTheme from "../../themes/v1SingleTheme";
 import { keyframes } from "@mui/system";
+import {
+  displayFormattedDate,
+  displayFormattedDateTime,
+} from "src/presentation/tools/isoDateToString";
 
 const spin = keyframes`from { transform: rotate(0deg); } to { transform: rotate(360deg); }`;
 
@@ -101,19 +105,12 @@ function formatRelativeTime(dateStr: string | null | undefined): string {
   if (diffMins < 60) return `${diffMins}m ago`;
   if (diffHours < 24) return `${diffHours}h ago`;
   if (diffDays < 30) return `${diffDays}d ago`;
-  return date.toLocaleDateString();
+  return displayFormattedDate(date);
 }
 
 function formatNextScan(dateStr: string | null | undefined): string {
   if (!dateStr) return "—";
-  const date = new Date(dateStr);
-  return date.toLocaleDateString("en-US", {
-    month: "short",
-    day: "numeric",
-    hour: "2-digit",
-    minute: "2-digit",
-    hour12: false,
-  });
+  return displayFormattedDateTime(dateStr);
 }
 
 function getStatusChipColor(

--- a/Clients/src/presentation/pages/AIDetection/components/SuppressionRulesTab.tsx
+++ b/Clients/src/presentation/pages/AIDetection/components/SuppressionRulesTab.tsx
@@ -28,6 +28,7 @@ import {
   listSuppressions,
   deleteSuppression,
 } from "../../../../application/repository/aiDetection.repository";
+import { displayFormattedDate } from "../../../tools/isoDateToString";
 import { SuppressionRule } from "../../../../domain/ai-detection/types";
 
 interface SuppressionRulesTabProps {
@@ -50,7 +51,7 @@ function formatExpiry(expires_at: string | null | undefined): string {
   if (!expires_at) return "Never";
   const d = dayjs(expires_at);
   const isPast = d.isBefore(dayjs());
-  return `${d.format("MMM D, YYYY")}${isPast ? " (expired)" : ""}`;
+  return `${displayFormattedDate(expires_at)}${isPast ? " (expired)" : ""}`;
 }
 
 function SuppressionRulesTab({ onMessage }: SuppressionRulesTabProps) {
@@ -159,9 +160,7 @@ function SuppressionRulesTab({ onMessage }: SuppressionRulesTabProps) {
                   {rule.reason || "—"}
                 </TableCell>
                 <TableCell sx={{ fontSize: 13 }}>{formatExpiry(rule.expires_at)}</TableCell>
-                <TableCell sx={{ fontSize: 13 }}>
-                  {dayjs(rule.created_at).format("MMM D, YYYY")}
-                </TableCell>
+                <TableCell sx={{ fontSize: 13 }}>{displayFormattedDate(rule.created_at)}</TableCell>
                 <TableCell align="right">
                   <Tooltip title="Delete rule" arrow placement="top">
                     <IconButton

--- a/Clients/src/presentation/pages/AIGateway/Logs/index.tsx
+++ b/Clients/src/presentation/pages/AIGateway/Logs/index.tsx
@@ -39,7 +39,7 @@ import {
   displayFormattedDate,
   displayFormattedDateTime,
   displayFormattedTime,
-} from "src/presentation/tools/isoDateToString";
+} from "../../../tools/isoDateToString";
 
 const AUTO_REFRESH_INTERVAL_MS = 10_000;
 const SEARCH_DEBOUNCE_MS = 300;

--- a/Clients/src/presentation/pages/AIGateway/Logs/index.tsx
+++ b/Clients/src/presentation/pages/AIGateway/Logs/index.tsx
@@ -35,10 +35,16 @@ import { apiServices } from "../../../../infrastructure/api/networkServices";
 import { getPaginationRowCount, setPaginationRowCount } from "../../../../application/utils/paginationStorage";
 import palette from "../../../themes/palette";
 import { sectionTitleSx, useCardSx, formatEntityType } from "../shared";
+import {
+  displayFormattedDate,
+  displayFormattedDateTime,
+  displayFormattedTime,
+} from "src/presentation/tools/isoDateToString";
 
 const AUTO_REFRESH_INTERVAL_MS = 10_000;
 const SEARCH_DEBOUNCE_MS = 300;
 const GR_DEFAULT_PAGE_SIZE = 25;
+const numberFormatter = new Intl.NumberFormat("en-US");
 
 type StatusFilter = "all" | "success" | "error";
 type SourceFilter = "all" | "playground" | "virtual-key";
@@ -91,7 +97,7 @@ function formatDateHeader(dateStr: string): string {
   if (date.toDateString() === todayStr) return "Today";
   if (date.toDateString() === yesterday.toDateString()) return "Yesterday";
 
-  return date.toLocaleDateString("en-US", { month: "short", day: "numeric" });
+  return displayFormattedDate(date);
 }
 
 function getDayKey(dateStr: string): string {
@@ -399,7 +405,7 @@ export default function LogsPage() {
               </MuiTooltip>
               <Box sx={{ flex: 1 }} />
               <Typography sx={{ fontSize: 11, color: palette.text.disabled }}>
-                {total.toLocaleString()} total
+                {numberFormatter.format(total)} total
               </Typography>
             </Stack>
 
@@ -491,7 +497,7 @@ export default function LogsPage() {
                       />
 
                       <Typography sx={{ fontSize: 11, color: palette.text.disabled, minWidth: 65 }}>
-                        {new Date(log.created_at).toLocaleTimeString()}
+                        {displayFormattedTime(log.created_at)}
                       </Typography>
                     </Stack>
                   </Stack>
@@ -755,7 +761,7 @@ export default function LogsPage() {
                       }}
                     >
                       <Typography sx={{ flex: 0.8, fontSize: 12, color: palette.text.tertiary }}>
-                        {new Date(log.created_at).toLocaleString("en-US", { month: "short", day: "numeric", hour: "2-digit", minute: "2-digit" })}
+                        {displayFormattedDateTime(log.created_at)}
                       </Typography>
                       <Typography sx={{ flex: 0.7, fontSize: 12 }}>
                         {log.guardrail_type === "pii" ? "PII" : "Filter"}

--- a/Clients/src/presentation/pages/AIGateway/MCPRuns/RunDetailDrawer.tsx
+++ b/Clients/src/presentation/pages/AIGateway/MCPRuns/RunDetailDrawer.tsx
@@ -3,6 +3,7 @@ import { Drawer, Box, Stack, Typography, Divider, CircularProgress } from "@mui/
 import { apiServices } from "../../../../infrastructure/api/networkServices";
 import Chip from "../../../components/Chip";
 import palette from "../../../themes/palette";
+import { displayFormattedTime } from "src/presentation/tools/isoDateToString";
 
 interface RunEntry {
   kind: "model" | "tool";
@@ -79,9 +80,7 @@ export default function RunDetailDrawer({ runId, onClose }: RunDetailDrawerProps
                   variant={e.kind === "model" ? "success" : "info"}
                   uppercase={false}
                 />
-                <Typography variant="caption">
-                  {new Date(e.created_at).toLocaleTimeString()}
-                </Typography>
+                <Typography variant="caption">{displayFormattedTime(e.created_at)}</Typography>
                 <Typography variant="caption" sx={{ ml: "auto" }}>
                   {e.model}
                 </Typography>

--- a/Clients/src/presentation/pages/AIGateway/MCPRuns/RunDetailDrawer.tsx
+++ b/Clients/src/presentation/pages/AIGateway/MCPRuns/RunDetailDrawer.tsx
@@ -3,7 +3,7 @@ import { Drawer, Box, Stack, Typography, Divider, CircularProgress } from "@mui/
 import { apiServices } from "../../../../infrastructure/api/networkServices";
 import Chip from "../../../components/Chip";
 import palette from "../../../themes/palette";
-import { displayFormattedTime } from "src/presentation/tools/isoDateToString";
+import { displayFormattedTime } from "../../../tools/isoDateToString";
 
 interface RunEntry {
   kind: "model" | "tool";

--- a/Clients/src/presentation/pages/AIGateway/Settings/index.tsx
+++ b/Clients/src/presentation/pages/AIGateway/Settings/index.tsx
@@ -31,6 +31,7 @@ import palette from "../../../themes/palette";
 import { sectionTitleSx, useCardSx, ProviderIcon, TOP_PROVIDERS } from "../shared";
 import VirtualKeysTab from "../VirtualKeys/index";
 import { validateApiKeyFormat } from "../../../../application/utils/apiKeyValidation";
+import { displayFormattedDate } from "src/presentation/tools/isoDateToString";
 
 const TOP_IDS = new Set(TOP_PROVIDERS.map((p) => p._id));
 
@@ -1239,7 +1240,7 @@ export default function AIGatewaySettingsPage() {
                             )}
                             {s.reviewed_at && (
                               <Typography sx={{ fontSize: 12, color: palette.text.tertiary }}>
-                                {new Date(s.reviewed_at).toLocaleDateString()}
+                                {displayFormattedDate(s.reviewed_at)}
                               </Typography>
                             )}
                           </Stack>

--- a/Clients/src/presentation/pages/AIGateway/Settings/index.tsx
+++ b/Clients/src/presentation/pages/AIGateway/Settings/index.tsx
@@ -31,7 +31,7 @@ import palette from "../../../themes/palette";
 import { sectionTitleSx, useCardSx, ProviderIcon, TOP_PROVIDERS } from "../shared";
 import VirtualKeysTab from "../VirtualKeys/index";
 import { validateApiKeyFormat } from "../../../../application/utils/apiKeyValidation";
-import { displayFormattedDate } from "src/presentation/tools/isoDateToString";
+import { displayFormattedDate } from "../../../tools/isoDateToString";
 
 const TOP_IDS = new Set(TOP_PROVIDERS.map((p) => p._id));
 

--- a/Clients/src/presentation/pages/AIGateway/SpendDashboard/index.tsx
+++ b/Clients/src/presentation/pages/AIGateway/SpendDashboard/index.tsx
@@ -47,12 +47,15 @@ import { sectionTitleSx, useCardSx, GUARDRAIL_ACTION_COLORS, formatEntityType } 
 import { useUserGuideSidebarContext } from "../../../components/UserGuide/UserGuideSidebarContext";
 import MockDashboard from "./MockDashboard";
 import OnboardingOverlay from "./OnboardingOverlay";
+import { displayFormattedDate } from "src/presentation/tools/isoDateToString";
+
+const numberFormatter = new Intl.NumberFormat("en-US");
 
 /** Shared date tick formatter for all time-series charts */
 const formatDayTick = (v: string, period: string) => {
   if (period === "1d") return v;
   const d = new Date(v + "T00:00:00");
-  return isNaN(d.getTime()) ? v : d.toLocaleDateString("en-US", { month: "short", day: "numeric" });
+  return isNaN(d.getTime()) ? v : displayFormattedDate(d);
 };
 
 const PERIOD_OPTIONS = [
@@ -766,7 +769,7 @@ export default function SpendDashboardPage() {
                         const v = Number(value) || 0;
                         const n = String(name ?? "");
                         return [
-                          v.toLocaleString(),
+                          numberFormatter.format(v),
                           n === "avg_prompt_tokens" ? "Prompt" : "Completion",
                         ];
                       }}

--- a/Clients/src/presentation/pages/AIGateway/SpendDashboard/index.tsx
+++ b/Clients/src/presentation/pages/AIGateway/SpendDashboard/index.tsx
@@ -47,7 +47,7 @@ import { sectionTitleSx, useCardSx, GUARDRAIL_ACTION_COLORS, formatEntityType } 
 import { useUserGuideSidebarContext } from "../../../components/UserGuide/UserGuideSidebarContext";
 import MockDashboard from "./MockDashboard";
 import OnboardingOverlay from "./OnboardingOverlay";
-import { displayFormattedDate } from "src/presentation/tools/isoDateToString";
+import { displayFormattedDate } from "../../../tools/isoDateToString";
 
 const numberFormatter = new Intl.NumberFormat("en-US");
 

--- a/Clients/src/presentation/pages/AgentDiscovery/AgentTable.tsx
+++ b/Clients/src/presentation/pages/AgentDiscovery/AgentTable.tsx
@@ -44,7 +44,7 @@ import {
   agentPagination,
 } from "./style";
 import { AgentTableProps } from "src/domain/interfaces/i.agentDiscovery";
-import { displayFormattedDate } from "src/presentation/tools/isoDateToString";
+import { displayFormattedDate } from "../../tools/isoDateToString";
 
 const cellStyle = singleTheme.tableStyles.primary.body.cell;
 

--- a/Clients/src/presentation/pages/AgentDiscovery/AgentTable.tsx
+++ b/Clients/src/presentation/pages/AgentDiscovery/AgentTable.tsx
@@ -44,6 +44,7 @@ import {
   agentPagination,
 } from "./style";
 import { AgentTableProps } from "src/domain/interfaces/i.agentDiscovery";
+import { displayFormattedDate } from "src/presentation/tools/isoDateToString";
 
 const cellStyle = singleTheme.tableStyles.primary.body.cell;
 
@@ -166,11 +167,7 @@ const AgentTable: React.FC<AgentTableProps> = ({
 
   const formatDate = (dateStr: string | null) => {
     if (!dateStr) return "—";
-    return new Date(dateStr).toLocaleDateString("en-US", {
-      year: "numeric",
-      month: "short",
-      day: "numeric",
-    });
+    return displayFormattedDate(dateStr);
   };
 
   const getRange = useMemo(() => {

--- a/Clients/src/presentation/pages/EntityGraph/DetailSidebar.tsx
+++ b/Clients/src/presentation/pages/EntityGraph/DetailSidebar.tsx
@@ -28,6 +28,7 @@ import { useNavigate } from "react-router-dom";
 import { EntityType } from "./EntityNode";
 import { VWLink } from "../../components/Link";
 import { text } from "../../themes/palette";
+import { displayFormattedDate } from "../../tools/isoDateToString";
 
 export interface EntityDetails {
   id: string;
@@ -79,7 +80,7 @@ const formatDate = (dateValue: unknown): string => {
   try {
     const date = new Date(String(dateValue));
     if (isNaN(date.getTime())) return String(dateValue);
-    return date.toLocaleDateString(undefined, { year: "numeric", month: "short", day: "numeric" });
+    return displayFormattedDate(date);
   } catch {
     return String(dateValue);
   }

--- a/Clients/src/presentation/pages/EvalsDashboard/BiasAuditDetail.tsx
+++ b/Clients/src/presentation/pages/EvalsDashboard/BiasAuditDetail.tsx
@@ -28,11 +28,14 @@ import {
   type ScoreDistributionTable,
 } from "../../../application/repository/deepEval.repository";
 import EditableText from "../../components/EditableText";
+import { displayFormattedDateTime } from "src/presentation/tools/isoDateToString";
 
 interface BiasAuditDetailProps {
   auditId: string;
   onBack: () => void;
 }
+
+const numberFormatter = new Intl.NumberFormat("en-US");
 
 function ResultsTable({
   table,
@@ -119,12 +122,12 @@ function ResultsTable({
               </Box>
               <Box component="td" sx={{ padding: "8px", textAlign: "right" }}>
                 <Typography sx={{ fontSize: 13, color: theme.palette.text.secondary }}>
-                  {row.applicant_count.toLocaleString()}
+                  {numberFormatter.format(row.applicant_count)}
                 </Typography>
               </Box>
               <Box component="td" sx={{ padding: "8px", textAlign: "right" }}>
                 <Typography sx={{ fontSize: 13, color: theme.palette.text.secondary }}>
-                  {row.selected_count.toLocaleString()}
+                  {numberFormatter.format(row.selected_count)}
                 </Typography>
               </Box>
               <Box component="td" sx={{ padding: "8px", textAlign: "right" }}>
@@ -288,7 +291,7 @@ function FairnessMetricsTableView({ table }: { table: FairnessMetricsTable }) {
               </Box>
               <Box component="td" sx={{ padding: "8px", textAlign: "right" }}>
                 <Typography sx={{ fontSize: 13, color: theme.palette.text.secondary }}>
-                  {g.count.toLocaleString()}
+                  {numberFormatter.format(g.count)}
                 </Typography>
               </Box>
               <Box component="td" sx={{ padding: "8px", textAlign: "right" }}>
@@ -573,12 +576,7 @@ export default function BiasAuditDetail({ auditId, onBack }: BiasAuditDetailProp
           </Stack>
           {audit?.createdAt && (
             <Typography sx={{ fontSize: 12, color: theme.palette.text.secondary }}>
-              {audit.presetName} · Created{" "}
-              {new Date(audit.createdAt).toLocaleDateString("en-US", {
-                month: "long",
-                day: "numeric",
-                year: "numeric",
-              })}
+              {audit.presetName} · Created {displayFormattedDateTime(audit.createdAt)}
             </Typography>
           )}
         </Stack>
@@ -681,7 +679,7 @@ export default function BiasAuditDetail({ auditId, onBack }: BiasAuditDetailProp
           >
             <StatCard
               title="Total applicants"
-              value={audit.results.total_applicants.toLocaleString()}
+              value={numberFormatter.format(audit.results.total_applicants)}
               Icon={Users}
             />
             <StatCard
@@ -692,7 +690,7 @@ export default function BiasAuditDetail({ auditId, onBack }: BiasAuditDetailProp
                     ? "Predicted positive"
                     : "Total selected"
               }
-              value={audit.results.total_selected.toLocaleString()}
+              value={numberFormatter.format(audit.results.total_selected)}
               Icon={UserCheck}
             />
             <StatCard
@@ -715,7 +713,7 @@ export default function BiasAuditDetail({ auditId, onBack }: BiasAuditDetailProp
             {audit.results.unknown_count > 0 && (
               <StatCard
                 title="Unknown"
-                value={audit.results.unknown_count.toLocaleString()}
+                value={numberFormatter.format(audit.results.unknown_count)}
                 Icon={HelpCircle}
               />
             )}

--- a/Clients/src/presentation/pages/EvalsDashboard/BiasAuditDetail.tsx
+++ b/Clients/src/presentation/pages/EvalsDashboard/BiasAuditDetail.tsx
@@ -28,7 +28,7 @@ import {
   type ScoreDistributionTable,
 } from "../../../application/repository/deepEval.repository";
 import EditableText from "../../components/EditableText";
-import { displayFormattedDateTime } from "src/presentation/tools/isoDateToString";
+import { displayFormattedDateTime } from "../../tools/isoDateToString";
 
 interface BiasAuditDetailProps {
   auditId: string;

--- a/Clients/src/presentation/pages/EvalsDashboard/EvalsDashboard.tsx
+++ b/Clients/src/presentation/pages/EvalsDashboard/EvalsDashboard.tsx
@@ -63,6 +63,7 @@ import {
 import type { LLMProvider } from "../../../infrastructure/api/evaluationLlmApiKeysService";
 import { evalModelsService } from "../../../infrastructure/api/evalModelsService";
 import { Plus as PlusIcon, Trash2 as DeleteIcon } from "lucide-react";
+import { displayFormattedDate } from "../../tools/isoDateToString";
 import { Collapse, IconButton, CircularProgress } from "@mui/material";
 import VWChip from "../../components/Chip";
 import ConfirmationModal from "../../components/Dialogs/ConfirmationModal";
@@ -566,11 +567,7 @@ export default function EvalsDashboard() {
   // Format date for display
   const formatKeyDate = (dateStr: string): string => {
     try {
-      return new Date(dateStr).toLocaleDateString("en-US", {
-        month: "short",
-        day: "numeric",
-        year: "numeric",
-      });
+      return displayFormattedDate(dateStr);
     } catch {
       return "-";
     }

--- a/Clients/src/presentation/pages/EvalsDashboard/ExperimentDetailContent.tsx
+++ b/Clients/src/presentation/pages/EvalsDashboard/ExperimentDetailContent.tsx
@@ -42,6 +42,7 @@ import {
   type Experiment,
   type EvaluationLog,
 } from "../../../application/repository/deepEval.repository";
+import { displayFormattedDate } from "src/presentation/tools/isoDateToString";
 
 // Preprocess LaTeX delimiters to work with remark-math
 const preprocessLatex = (text: string): string => {
@@ -321,7 +322,7 @@ export default function ExperimentDetailContent({
         (experiment as unknown as { config?: Record<string, Record<string, unknown>> }).config ||
         {};
 
-      const nextName = `${experiment.name || "Eval"} (rerun ${new Date().toLocaleDateString()})`;
+      const nextName = `${experiment.name || "Eval"} (rerun ${displayFormattedDate(new Date())})`;
 
       const payload = {
         project_id: projectId,
@@ -837,7 +838,7 @@ export default function ExperimentDetailContent({
                       : palette.text.secondary,
                 }}
               >
-                {new Date(experiment.created_at).toLocaleDateString()}
+                {displayFormattedDate(experiment.created_at)}
               </Typography>
             </Box>
           </Stack>

--- a/Clients/src/presentation/pages/EvalsDashboard/ExperimentDetailContent.tsx
+++ b/Clients/src/presentation/pages/EvalsDashboard/ExperimentDetailContent.tsx
@@ -42,7 +42,7 @@ import {
   type Experiment,
   type EvaluationLog,
 } from "../../../application/repository/deepEval.repository";
-import { displayFormattedDate } from "src/presentation/tools/isoDateToString";
+import { displayFormattedDate } from "../../tools/isoDateToString";
 
 // Preprocess LaTeX delimiters to work with remark-math
 const preprocessLatex = (text: string): string => {

--- a/Clients/src/presentation/pages/EvalsDashboard/ProjectExperiments.tsx
+++ b/Clients/src/presentation/pages/EvalsDashboard/ProjectExperiments.tsx
@@ -39,6 +39,11 @@ import HelperIcon from "../../components/HelperIcon";
 import TipBox from "../../components/TipBox";
 import { useAuth } from "../../../application/hooks/useAuth";
 import allowedRoles from "../../../application/constants/permissions";
+import {
+  displayFormattedDate,
+  displayFormattedDateTime,
+  displayFormattedTime,
+} from "../../tools/isoDateToString";
 
 interface ProjectExperimentsProps {
   projectId: string;
@@ -249,15 +254,8 @@ export default function ProjectExperiments({
       const baseConfig = originalExp.config || {};
 
       const now = new Date();
-      const dateStr = now.toLocaleDateString("en-US", {
-        month: "short",
-        day: "numeric",
-      });
-      const timeStr = now.toLocaleTimeString("en-US", {
-        hour: "2-digit",
-        minute: "2-digit",
-        hour12: true,
-      });
+      const dateStr = displayFormattedDate(now);
+      const timeStr = displayFormattedTime(now);
       const nextName = `${originalExp.name || "Eval"} (rerun ${dateStr}, ${timeStr})`;
 
       const payload = {
@@ -543,15 +541,7 @@ export default function ProjectExperiments({
     }
 
     // Format the date with time
-    const createdDate = exp.created_at
-      ? new Date(exp.created_at).toLocaleDateString("en-US", {
-          month: "short",
-          day: "numeric",
-          year: "numeric",
-          hour: "2-digit",
-          minute: "2-digit",
-        })
-      : "-";
+    const createdDate = exp.created_at ? displayFormattedDateTime(exp.created_at) : "-";
 
     // Determine judge display based on evaluation mode
     const evaluationMode = exp.config?.evaluationMode || "standard";

--- a/Clients/src/presentation/pages/EvalsDashboard/ProjectOverview.tsx
+++ b/Clients/src/presentation/pages/EvalsDashboard/ProjectOverview.tsx
@@ -31,6 +31,7 @@ import TipBox from "../../components/TipBox";
 import { useAuth } from "../../../application/hooks/useAuth";
 import allowedRoles from "../../../application/constants/permissions";
 import { palette } from "../../themes/palette";
+import { displayFormattedDateTime } from "../../tools/isoDateToString";
 
 interface ProjectOverviewProps {
   projectId: string;
@@ -339,15 +340,7 @@ export default function ProjectOverview({
       }
 
       // Format date
-      const createdDate = exp.created_at
-        ? new Date(exp.created_at).toLocaleDateString("en-US", {
-            month: "short",
-            day: "numeric",
-            year: "numeric",
-            hour: "2-digit",
-            minute: "2-digit",
-          })
-        : "-";
+      const createdDate = exp.created_at ? displayFormattedDateTime(exp.created_at) : "-";
 
       // Judge/scorer display
       const judgeModel = exp.config?.judgeLlm?.model || exp.config?.judgeLlm?.provider || "";

--- a/Clients/src/presentation/pages/EvalsDashboard/ProjectsList.tsx
+++ b/Clients/src/presentation/pages/EvalsDashboard/ProjectsList.tsx
@@ -33,6 +33,7 @@ import { PageHeader } from "../../components/Layout/PageHeader";
 import SelectableCard from "../../components/SelectableCard";
 import { CustomizableButton } from "../../components/button/customizable-button";
 import StandardModal from "../../components/Modals/StandardModal";
+import { displayFormattedDate } from "../../tools/isoDateToString";
 import Field from "../../components/Inputs/Field";
 import Alert from "../../components/Alert";
 import { EmptyState } from "../../components/EmptyState";
@@ -314,11 +315,7 @@ export default function ProjectsList() {
   };
 
   const formatDate = (date: string) => {
-    return new Date(date).toLocaleDateString("en-US", {
-      year: "numeric",
-      month: "short",
-      day: "numeric",
-    });
+    return displayFormattedDate(date);
   };
 
   const handleMenuOpen = (event: React.MouseEvent<HTMLElement>, project: DeepEvalProject) => {

--- a/Clients/src/presentation/pages/EvalsDashboard/ReportPage.tsx
+++ b/Clients/src/presentation/pages/EvalsDashboard/ReportPage.tsx
@@ -36,6 +36,7 @@ import CustomAxios from "../../../infrastructure/api/customAxios";
 import { getAllExperiments } from "../../../application/repository/deepEval.repository";
 import { palette } from "../../themes/palette";
 import singleTheme from "../../themes/v1SingleTheme";
+import { displayFormattedDateTime } from "../../tools/isoDateToString";
 
 interface ReportPageProps {
   projectId: string;
@@ -297,13 +298,7 @@ export default function ReportPage({
 
   const formatDate = (iso: string) => {
     try {
-      return new Date(iso).toLocaleDateString("en-US", {
-        month: "short",
-        day: "numeric",
-        year: "numeric",
-        hour: "2-digit",
-        minute: "2-digit",
-      });
+      return displayFormattedDateTime(iso);
     } catch {
       return iso;
     }

--- a/Clients/src/presentation/pages/EvalsDashboard/biasAuditHelpers.tsx
+++ b/Clients/src/presentation/pages/EvalsDashboard/biasAuditHelpers.tsx
@@ -1,5 +1,6 @@
 import Chip from "../../components/Chip";
 import { palette } from "../../themes/palette";
+import { displayFormattedDate } from "../../tools/isoDateToString";
 
 export function getStatusChip(status: string) {
   switch (status) {
@@ -61,9 +62,5 @@ export function getModeChip(mode: string) {
 
 export function formatDate(dateStr: string | null) {
   if (!dateStr) return "—";
-  return new Date(dateStr).toLocaleDateString("en-US", {
-    month: "short",
-    day: "numeric",
-    year: "numeric",
-  });
+  return displayFormattedDate(dateStr);
 }

--- a/Clients/src/presentation/pages/EvalsDashboard/components/PerformanceChart.tsx
+++ b/Clients/src/presentation/pages/EvalsDashboard/components/PerformanceChart.tsx
@@ -15,6 +15,7 @@ import {
   type Experiment,
 } from "../../../../application/repository/deepEval.repository";
 import { vwTooltipStyle, ChartOutlineWrapper } from "../../../components/Charts/VWCharts";
+import { displayFormattedDate, displayFormattedTime } from "../../../tools/isoDateToString";
 
 export type TimeRange = "7d" | "30d" | "100d" | "all";
 
@@ -156,15 +157,8 @@ export default function PerformanceChart({ projectId, timeRange }: PerformanceCh
         });
 
         // Build chart point
-        const dateStr = new Date(exp.created_at).toLocaleDateString("en-US", {
-          month: "short",
-          day: "numeric",
-        });
-        const timeStr = new Date(exp.created_at).toLocaleTimeString("en-US", {
-          hour: "2-digit",
-          minute: "2-digit",
-          hour12: true,
-        });
+        const dateStr = displayFormattedDate(exp.created_at);
+        const timeStr = displayFormattedTime(exp.created_at);
         const point: ChartPoint = {
           name: `Run ${i + 1}`,
           date: `${dateStr}`,

--- a/Clients/src/presentation/pages/FileManager/components/FilePreviewPanel/index.tsx
+++ b/Clients/src/presentation/pages/FileManager/components/FilePreviewPanel/index.tsx
@@ -43,6 +43,7 @@ import {
 } from "../../../../../application/utils/officePreview.utils";
 import { useIsAdmin } from "../../../../../application/hooks/useIsAdmin";
 import { status } from "../../../../themes/palette";
+import { displayFormattedDate } from "../../../../tools/isoDateToString";
 
 interface FilePreviewPanelProps {
   isOpen: boolean;
@@ -101,12 +102,7 @@ const formatFileSize = (bytes?: number): string => {
 
 const formatDate = (dateStr?: string): string => {
   if (!dateStr) return "Unknown date";
-  const date = new Date(dateStr);
-  return date.toLocaleDateString("en-US", {
-    year: "numeric",
-    month: "short",
-    day: "numeric",
-  });
+  return displayFormattedDate(dateStr);
 };
 
 /**

--- a/Clients/src/presentation/pages/FileManager/components/FileVersionHistoryDrawer/index.tsx
+++ b/Clients/src/presentation/pages/FileManager/components/FileVersionHistoryDrawer/index.tsx
@@ -31,6 +31,7 @@ import StatusBadge from "../StatusBadge";
 import dayjs from "dayjs";
 import relativeTime from "dayjs/plugin/relativeTime";
 import { text } from "../../../../themes/palette";
+import { displayFormattedDate, displayFormattedDateTime } from "../../../../tools/isoDateToString";
 
 dayjs.extend(relativeTime);
 
@@ -42,7 +43,7 @@ interface FileVersionHistoryDrawerProps {
 
 const formatDate = (dateStr?: string): string => {
   if (!dateStr) return "Unknown date";
-  return dayjs(dateStr).format("MMM D, YYYY [at] h:mm A");
+  return displayFormattedDateTime(dateStr, { separator: " at " });
 };
 
 const formatRelativeTime = (date: string): string => {
@@ -56,7 +57,7 @@ const formatRelativeTime = (date: string): string => {
   if (diffHours < 24) return `${diffHours}h ago`;
   const diffDays = Math.abs(now.diff(target, "day"));
   if (diffDays < 7) return `${diffDays}d ago`;
-  return target.format("MMM D, YYYY");
+  return displayFormattedDate(date);
 };
 
 const VERSIONS_PAGE_SIZE = 20;

--- a/Clients/src/presentation/pages/IntakeFormBuilder/IntakeFormsListPage.tsx
+++ b/Clients/src/presentation/pages/IntakeFormBuilder/IntakeFormsListPage.tsx
@@ -24,6 +24,7 @@ import {
 } from "@mui/material";
 import TabContext from "@mui/lab/TabContext";
 import TabBar from "../../components/TabBar";
+import { displayFormattedDate } from "../../tools/isoDateToString";
 import {
   Plus,
   Settings,
@@ -73,11 +74,7 @@ import {
 function formatDate(date: Date | string): string {
   const d = new Date(date);
   if (isNaN(d.getTime())) return "—";
-  return d.toLocaleDateString("en-US", {
-    year: "numeric",
-    month: "short",
-    day: "numeric",
-  });
+  return displayFormattedDate(d);
 }
 
 const ENTITY_LABELS: Record<string, string> = {

--- a/Clients/src/presentation/pages/ModelInventory/ModelEvaluationsTab.tsx
+++ b/Clients/src/presentation/pages/ModelInventory/ModelEvaluationsTab.tsx
@@ -9,6 +9,7 @@ import {
   type ModelEvaluation,
   type ModelEvaluationsResponse,
 } from "../../../application/repository/modelEvaluations.repository";
+import { displayFormattedDate } from "../../tools/isoDateToString";
 
 const statusColorMap: Record<string, string> = {
   completed: "#4caf50",
@@ -178,15 +179,7 @@ export default function ModelEvaluationsTab() {
                     )}
                   </Stack>
                 </td>
-                <td>
-                  {e.created_at
-                    ? new Date(e.created_at).toLocaleDateString("en-US", {
-                        month: "short",
-                        day: "numeric",
-                        year: "numeric",
-                      })
-                    : "—"}
-                </td>
+                <td>{e.created_at ? displayFormattedDate(e.created_at) : "—"}</td>
               </tr>
             ))}
           </tbody>

--- a/Clients/src/presentation/pages/PostMarketMonitoring/MonitoringForm/index.tsx
+++ b/Clients/src/presentation/pages/PostMarketMonitoring/MonitoringForm/index.tsx
@@ -29,9 +29,9 @@ import {
   PMMQuestion,
   PMMResponseSave,
 } from "../../../../domain/types/PostMarketMonitoring";
-import dayjs from "dayjs";
 import { AlertState } from "../../../../application/interfaces/appStates";
 import { brand } from "../../../themes/palette";
+import { displayFormattedDate, displayFormattedTime } from "../../../tools/isoDateToString";
 
 interface LocalAlertState extends AlertState {
   isToast: boolean;
@@ -297,7 +297,7 @@ const MonitoringForm: React.FC = () => {
                 Due date
               </Typography>
               <Typography sx={{ fontSize: 13, fontWeight: 500 }}>
-                {dayjs(cycle.due_at).format("MMM D, YYYY")}
+                {displayFormattedDate(cycle.due_at)}
               </Typography>
             </Stack>
 
@@ -313,7 +313,7 @@ const MonitoringForm: React.FC = () => {
           {/* Autosave indicator */}
           {lastSaved && (
             <Typography sx={{ fontSize: 11, color: theme.palette.other.icon }}>
-              Last saved: {dayjs(lastSaved).format("HH:mm:ss")}
+              Last saved: {displayFormattedTime(lastSaved, { includeSeconds: true })}
             </Typography>
           )}
         </Stack>
@@ -333,7 +333,7 @@ const MonitoringForm: React.FC = () => {
             <CheckCircle size={20} color={theme.palette.status.success.main} />
             <Typography sx={{ fontSize: 13, color: theme.palette.status.success.text }}>
               This monitoring cycle was completed on{" "}
-              {dayjs(cycle.completed_at).format("MMMM D, YYYY")}
+              {cycle.completed_at ? displayFormattedDate(cycle.completed_at) : ""}
               {cycle.completed_by_name && ` by ${cycle.completed_by_name}`}.
             </Typography>
           </Stack>

--- a/Clients/src/presentation/pages/PostMarketMonitoring/ReportsArchive/index.tsx
+++ b/Clients/src/presentation/pages/PostMarketMonitoring/ReportsArchive/index.tsx
@@ -33,6 +33,7 @@ import {
   PMMReportsFilterRequest,
 } from "../../../../domain/types/PostMarketMonitoring";
 import dayjs, { Dayjs } from "dayjs";
+import { displayFormattedDate } from "../../../tools/isoDateToString";
 import { AlertState } from "../../../../application/interfaces/appStates";
 
 interface LocalAlertState extends AlertState {
@@ -306,7 +307,7 @@ const ReportsArchive: React.FC = () => {
                       </TableCell>
                       <TableCell sx={tableCellStyle}>#{report.cycle_number}</TableCell>
                       <TableCell sx={tableCellStyle}>
-                        {dayjs(report.completed_at).format("MMM D, YYYY")}
+                        {report.completed_at ? displayFormattedDate(report.completed_at) : "-"}
                       </TableCell>
                       <TableCell sx={tableCellStyle}>{report.completed_by_name || "-"}</TableCell>
                       <TableCell sx={tableCellStyle} align="center">

--- a/Clients/src/presentation/pages/ProjectView/Activity/index.tsx
+++ b/Clients/src/presentation/pages/ProjectView/Activity/index.tsx
@@ -17,6 +17,7 @@ import { EntityType, getEntityHistoryConfig } from "../../../../config/changeHis
 import dayjs from "dayjs";
 import relativeTime from "dayjs/plugin/relativeTime";
 import { brand } from "../../../themes/palette";
+import { displayFormattedDate, displayFormattedTime } from "../../../tools/isoDateToString";
 
 dayjs.extend(relativeTime);
 
@@ -49,14 +50,14 @@ const formatRelativeTime = (date: string | Date): string => {
   if (diffHours < 24 && targetDate.isSame(now, "day")) {
     if (diffHours === 1) return "An hour ago";
     if (diffHours < 3) return "A few hours ago";
-    return `Today at ${targetDate.format("h:mm A")}`;
+    return `Today at ${displayFormattedTime(date)}`;
   }
 
   if (diffDays === 1 || (diffHours < 48 && targetDate.isSame(now.subtract(1, "day"), "day"))) {
-    return `Yesterday at ${targetDate.format("h:mm A")}`;
+    return `Yesterday at ${displayFormattedTime(date)}`;
   }
 
-  return `${targetDate.format("MMMM D, YYYY")} at ${targetDate.format("h:mm A")}`;
+  return `${displayFormattedDate(date)} at ${displayFormattedTime(date)}`;
 };
 
 const Activity: React.FC<ActivityProps> = ({ entityType, entityId }) => {
@@ -135,8 +136,8 @@ const Activity: React.FC<ActivityProps> = ({ entityType, entityId }) => {
           ? `${creationEntry.user_name} ${creationEntry.user_surname}`
           : creationEntry.user_email || "an unknown user";
 
-    const creationDate = dayjs(creationEntry.changed_at).format("MMMM D, YYYY");
-    const creationTime = dayjs(creationEntry.changed_at).format("h:mm A");
+    const creationDate = displayFormattedDate(creationEntry.changed_at);
+    const creationTime = displayFormattedTime(creationEntry.changed_at);
 
     return { creatorName, creationDate, creationTime };
   }, [creationEntry, currentUserId]);

--- a/Clients/src/presentation/pages/ProjectView/CEMarking/index.tsx
+++ b/Clients/src/presentation/pages/ProjectView/CEMarking/index.tsx
@@ -33,6 +33,7 @@ import { CustomizableButton } from "../../../components/button/customizable-butt
 import StandardModal from "../../../components/Modals/StandardModal";
 import Field from "../../../components/Inputs/Field";
 import DatePicker from "../../../components/Inputs/Datepicker";
+import { displayFormattedDate } from "../../../tools/isoDateToString";
 import VWTooltip from "../../../components/VWTooltip";
 import Checkbox from "../../../components/Inputs/Checkbox";
 import {
@@ -1903,7 +1904,7 @@ const CEMarking: React.FC<CEMarkingProps> = ({ projectId }) => {
                               •
                             </Typography>
                             <Typography sx={{ fontSize: 12, color: theme.palette.text.secondary }}>
-                              Uploaded: {dayjs(evidence.uploaded_time).format("MMM DD, YYYY")}
+                              Uploaded: {displayFormattedDate(evidence.uploaded_time)}
                             </Typography>
                           </>
                         )}
@@ -2000,7 +2001,7 @@ const CEMarking: React.FC<CEMarkingProps> = ({ projectId }) => {
                               •
                             </Typography>
                             <Typography sx={{ fontSize: 12, color: theme.palette.text.secondary }}>
-                              Occurred: {dayjs(incident.occurred_date).format("MMM DD, YYYY")}
+                              Occurred: {displayFormattedDate(incident.occurred_date)}
                             </Typography>
                           </>
                         )}

--- a/Clients/src/presentation/pages/ProjectView/IntakeSubmissionCard/index.tsx
+++ b/Clients/src/presentation/pages/ProjectView/IntakeSubmissionCard/index.tsx
@@ -3,7 +3,7 @@ import { Box, Typography, Stack, Collapse, useTheme } from "@mui/material";
 import { ChevronDown, ChevronUp } from "lucide-react";
 import { useEntityIntakeSubmission } from "../../../../application/hooks/useEntityIntakeSubmission";
 import type { IntakeSubmissionField } from "../../../../application/repository/intakeForm.repository";
-import dayjs from "dayjs";
+import { displayFormattedDate } from "../../../tools/isoDateToString";
 
 interface IntakeSubmissionCardProps {
   projectId: number;
@@ -16,9 +16,7 @@ function renderFieldValue(field: IntakeSubmissionField): string {
   if (type === "checkbox") return value ? "Yes" : "No";
 
   if (type === "date") {
-    return dayjs(value as string).isValid()
-      ? dayjs(value as string).format("MMMM D, YYYY")
-      : String(value);
+    return displayFormattedDate(value as string);
   }
 
   if (type === "select" && options) {
@@ -113,9 +111,7 @@ export default function IntakeSubmissionCard({ projectId }: IntakeSubmissionCard
       {/* Meta line */}
       <Typography sx={{ fontSize: 12, color: theme.palette.text.accent, mb: 3 }}>
         {submission.formName}
-        {submission.submittedAt && (
-          <> &middot; {dayjs(submission.submittedAt).format("MMM D, YYYY")}</>
-        )}
+        {submission.submittedAt && <> &middot; {displayFormattedDate(submission.submittedAt)}</>}
         {(submission.submitterName || submission.submitterEmail) && (
           <> &middot; {submission.submitterName || submission.submitterEmail}</>
         )}

--- a/Clients/src/presentation/pages/ProjectView/RisksView/index.tsx
+++ b/Clients/src/presentation/pages/ProjectView/RisksView/index.tsx
@@ -11,6 +11,7 @@ import { ProjectRisk } from "../../../../application/hooks/useProjectRisks";
 import { getAllEntities } from "../../../../application/repository/entity.repository";
 import { VendorRisk } from "../../../../domain/types/VendorRisk";
 import { StatusTileCards, StatusTileItem } from "../../../components/Cards/StatusTileCards";
+import { displayFormattedDate } from "src/presentation/tools/isoDateToString";
 
 const projectRisksColNames = [
   {
@@ -104,7 +105,7 @@ const RisksView: FC<RisksViewProps> = memo(({ risksSummary, risksData, title, pr
 
         // Special formatting for dates
         if (col.id === "review_date" && value) {
-          value = new Date(value).toLocaleDateString();
+          value = displayFormattedDate(value);
         }
 
         // Special formatting for ALE currency

--- a/Clients/src/presentation/pages/ProjectView/RisksView/index.tsx
+++ b/Clients/src/presentation/pages/ProjectView/RisksView/index.tsx
@@ -11,7 +11,7 @@ import { ProjectRisk } from "../../../../application/hooks/useProjectRisks";
 import { getAllEntities } from "../../../../application/repository/entity.repository";
 import { VendorRisk } from "../../../../domain/types/VendorRisk";
 import { StatusTileCards, StatusTileItem } from "../../../components/Cards/StatusTileCards";
-import { displayFormattedDate } from "src/presentation/tools/isoDateToString";
+import { displayFormattedDate } from "../../../tools/isoDateToString";
 
 const projectRisksColNames = [
   {

--- a/Clients/src/presentation/pages/ShadowAI/AIToolsPage.tsx
+++ b/Clients/src/presentation/pages/ShadowAI/AIToolsPage.tsx
@@ -46,6 +46,7 @@ import TablePaginationActions from "../../components/TablePagination";
 import GovernanceWizardModal from "./GovernanceWizardModal";
 import { PageHeaderExtended } from "../../components/Layout/PageHeaderExtended";
 import Alert from "../../components/Alert";
+import { displayFormattedDate } from "src/presentation/tools/isoDateToString";
 import {
   SelectorVertical,
   SortableColumn,
@@ -322,7 +323,7 @@ export default function AIToolsPage() {
                 title="First detected"
                 count={
                   selectedTool.first_detected_at
-                    ? new Date(selectedTool.first_detected_at).toLocaleDateString()
+                    ? displayFormattedDate(selectedTool.first_detected_at)
                     : "—"
                 }
                 disableNavigation
@@ -330,9 +331,7 @@ export default function AIToolsPage() {
               <DashboardHeaderCard
                 title="Last seen"
                 count={
-                  selectedTool.last_seen_at
-                    ? new Date(selectedTool.last_seen_at).toLocaleDateString()
-                    : "—"
+                  selectedTool.last_seen_at ? displayFormattedDate(selectedTool.last_seen_at) : "—"
                 }
                 disableNavigation
               />
@@ -586,7 +585,7 @@ export default function AIToolsPage() {
                       {t.risk_score ?? 0}
                     </TableCell>
                     <TableCell sx={singleTheme.tableStyles.primary.body.cell}>
-                      {t.last_seen_at ? new Date(t.last_seen_at).toLocaleDateString() : "—"}
+                      {t.last_seen_at ? displayFormattedDate(t.last_seen_at) : "—"}
                     </TableCell>
                   </TableRow>
                 );

--- a/Clients/src/presentation/pages/ShadowAI/AIToolsPage.tsx
+++ b/Clients/src/presentation/pages/ShadowAI/AIToolsPage.tsx
@@ -46,7 +46,7 @@ import TablePaginationActions from "../../components/TablePagination";
 import GovernanceWizardModal from "./GovernanceWizardModal";
 import { PageHeaderExtended } from "../../components/Layout/PageHeaderExtended";
 import Alert from "../../components/Alert";
-import { displayFormattedDate } from "src/presentation/tools/isoDateToString";
+import { displayFormattedDate } from "../../tools/isoDateToString";
 import {
   SelectorVertical,
   SortableColumn,

--- a/Clients/src/presentation/pages/ShadowAI/SettingsPage.tsx
+++ b/Clients/src/presentation/pages/ShadowAI/SettingsPage.tsx
@@ -48,7 +48,7 @@ import Select from "../../components/Inputs/Select";
 import { PageHeaderExtended } from "../../components/Layout/PageHeaderExtended";
 import { useUserGuideSidebarContext } from "../../components/UserGuide";
 import { palette } from "../../themes/palette";
-import { displayFormattedDate } from "src/presentation/tools/isoDateToString";
+import { displayFormattedDate } from "../../tools/isoDateToString";
 
 const numberFormatter = new Intl.NumberFormat("en-US");
 

--- a/Clients/src/presentation/pages/ShadowAI/SettingsPage.tsx
+++ b/Clients/src/presentation/pages/ShadowAI/SettingsPage.tsx
@@ -48,6 +48,9 @@ import Select from "../../components/Inputs/Select";
 import { PageHeaderExtended } from "../../components/Layout/PageHeaderExtended";
 import { useUserGuideSidebarContext } from "../../components/UserGuide";
 import { palette } from "../../themes/palette";
+import { displayFormattedDate } from "src/presentation/tools/isoDateToString";
+
+const numberFormatter = new Intl.NumberFormat("en-US");
 
 const sectionTitleSx = {
   fontWeight: 600,
@@ -330,10 +333,10 @@ function ApiKeysSection() {
                       <Chip label={k.is_active ? "Active" : "Revoked"} size="small" />
                     </TableCell>
                     <TableCell sx={singleTheme.tableStyles.primary.body.cell}>
-                      {k.created_at ? new Date(k.created_at).toLocaleDateString() : "—"}
+                      {k.created_at ? displayFormattedDate(k.created_at) : "—"}
                     </TableCell>
                     <TableCell sx={singleTheme.tableStyles.primary.body.cell}>
-                      {k.last_used_at ? new Date(k.last_used_at).toLocaleDateString() : "Never"}
+                      {k.last_used_at ? displayFormattedDate(k.last_used_at) : "Never"}
                     </TableCell>
                     <TableCell align="right" sx={singleTheme.tableStyles.primary.body.cell}>
                       {k.is_active ? (
@@ -596,7 +599,7 @@ function SyslogConfigSection() {
                       <Chip label={c.is_active ? "Active" : "Inactive"} size="small" />
                     </TableCell>
                     <TableCell sx={singleTheme.tableStyles.primary.body.cell}>
-                      {c.created_at ? new Date(c.created_at).toLocaleDateString() : "—"}
+                      {c.created_at ? displayFormattedDate(c.created_at) : "—"}
                     </TableCell>
                     <TableCell align="right" sx={singleTheme.tableStyles.primary.body.cell}>
                       <Stack direction="row" gap="4px" justifyContent="flex-end">
@@ -1073,7 +1076,7 @@ function RateLimitSection({
 
         {settings && currentValue > 0 && (
           <Typography sx={{ fontSize: 12, color: palette.text.disabled }}>
-            Currently limited to {currentValue.toLocaleString()} events/hour
+            Currently limited to {numberFormatter.format(currentValue)} events/hour
           </Typography>
         )}
         {settings && currentValue === 0 && (

--- a/Clients/src/presentation/pages/ShadowAI/UserActivityPage.tsx
+++ b/Clients/src/presentation/pages/ShadowAI/UserActivityPage.tsx
@@ -51,6 +51,7 @@ import {
   SortableTableHead,
 } from "./constants";
 import { palette } from "../../themes/palette";
+import { displayFormattedDate } from "src/presentation/tools/isoDateToString";
 
 interface UserDetailData {
   email: string;
@@ -360,7 +361,7 @@ export default function UserActivityPage() {
                           {t.event_count}
                         </TableCell>
                         <TableCell sx={singleTheme.tableStyles.primary.body.cell}>
-                          {new Date(t.last_used).toLocaleDateString()}
+                          {displayFormattedDate(t.last_used)}
                         </TableCell>
                       </TableRow>
                     ))}

--- a/Clients/src/presentation/pages/ShadowAI/UserActivityPage.tsx
+++ b/Clients/src/presentation/pages/ShadowAI/UserActivityPage.tsx
@@ -51,7 +51,7 @@ import {
   SortableTableHead,
 } from "./constants";
 import { palette } from "../../themes/palette";
-import { displayFormattedDate } from "src/presentation/tools/isoDateToString";
+import { displayFormattedDate } from "../../tools/isoDateToString";
 
 interface UserDetailData {
   email: string;

--- a/Clients/src/presentation/pages/SharedView/index.tsx
+++ b/Clients/src/presentation/pages/SharedView/index.tsx
@@ -17,6 +17,7 @@ import {
 } from "@mui/material";
 import { Download, ShieldX } from "lucide-react";
 import { ENV_VARs } from "../../../../env.vars";
+import { displayFormattedDate } from "src/presentation/tools/isoDateToString";
 
 /**
  * SharedView page component for displaying publicly shared data
@@ -259,7 +260,7 @@ const SharedView: React.FC = () => {
     if (key === "status_date") {
       try {
         const date = new Date(value);
-        return <Typography variant="body2">{date.toLocaleDateString()}</Typography>;
+        return <Typography variant="body2">{displayFormattedDate(date)}</Typography>;
       } catch {
         return <Typography variant="body2">{String(value)}</Typography>;
       }

--- a/Clients/src/presentation/pages/SharedView/index.tsx
+++ b/Clients/src/presentation/pages/SharedView/index.tsx
@@ -17,7 +17,7 @@ import {
 } from "@mui/material";
 import { Download, ShieldX } from "lucide-react";
 import { ENV_VARs } from "../../../../env.vars";
-import { displayFormattedDate } from "src/presentation/tools/isoDateToString";
+import { displayFormattedDate } from "../../tools/isoDateToString";
 
 /**
  * SharedView page component for displaying publicly shared data

--- a/Clients/src/presentation/pages/SuperAdmin/AllUsers/index.tsx
+++ b/Clients/src/presentation/pages/SuperAdmin/AllUsers/index.tsx
@@ -33,7 +33,7 @@ import SearchBox from "../../../components/Search/SearchBox";
 import { EmptyState } from "../../../components/EmptyState";
 import Select from "../../../components/Inputs/Select";
 import singleTheme from "../../../themes/v1SingleTheme";
-import { displayFormattedDate } from "src/presentation/tools/isoDateToString";
+import { displayFormattedDate } from "../../../tools/isoDateToString";
 import { getSelectStyles } from "../../../utils/inputStyles";
 
 const DeleteUserModal = ({

--- a/Clients/src/presentation/pages/SuperAdmin/AllUsers/index.tsx
+++ b/Clients/src/presentation/pages/SuperAdmin/AllUsers/index.tsx
@@ -33,6 +33,7 @@ import SearchBox from "../../../components/Search/SearchBox";
 import { EmptyState } from "../../../components/EmptyState";
 import Select from "../../../components/Inputs/Select";
 import singleTheme from "../../../themes/v1SingleTheme";
+import { displayFormattedDate } from "src/presentation/tools/isoDateToString";
 import { getSelectStyles } from "../../../utils/inputStyles";
 
 const DeleteUserModal = ({
@@ -182,13 +183,7 @@ const EditUserModal = ({
             Joined
           </Typography>
           <Typography sx={{ fontSize: 13, color: "text.secondary" }}>
-            {target
-              ? new Date(target.created_at).toLocaleDateString("en-US", {
-                  year: "numeric",
-                  month: "long",
-                  day: "numeric",
-                })
-              : "—"}
+            {target ? displayFormattedDate(target.created_at) : "—"}
           </Typography>
         </Stack>
         <Stack spacing={0.5}>
@@ -196,13 +191,7 @@ const EditUserModal = ({
             Last login
           </Typography>
           <Typography sx={{ fontSize: 13, color: "text.secondary" }}>
-            {target?.last_login
-              ? new Date(target.last_login).toLocaleDateString("en-US", {
-                  year: "numeric",
-                  month: "long",
-                  day: "numeric",
-                })
-              : "Never"}
+            {target?.last_login ? displayFormattedDate(target.last_login) : "Never"}
           </Typography>
         </Stack>
         {error && <Typography sx={{ fontSize: 13, color: "#D32F2F" }}>{error}</Typography>}
@@ -629,11 +618,7 @@ const AllUsers = () => {
                       </Box>
                     </TableCell>
                     <TableCell sx={tableStyles.body.cell}>
-                      {new Date(user.created_at).toLocaleDateString("en-US", {
-                        year: "numeric",
-                        month: "short",
-                        day: "numeric",
-                      })}
+                      {displayFormattedDate(user.created_at)}
                     </TableCell>
                     <TableCell sx={{ ...tableStyles.body.cell, textAlign: "right" }}>
                       <Button

--- a/Clients/src/presentation/pages/SuperAdmin/Organizations/index.tsx
+++ b/Clients/src/presentation/pages/SuperAdmin/Organizations/index.tsx
@@ -25,7 +25,7 @@ import { PageHeaderExtended } from "../../../components/Layout/PageHeaderExtende
 import SearchBox from "../../../components/Search/SearchBox";
 import { EmptyState } from "../../../components/EmptyState";
 import singleTheme from "../../../themes/v1SingleTheme";
-import { displayFormattedDate } from "src/presentation/tools/isoDateToString";
+import { displayFormattedDate } from "../../../tools/isoDateToString";
 
 /** Isolated create modal — its input state won't re-render the parent table */
 const CreateOrgModal = ({

--- a/Clients/src/presentation/pages/SuperAdmin/Organizations/index.tsx
+++ b/Clients/src/presentation/pages/SuperAdmin/Organizations/index.tsx
@@ -25,6 +25,7 @@ import { PageHeaderExtended } from "../../../components/Layout/PageHeaderExtende
 import SearchBox from "../../../components/Search/SearchBox";
 import { EmptyState } from "../../../components/EmptyState";
 import singleTheme from "../../../themes/v1SingleTheme";
+import { displayFormattedDate } from "src/presentation/tools/isoDateToString";
 
 /** Isolated create modal — its input state won't re-render the parent table */
 const CreateOrgModal = ({
@@ -286,11 +287,7 @@ const Organizations = () => {
                     <Typography sx={{ fontSize: 13 }}>{org.user_count ?? 0}</Typography>
                   </TableCell>
                   <TableCell sx={tableStyles.body.cell}>
-                    {new Date(org.created_at).toLocaleDateString("en-US", {
-                      year: "numeric",
-                      month: "short",
-                      day: "numeric",
-                    })}
+                    {displayFormattedDate(org.created_at)}
                   </TableCell>
                   <TableCell sx={{ ...tableStyles.body.cell, textAlign: "right" }}>
                     <Stack direction="row" justifyContent="flex-end" gap="8px">

--- a/Clients/src/presentation/pages/SuperAdmin/Users/index.tsx
+++ b/Clients/src/presentation/pages/SuperAdmin/Users/index.tsx
@@ -26,7 +26,7 @@ import SearchBox from "../../../components/Search/SearchBox";
 import { EmptyState } from "../../../components/EmptyState";
 import { ROLE_OPTIONS, ROLE_COLORS } from "../../../../application/constants/roles";
 import singleTheme from "../../../themes/v1SingleTheme";
-import { displayFormattedDate } from "src/presentation/tools/isoDateToString";
+import { displayFormattedDate } from "../../../tools/isoDateToString";
 
 const Users = () => {
   const { id: orgId } = useParams<{ id: string }>();

--- a/Clients/src/presentation/pages/SuperAdmin/Users/index.tsx
+++ b/Clients/src/presentation/pages/SuperAdmin/Users/index.tsx
@@ -26,6 +26,7 @@ import SearchBox from "../../../components/Search/SearchBox";
 import { EmptyState } from "../../../components/EmptyState";
 import { ROLE_OPTIONS, ROLE_COLORS } from "../../../../application/constants/roles";
 import singleTheme from "../../../themes/v1SingleTheme";
+import { displayFormattedDate } from "src/presentation/tools/isoDateToString";
 
 const Users = () => {
   const { id: orgId } = useParams<{ id: string }>();
@@ -235,20 +236,10 @@ const Users = () => {
                       </Box>
                     </TableCell>
                     <TableCell sx={tableStyles.body.cell}>
-                      {new Date(user.created_at).toLocaleDateString("en-US", {
-                        year: "numeric",
-                        month: "short",
-                        day: "numeric",
-                      })}
+                      {displayFormattedDate(user.created_at)}
                     </TableCell>
                     <TableCell sx={tableStyles.body.cell}>
-                      {user.last_login
-                        ? new Date(user.last_login).toLocaleDateString("en-US", {
-                            year: "numeric",
-                            month: "short",
-                            day: "numeric",
-                          })
-                        : "Never"}
+                      {user.last_login ? displayFormattedDate(user.last_login) : "Never"}
                     </TableCell>
                     <TableCell sx={{ ...tableStyles.body.cell, textAlign: "right" }}>
                       <Button

--- a/Clients/src/presentation/pages/TrainingRegistar/index.tsx
+++ b/Clients/src/presentation/pages/TrainingRegistar/index.tsx
@@ -43,6 +43,7 @@ import { FileMetadata } from "../../../application/repository/file.repository";
 import { User } from "../../../domain/types/User";
 
 import Alert from "../../../presentation/components/Alert";
+import { displayFormattedDate } from "src/presentation/tools/isoDateToString";
 
 // Types (Type Safety)
 type AlertVariant = "success" | "info" | "warning" | "error";
@@ -849,7 +850,7 @@ const Training: React.FC = () => {
       mapped_trainings: e.mapped_training_ids?.length
         ? e.mapped_training_ids.map((id) => trainingNameById.get(id) || `Training ${id}`).join(", ")
         : "-",
-      expiry_date: e.expiry_date ? new Date(e.expiry_date as any).toLocaleDateString() : "-",
+      expiry_date: e.expiry_date ? displayFormattedDate(e.expiry_date as any) : "-",
     }));
   }, [filteredEvidence, trainingNameById]);
 

--- a/Clients/src/presentation/pages/TrainingRegistar/index.tsx
+++ b/Clients/src/presentation/pages/TrainingRegistar/index.tsx
@@ -43,7 +43,7 @@ import { FileMetadata } from "../../../application/repository/file.repository";
 import { User } from "../../../domain/types/User";
 
 import Alert from "../../../presentation/components/Alert";
-import { displayFormattedDate } from "src/presentation/tools/isoDateToString";
+import { displayFormattedDate } from "../../tools/isoDateToString";
 
 // Types (Type Safety)
 type AlertVariant = "success" | "info" | "warning" | "error";

--- a/Clients/src/presentation/tools/__tests__/isoDateToString.test.ts
+++ b/Clients/src/presentation/tools/__tests__/isoDateToString.test.ts
@@ -1,13 +1,23 @@
 import { describe, it, expect, beforeEach } from "vitest";
-import { formatDate, displayFormattedDate, formatDateTime } from "../isoDateToString";
+import {
+  displayFormattedDate,
+  displayFormattedDateTime,
+  displayFormattedTime,
+  formatDate,
+  formatDateTime,
+} from "../isoDateToString";
 
 describe("formatDate", () => {
-  it("formats an ISO date to 'day month year'", () => {
-    expect(formatDate("2024-11-01")).toBe("1 November 2024");
+  beforeEach(() => {
+    localStorage.clear();
   });
 
-  it("formats another date correctly", () => {
-    expect(formatDate("2023-03-15T00:00:00Z")).toBe("15 March 2023");
+  it("formats an ISO date using the default preference", () => {
+    expect(formatDate("2024-11-01")).toBe("01-11-2024");
+  });
+
+  it("formats another date using the default preference", () => {
+    expect(formatDate("2023-03-15T00:00:00Z")).toBe("15-03-2023");
   });
 
   it("throws for empty string", () => {
@@ -35,6 +45,17 @@ describe("displayFormattedDate", () => {
     expect(result).toBe("11-01-2024");
   });
 
+  it.each([
+    ["DD-MM-YYYY", "01-11-2024"],
+    ["MM-DD-YYYY", "11-01-2024"],
+    ["DD/MM/YY", "01/11/24"],
+    ["MM/DD/YY", "11/01/24"],
+  ])("respects localStorage preference for %s", (dateFormat, expected) => {
+    localStorage.setItem("verifywise_preferences", JSON.stringify({ date_format: dateFormat }));
+    const result = displayFormattedDate("2024-11-01");
+    expect(result).toBe(expected);
+  });
+
   it("handles Date objects", () => {
     // Construct a LOCAL-midnight date so round-trip via toISOString → dayjs
     // (which formats in local) renders the same calendar day in every TZ.
@@ -56,13 +77,43 @@ describe("displayFormattedDate", () => {
   });
 });
 
+describe("displayFormattedTime", () => {
+  it("formats time without seconds by default", () => {
+    expect(displayFormattedTime("2024-11-01T14:30:25")).toBe("14:30");
+  });
+
+  it("formats time with seconds when requested", () => {
+    expect(displayFormattedTime("2024-11-01T14:30:25", { includeSeconds: true })).toBe("14:30:25");
+  });
+});
+
+describe("displayFormattedDateTime", () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  it("formats date and time using the preferred date format", () => {
+    localStorage.setItem("verifywise_preferences", JSON.stringify({ date_format: "MM/DD/YY" }));
+    expect(displayFormattedDateTime("2024-11-01T14:30:25")).toBe("11/01/24, 14:30");
+  });
+
+  it("includes seconds when requested", () => {
+    expect(displayFormattedDateTime("2024-11-01T14:30:25", { includeSeconds: true })).toBe(
+      "01-11-2024, 14:30:25",
+    );
+  });
+
+  it("supports a custom separator", () => {
+    expect(displayFormattedDateTime("2024-11-01T14:30:25", { separator: " at " })).toBe(
+      "01-11-2024 at 14:30",
+    );
+  });
+});
+
 describe("formatDateTime", () => {
   it("formats date with time components", () => {
-    // Use a UTC midnight date, but formatDateTime uses local time
-    // so we test the pattern rather than exact values
-    const result = formatDateTime("2024-11-01T14:30:25Z");
-    // Should contain the date parts and time separated by comma
-    expect(result).toMatch(/\d+ \w+ \d{4}, \d{2}:\d{2}:\d{2}/);
+    const result = formatDateTime("2024-11-01T14:30:25");
+    expect(result).toBe("01-11-2024, 14:30:25");
   });
 
   it("throws for empty string", () => {
@@ -74,9 +125,7 @@ describe("formatDateTime", () => {
   });
 
   it("includes hours, minutes, and seconds", () => {
-    // Use a date where local time will have identifiable components
-    const result = formatDateTime("2024-06-15T00:00:00Z");
-    // Result should match the pattern "day Month year, HH:MM:SS"
-    expect(result).toMatch(/^\d{1,2} \w+ \d{4}, \d{2}:\d{2}:\d{2}$/);
+    const result = formatDateTime("2024-06-15T00:00:00");
+    expect(result).toMatch(/^\d{2}-\d{2}-\d{4}, \d{2}:\d{2}:\d{2}$/);
   });
 });

--- a/Clients/src/presentation/tools/isoDateToString.ts
+++ b/Clients/src/presentation/tools/isoDateToString.ts
@@ -1,27 +1,35 @@
-import dayjs from "dayjs";
+import { format, isValid, parseISO } from "date-fns";
 import { UserDateFormat } from "../../domain/enums/userDateFormat.enum";
 import { storageService } from "../../infrastructure/storage";
 
-/**
- * Converts an ISO date string to a formatted date string.
- *
- * @param {string} isoDate - The ISO date string to be converted.
- * @returns {string} The formatted date string in the format "1 November 2024".
- */
-export function formatDate(isoDate: string): string {
-  if (!isoDate || !/^\d{4}-\d{2}-\d{2}/.test(isoDate)) {
-    throw new Error("Invalid ISO date format");
+const DATE_FORMAT_MAP: Record<UserDateFormat, string> = {
+  [UserDateFormat.DD_MM_YYYY_DASH]: "dd-MM-yyyy",
+  [UserDateFormat.MM_DD_YYYY_DASH]: "MM-dd-yyyy",
+  [UserDateFormat.DD_MM_YY_SLASH]: "dd/MM/yy",
+  [UserDateFormat.MM_DD_YY_SLASH]: "MM/dd/yy",
+};
+
+const getPreferredDateFormat = (): string => {
+  const preferences = storageService.get("preferences", {});
+  const dateFormat = preferences.date_format as UserDateFormat | undefined;
+
+  return dateFormat && DATE_FORMAT_MAP[dateFormat]
+    ? DATE_FORMAT_MAP[dateFormat]
+    : DATE_FORMAT_MAP[UserDateFormat.DD_MM_YYYY_DASH];
+};
+
+const parseDateValue = (value: string | Date): Date | null => {
+  if (value instanceof Date) {
+    return isValid(value) ? value : null;
   }
 
-  const date = new Date(isoDate);
-  const day = date.getUTCDate();
-  const month = date.toLocaleString("default", {
-    month: "long",
-    timeZone: "UTC",
-  });
-  const year = date.getUTCFullYear();
-  return `${day} ${month} ${year}`;
-}
+  if (!value || !/^\d{4}-\d{2}-\d{2}/.test(value)) {
+    return null;
+  }
+
+  const parsed = parseISO(value);
+  return isValid(parsed) ? parsed : null;
+};
 
 /**
  * Converts an ISO date string to a formatted date string based on the user preference.
@@ -30,19 +38,67 @@ export function formatDate(isoDate: string): string {
  * @returns {string} The formatted date string in the format (default: DD-MM-YYYY).
  */
 export const displayFormattedDate = (isoDate: string | Date): string => {
-  const dateStr = isoDate instanceof Date ? isoDate.toISOString() : isoDate;
+  const date = parseDateValue(isoDate);
 
-  if (!dateStr || !/^\d{4}-\d{2}-\d{2}/.test(dateStr)) {
-    console.warn("Invalid ISO date format:", dateStr);
-    return String(dateStr);
+  if (!date) {
+    console.warn("Invalid ISO date format:", isoDate);
+    return String(isoDate);
   }
 
-  const preferences = storageService.get("preferences", {});
-  const dateFormat = (preferences.date_format as UserDateFormat) || UserDateFormat.DD_MM_YYYY_DASH;
-
-  const formattedDate = dayjs(dateStr).format(dateFormat);
-  return formattedDate;
+  return format(date, getPreferredDateFormat());
 };
+
+/**
+ * Converts an ISO date string to a formatted date string based on the user preference.
+ */
+export function formatDate(isoDate: string | Date): string {
+  const date = parseDateValue(isoDate);
+
+  if (!date) {
+    throw new Error("Invalid ISO date format");
+  }
+
+  return format(date, getPreferredDateFormat());
+}
+
+/**
+ * Converts an ISO date string to a formatted time string.
+ */
+export function displayFormattedTime(
+  isoDate: string | Date,
+  options: { includeSeconds?: boolean } = {},
+): string {
+  const date = parseDateValue(isoDate);
+
+  if (!date) {
+    console.warn("Invalid ISO date format:", isoDate);
+    return String(isoDate);
+  }
+
+  return format(date, options.includeSeconds ? "HH:mm:ss" : "HH:mm");
+}
+
+/**
+ * Converts an ISO date string to a formatted date and time string.
+ */
+export function displayFormattedDateTime(
+  isoDate: string | Date,
+  options: { includeSeconds?: boolean; separator?: string } = {},
+): string {
+  const date = parseDateValue(isoDate);
+
+  if (!date) {
+    console.warn("Invalid ISO date format:", isoDate);
+    return String(isoDate);
+  }
+
+  const separator = options.separator ?? ", ";
+  return `${format(date, getPreferredDateFormat())}${separator}${format(
+    date,
+    options.includeSeconds ? "HH:mm:ss" : "HH:mm",
+  )}`;
+}
+
 /**
  * Converts an ISO date string to a formatted date and time string.
  *
@@ -50,21 +106,9 @@ export const displayFormattedDate = (isoDate: string | Date): string => {
  * @returns {string} The formatted date and time string in the format "1 November 2024, 14:30:25".
  */
 export function formatDateTime(isoDate: string): string {
-  if (!isoDate || !/^\d{4}-\d{2}-\d{2}/.test(isoDate)) {
+  if (!parseDateValue(isoDate)) {
     throw new Error("Invalid ISO date format");
   }
 
-  const date = new Date(isoDate);
-  const day = date.getDate();
-  const month = date.toLocaleString("default", {
-    month: "long",
-  });
-  const year = date.getFullYear();
-
-  // Format time with hours, minutes, and seconds
-  const hours = date.getHours().toLocaleString().padStart(2, "0");
-  const minutes = date.getMinutes().toLocaleString().padStart(2, "0");
-  const seconds = date.getSeconds().toLocaleString().padStart(2, "0");
-
-  return `${day} ${month} ${year}, ${hours}:${minutes}:${seconds}`;
+  return displayFormattedDateTime(isoDate, { includeSeconds: true });
 }


### PR DESCRIPTION
## Describe your changes

Centralized frontend date display formatting in `isoDateToString` using `date-fns`, with helpers for date, date-time, and time that honor the stored `date_format` preference.
Migrated presentation tables, detail views, and shared components away from raw `toLocale*` and hard-coded display `dayjs` formats. Verified typecheck, format-check, targeted tests, and zero `toLocale*` matches under `Clients/src/presentation`.

Fixes No. 10 of #4018 

## Please ensure all items are checked off before requesting a review:

- [x] I deployed the code locally.
- [x] I have performed a self-review of my code.
- [x] I have included the issue # in the PR.
- [x] I have labelled the PR correctly.
- [x] The issue I am working on is assigned to me.
- [x] I have avoided using hardcoded values to ensure scalability and maintain consistency across the application.
- [x] I have ensured that font sizes, color choices, and other UI elements are referenced from the theme.
- [x] My pull request is focused and addresses a single, specific feature.
- [ ] If there are UI changes, I have attached a screenshot or video to this PR.
- [ ] If I added or modified an API endpoint, the change is reflected in the generated OpenAPI spec (`npm run generate:swagger`).
- [ ] If the endpoint requires authentication, it uses `authenticateJWT` and the generated spec declares `bearerAuth` security.
- [ ] I ran `npm run check:api-drift` and committed the regenerated `swagger.yaml` and `endpoints.ts`.
