### PR TITLE
Hide AI Gateway Prompts feature behind a flag

### DIFF
--- a/Clients/src/application/config/featureFlags.ts
+++ b/Clients/src/application/config/featureFlags.ts
@@ -1,0 +1,16 @@
+/**
+ * Frontend feature flags.
+ *
+ * Simple compile-time toggles for hiding features from the UI without removing
+ * their code. Flip a flag and every gated touch point follows.
+ */
+
+/**
+ * AI Gateway "Prompts" feature (prompt library / templates).
+ *
+ * When false, the Prompts page is unrouted, its sidebar item and breadcrumbs
+ * are hidden, the Endpoints prompt-template picker stays dormant, and the
+ * user-guide article is unregistered. The page, editor, backend router, CRUD,
+ * and database tables remain in place; set this to true to surface it again.
+ */
+export const SHOW_AI_GATEWAY_PROMPTS = false;

--- a/Clients/src/application/config/routes.tsx
+++ b/Clients/src/application/config/routes.tsx
@@ -1,6 +1,7 @@
 import { Suspense } from "react";
 import { Route, Navigate } from "react-router-dom";
 import { lazyRoute, LazyFallback } from "../utils/lazyRoute";
+import { SHOW_AI_GATEWAY_PROMPTS } from "./featureFlags";
 
 // Eager imports — app shell, route guard, and Use cases page (mounts with layout for table skeleton UX)
 import Dashboard from "../../presentation/containers/Dashboard";
@@ -917,22 +918,27 @@ export const createRoutes = (
         </Suspense>
       }
     />
-    <Route
-      path="/ai-gateway/prompts"
-      element={
-        <Suspense fallback={<LazyFallback />}>
-          <AIGatewayPromptsPage />
-        </Suspense>
-      }
-    />
-    <Route
-      path="/ai-gateway/prompts/:id"
-      element={
-        <Suspense fallback={<LazyFallback />}>
-          <AIGatewayPromptEditorPage />
-        </Suspense>
-      }
-    />
+    {/* Prompts routes are gated behind SHOW_AI_GATEWAY_PROMPTS. */}
+    {SHOW_AI_GATEWAY_PROMPTS && (
+      <Route
+        path="/ai-gateway/prompts"
+        element={
+          <Suspense fallback={<LazyFallback />}>
+            <AIGatewayPromptsPage />
+          </Suspense>
+        }
+      />
+    )}
+    {SHOW_AI_GATEWAY_PROMPTS && (
+      <Route
+        path="/ai-gateway/prompts/:id"
+        element={
+          <Suspense fallback={<LazyFallback />}>
+            <AIGatewayPromptEditorPage />
+          </Suspense>
+        }
+      />
+    )}
     <Route
       path="/ai-gateway/virtual-keys"
       element={

--- a/Clients/src/application/contexts/AIGatewaySidebar.context.tsx
+++ b/Clients/src/application/contexts/AIGatewaySidebar.context.tsx
@@ -7,6 +7,7 @@
 
 import { createContext, useContext, useState, useEffect, ReactNode, FC } from "react";
 import { apiServices } from "../../infrastructure/api/networkServices";
+import { SHOW_AI_GATEWAY_PROMPTS } from "../config/featureFlags";
 
 interface AIGatewaySidebarContextType {
   activeTab: string;
@@ -31,9 +32,13 @@ export const AIGatewaySidebarProvider: FC<{ children: ReactNode }> = ({ children
     let cancelled = false;
     const load = async () => {
       try {
+        // Prompts is gated behind SHOW_AI_GATEWAY_PROMPTS — when off, its badge
+        // count is not fetched and stays at 0.
         const [endpointsRes, promptsRes, vkeysRes] = await Promise.all([
           apiServices.get<Record<string, any>>("/ai-gateway/endpoints").catch(() => null),
-          apiServices.get<Record<string, any>>("/ai-gateway/prompts").catch(() => null),
+          SHOW_AI_GATEWAY_PROMPTS
+            ? apiServices.get<Record<string, any>>("/ai-gateway/prompts").catch(() => null)
+            : Promise.resolve(null),
           apiServices.get<Record<string, any>>("/ai-gateway/virtual-keys").catch(() => null),
         ]);
         if (cancelled) return;

--- a/Clients/src/application/contexts/__tests__/AIGatewaySidebar.context.test.tsx
+++ b/Clients/src/application/contexts/__tests__/AIGatewaySidebar.context.test.tsx
@@ -58,7 +58,9 @@ describe("AIGatewaySidebarContext", () => {
       await waitFor(() => {
         expect(result.current.endpointsCount).toBe(2); // 2 active
       });
-      expect(result.current.promptsCount).toBe(2);
+      // Prompts is hidden behind SHOW_AI_GATEWAY_PROMPTS (currently off), so the
+      // provider does not fetch the prompts count and it stays at 0.
+      expect(result.current.promptsCount).toBe(0);
       expect(result.current.virtualKeysCount).toBe(1); // 1 active
     });
 

--- a/Clients/src/presentation/pages/AIGateway/AIGatewaySidebar.tsx
+++ b/Clients/src/presentation/pages/AIGateway/AIGatewaySidebar.tsx
@@ -26,6 +26,7 @@ import SidebarShell, {
   SidebarMenuItem,
   SidebarMenuGroup,
 } from "../../components/Sidebar/SidebarShell";
+import { SHOW_AI_GATEWAY_PROMPTS } from "../../../application/config/featureFlags";
 
 interface AIGatewaySidebarProps {
   activeTab: string;
@@ -67,13 +68,19 @@ export default function AIGatewaySidebar({
       value: "guardrails",
       icon: <ShieldCheck size={16} strokeWidth={1.5} />,
     },
-    {
-      id: "prompts",
-      label: "Prompts",
-      value: "prompts",
-      icon: <BookOpen size={16} strokeWidth={1.5} />,
-      count: promptsCount,
-    },
+    // Prompts is gated behind SHOW_AI_GATEWAY_PROMPTS — hidden from the UI
+    // while the page, routes, and backend remain in place.
+    ...(SHOW_AI_GATEWAY_PROMPTS
+      ? [
+          {
+            id: "prompts",
+            label: "Prompts",
+            value: "prompts",
+            icon: <BookOpen size={16} strokeWidth={1.5} />,
+            count: promptsCount,
+          },
+        ]
+      : []),
     {
       id: "models",
       label: "Models",

--- a/Clients/src/presentation/pages/AIGateway/Endpoints/index.tsx
+++ b/Clients/src/presentation/pages/AIGateway/Endpoints/index.tsx
@@ -25,6 +25,7 @@ import { apiServices } from "../../../../infrastructure/api/networkServices";
 import palette from "../../../themes/palette";
 import { useCardSx, ProviderIcon, useGatewayModels, slugify } from "../shared";
 import { displayFormattedDate } from "../../../tools/isoDateToString";
+import { SHOW_AI_GATEWAY_PROMPTS } from "../../../../application/config/featureFlags";
 
 interface EndpointForm {
   display_name: string;
@@ -73,6 +74,9 @@ export default function EndpointsPage() {
   const [formError, setFormError] = useState("");
   const [deleteTarget, setDeleteTarget] = useState<{ id: number; name: string } | null>(null);
 
+  // Prompts is gated behind SHOW_AI_GATEWAY_PROMPTS. When the flag is off the
+  // list stays empty, so the prompt-template picker and bound-prompt chip
+  // render nothing.
   const [prompts, setPrompts] = useState<any[]>([]);
   const [form, setForm] = useState<EndpointForm>({ ...EMPTY_FORM });
   const { providerItems, getModelsForProvider } = useGatewayModels();
@@ -83,7 +87,9 @@ export default function EndpointsPage() {
         apiServices.get<Record<string, any>>("/ai-gateway/endpoints"),
         apiServices.get<Record<string, any>>("/ai-gateway/keys"),
         apiServices.get<Record<string, any>>("/ai-gateway/guardrails").catch(() => null),
-        apiServices.get<Record<string, any>>("/ai-gateway/prompts").catch(() => null),
+        SHOW_AI_GATEWAY_PROMPTS
+          ? apiServices.get<Record<string, any>>("/ai-gateway/prompts").catch(() => null)
+          : Promise.resolve(null),
       ]);
       setEndpoints(endpointsRes?.data?.endpoints || []);
       setApiKeys(keysRes?.data?.data || []);

--- a/shared/user-guide-content/content/index.ts
+++ b/shared/user-guide-content/content/index.ts
@@ -83,7 +83,9 @@ import { guardrailsContent as aiGatewayGuardrailsContent } from './ai-gateway/gu
 import { aiGatewaySettingsContent } from './ai-gateway/settings';
 import { virtualKeysContent as aiGatewayVirtualKeysContent } from './ai-gateway/virtual-keys';
 import { logsContent as aiGatewayLogsContent } from './ai-gateway/logs';
-import { promptsContent as aiGatewayPromptsContent } from './ai-gateway/prompts';
+// Prompts is hidden behind SHOW_AI_GATEWAY_PROMPTS in the app; its content is
+// unregistered here while the feature is hidden (see userGuideConfig.ts).
+// import { promptsContent as aiGatewayPromptsContent } from './ai-gateway/prompts';
 import { aiGatewayModelsContent } from './ai-gateway/models';
 import { mcpOverviewContent } from './ai-gateway/mcp-overview';
 import { mcpServersContent } from './ai-gateway/mcp-servers';
@@ -210,7 +212,8 @@ export const articleContentMap: Record<string, ArticleContent> = {
   'ai-gateway/settings': aiGatewaySettingsContent,
   'ai-gateway/virtual-keys': aiGatewayVirtualKeysContent,
   'ai-gateway/logs': aiGatewayLogsContent,
-  'ai-gateway/prompts': aiGatewayPromptsContent,
+  // Prompts feature hidden from the UI.
+  // 'ai-gateway/prompts': aiGatewayPromptsContent,
   'ai-gateway/models': aiGatewayModelsContent,
   // Agent Control
   'ai-gateway/mcp-overview': mcpOverviewContent,

--- a/shared/user-guide-content/userGuideConfig.ts
+++ b/shared/user-guide-content/userGuideConfig.ts
@@ -620,12 +620,16 @@ export const collections: Collection[] = [
         description: 'View, filter, and inspect every request that flows through the AI Gateway.',
         keywords: ['logs', 'request', 'response', 'audit', 'filter', 'search', 'status', 'error', 'auto-refresh', 'conversation'],
       },
-      {
-        id: 'prompts',
-        title: 'Prompts',
-        description: 'Create versioned prompt templates with variables, test them with streaming responses, and bind them to endpoints.',
-        keywords: ['prompt', 'template', 'variable', 'version', 'publish', 'draft', 'system prompt', 'message', 'test', 'editor'],
-      },
+      // Prompts is hidden in the app behind the SHOW_AI_GATEWAY_PROMPTS flag
+      // (Clients/src/application/config/featureFlags.ts). This shared package
+      // cannot import that flag, so the article stays unregistered here while
+      // the feature is hidden. Restore both together to bring it back.
+      // {
+      //   id: 'prompts',
+      //   title: 'Prompts',
+      //   description: 'Create versioned prompt templates with variables, test them with streaming responses, and bind them to endpoints.',
+      //   keywords: ['prompt', 'template', 'variable', 'version', 'publish', 'draft', 'system prompt', 'message', 'test', 'editor'],
+      // },
       {
         id: 'models',
         title: 'Models',


### PR DESCRIPTION
## Changes

Hides the AI Gateway / Agent Control **Prompts** feature (prompt library / templates) from the UI, gated behind a single `SHOW_AI_GATEWAY_PROMPTS` flag (defaulted off). Frontend-only — the page, editor, Python router, CRUD, and database tables are untouched.

- New `Clients/src/application/config/featureFlags.ts` is the single source of truth, matching the existing `SHOW_AI_AGENT_DASHBOARD_TABS` pattern.
- Sidebar nav item, the two `/ai-gateway/prompts` routes, the Endpoints prompt fetch, and the sidebar badge count are gated on the flag as live code (no commented-out blocks).
- Breadcrumb entries are left as plain live code; they are inert because the route is unreachable when the flag is off.
- The shared user-guide package cannot import the frontend flag, so the Prompts article stays unregistered there with a note pointing at the flag.
- Updated the `AIGatewaySidebar.context` test: `promptsCount` is `0` when the flag is off because the provider no longer fetches it.

## Benefits

- Flipping `SHOW_AI_GATEWAY_PROMPTS` to `true` restores the whole feature in one place — no risk of half-wired restoration.
- Editing an endpoint that already has a bound prompt does not lose the binding: the value round-trips through the form from the endpoint object, and the picker stays hidden.

## Notes

- Build, typecheck, format-check, and i18n audit all pass locally; the previously affected unit test now passes.
- No backend or migration changes. The prompts endpoints remain live but unreachable from the UI.