### PR TITLE
feat(frontend): apply TableEmptyStateLayout to inventory and framewok tables

### DIFF
--- a/Clients/src/i18n/translations.ts
+++ b/Clients/src/i18n/translations.ts
@@ -4790,6 +4790,7 @@ export const translations: Record<string, Record<string, string>> = {
       "Keine Ordner verfügbar. Erstellen Sie zuerst einen Ordner.",
     "No folders yet": "Noch keine Ordner",
     "No framework plugins available.": "Keine Rahmenwerk-Plugins verfügbar.",
+    "No framework risks yet": "Noch keine Rahmenwerksrisiken",
     "No frameworks available. Please contact support if this issue persists.":
       "Keine Rahmenwerke verfügbar. Bitte wenden Sie sich an den Support, falls das Problem bestehen bleibt.",
     "No frameworks enabled for this organization.":
@@ -13422,6 +13423,7 @@ export const translations: Record<string, Record<string, string>> = {
       "Aucun dossier disponible. Créez d'abord un dossier.",
     "No folders yet": "Pas encore de dossiers",
     "No framework plugins available.": "Aucun plugin de référentiel disponible.",
+    "No framework risks yet": "Pas encore de risques du référentiel",
     "No frameworks available. Please contact support if this issue persists.":
       "Aucun référentiel disponible. Veuillez contacter le support si le problème persiste.",
     "No frameworks enabled for this organization.":
@@ -20299,6 +20301,7 @@ export const translations: Record<string, Record<string, string>> = {
     "No feedback files attached yet": "Aún no hay archivos de comentarios adjuntos",
     "No folders yet": "Aún no hay carpetas",
     "No framework plugins available.": "No hay complementos de marcos disponibles.",
+    "No framework risks yet": "Aún no hay riesgos del marco",
     "No frameworks installed": "No hay marcos instalados",
     "No local providers configured yet": "Aún no hay proveedores locales configurados",
     "No log data available.": "No hay datos de registro disponibles.",

--- a/Clients/src/presentation/components/LinkedModelsView/index.tsx
+++ b/Clients/src/presentation/components/LinkedModelsView/index.tsx
@@ -17,6 +17,7 @@ import CustomizableSkeleton from "../Skeletons";
 import singleTheme from "../../themes/v1SingleTheme";
 import { ModelInventoryStatus } from "../../../domain/enums/modelInventory.enum";
 import { EmptyState } from "../EmptyState";
+import { TableEmptyStateLayout } from "../Table/TableEmptyStateLayout";
 import { VWLink } from "../Link";
 import InfoBox from "../InfoBox";
 
@@ -108,31 +109,37 @@ export function LinkedModelsView({
     return (
       <Stack spacing={3}>
         {headerContent}
-        <Stack
-          alignItems="center"
-          justifyContent="center"
-          sx={{
-            minHeight: 300,
-            backgroundColor: theme.palette.background.paper,
-            borderRadius: 1,
-            border: `1px solid ${theme.palette.divider}`,
-          }}
+        <TableEmptyStateLayout
+          header={
+            <TableHead
+              sx={{
+                backgroundColor: singleTheme.tableStyles.primary.header.backgroundColors,
+              }}
+            >
+              <TableRow sx={singleTheme.tableStyles.primary.header.row}>
+                {TABLE_COLUMNS.map((column) => (
+                  <TableCell key={column.id} sx={singleTheme.tableStyles.primary.header.cell}>
+                    {column.label}
+                  </TableCell>
+                ))}
+              </TableRow>
+            </TableHead>
+          }
         >
-          <EmptyState icon={Cpu} message={emptyMessage} />
-          <Typography
-            sx={{
-              color: theme.palette.text.tertiary,
-              fontSize: 13,
-              mt: 1,
-              textAlign: "center",
-              maxWidth: 500,
-            }}
-          >
-            To link a model to this framework, you first need to add it to your model inventory.
-            When adding a model, you can select which framework(s) to link it to.{" "}
-            <VWLink onClick={() => navigate("/model-inventory")}>Go to Model Inventory</VWLink>
-          </Typography>
-        </Stack>
+          <EmptyState icon={Cpu} message={emptyMessage}>
+            <Typography
+              sx={{
+                color: theme.palette.text.tertiary,
+                fontSize: 13,
+                textAlign: "center",
+              }}
+            >
+              To link a model to this framework, you first need to add it to your model inventory.
+              When adding a model, you can select which framework(s) to link it to.{" "}
+              <VWLink onClick={() => navigate("/model-inventory")}>Go to Model Inventory</VWLink>
+            </Typography>
+          </EmptyState>
+        </TableEmptyStateLayout>
       </Stack>
     );
   }

--- a/Clients/src/presentation/components/RisksView/index.tsx
+++ b/Clients/src/presentation/components/RisksView/index.tsx
@@ -28,6 +28,8 @@ const RisksView = ({
   headerContent,
   refreshTrigger,
   readOnly = false,
+  emptyMessage,
+  showEmptyTips = false,
 }: IRisksViewProps) => {
   const { users, loading: usersLoading } = useUsers();
   const { userRoleName } = useAuth();
@@ -332,6 +334,8 @@ const RisksView = ({
               flashRow={null}
               canRunBulkActions={canRunBulkActions}
               onBulkActionSuccess={() => setRefreshKey((k) => k + 1)}
+              emptyMessage={emptyMessage}
+              showEmptyTips={showEmptyTips}
             />
           )}
         </Stack>

--- a/Clients/src/presentation/components/Table/VWProjectRisksTable/index.tsx
+++ b/Clients/src/presentation/components/Table/VWProjectRisksTable/index.tsx
@@ -2,7 +2,6 @@ import {
   Box,
   Stack,
   Table,
-  TableBody,
   TableCell,
   TableContainer,
   TablePagination,
@@ -23,9 +22,14 @@ import {
   UserCheck,
   Tag as TagIcon,
   Archive,
+  TrendingDown,
+  Grid3X3,
+  ListChecks,
 } from "lucide-react";
 import VWProjectRisksTableBody from "./VWProjectRisksTableBody";
 import { EmptyState } from "../../EmptyState";
+import EmptyStateTip from "../../EmptyState/EmptyStateTip";
+import { TableEmptyStateLayout } from "../TableEmptyStateLayout";
 import { IVWProjectRisksTable } from "../../../types/interfaces/i.risk";
 import { RiskModel } from "../../../../domain/models/Common/risks/risk.model";
 import { text } from "../../../themes/palette";
@@ -204,6 +208,8 @@ const VWProjectRisksTable = ({
   visibleColumns,
   canRunBulkActions = false,
   onBulkActionSuccess,
+  emptyMessage = "There is currently no data in this table.",
+  showEmptyTips = false,
 }: IVWProjectRisksTable) => {
   const { data: customFieldDefs = [] } = useCustomFieldDefinitions("project_risk");
 
@@ -512,162 +518,194 @@ const VWProjectRisksTable = ({
   );
 
   return (
-    <Stack sx={{ width: "100%" }}>
-      {canRunBulkActions && (
-        <BulkActionsToolbar
-          count={selectionCount}
-          onClear={clearSelection}
-          actions={bulkActions}
-          selectAll={{
-            totalCount: allSelectableRiskIds.length,
-            onSelectAll: () => setAllSelected(allSelectableRiskIds),
-          }}
-        />
-      )}
-      <TableContainer>
-        <Table
-          sx={{
-            ...singleTheme.tableStyles.primary.frame,
-          }}
-        >
-          <SortableTableHead
-            columns={filteredColumns}
-            sortConfig={sortConfig}
-            onSort={handleSort}
-            selection={
-              canRunBulkActions
-                ? {
-                    allSelected: allSelected && selectableRows.length > 0,
-                    someSelected,
-                    onToggleAll: toggleAll,
-                  }
-                : undefined
-            }
-          />
-          {sortedRows.length !== 0 ? (
-            <VWProjectRisksTableBody
-              rows={sortedRows}
-              page={hidePagination ? 0 : page}
-              rowsPerPage={hidePagination ? sortedRows.length : rowsPerPage}
-              setSelectedRow={setSelectedRow}
-              setAnchor={setAnchor}
-              onDeleteRisk={onDeleteRisk}
-              flashRow={flashRow}
+    <>
+      {sortedRows.length === 0 ? (
+        <TableEmptyStateLayout
+          header={
+            <SortableTableHead
+              columns={filteredColumns}
               sortConfig={sortConfig}
-              visibleColumns={visibleColumns}
-              customFieldDefs={customFieldDefs}
-              selection={canRunBulkActions ? { isSelected, onToggle: toggleSelection } : undefined}
+              onSort={handleSort}
+              selection={
+                canRunBulkActions
+                  ? {
+                      allSelected: false,
+                      someSelected: false,
+                      onToggleAll: toggleAll,
+                    }
+                  : undefined
+              }
             />
-          ) : (
-            <TableBody>
-              <TableRow>
-                <TableCell
-                  colSpan={filteredColumns.length + (canRunBulkActions ? 1 : 0)}
-                  sx={{ border: "none", p: 0 }}
-                >
-                  <EmptyState
-                    icon={ShieldAlert}
-                    message="There is currently no data in this table."
-                  />
-                </TableCell>
-              </TableRow>
-            </TableBody>
+          }
+          tableSx={{ ...singleTheme.tableStyles.primary.frame }}
+        >
+          <EmptyState icon={ShieldAlert} message={emptyMessage}>
+            {showEmptyTips && (
+              <>
+                <EmptyStateTip
+                  icon={TrendingDown}
+                  title="Identify AI-specific risks"
+                  description="Document risks related to bias, data quality, security, transparency, and model drift. Cover both technical and organizational risks."
+                />
+                <EmptyStateTip
+                  icon={Grid3X3}
+                  title="Assess likelihood and impact"
+                  description="Rate each risk by likelihood and impact. The risk score and level help you prioritize what needs attention first."
+                />
+                <EmptyStateTip
+                  icon={ListChecks}
+                  title="Create treatment plans"
+                  description="Define mitigation strategies for each risk and track their progress. Link treatments to specific controls for full traceability."
+                />
+              </>
+            )}
+          </EmptyState>
+        </TableEmptyStateLayout>
+      ) : (
+        <Stack sx={{ width: "100%" }}>
+          {canRunBulkActions && (
+            <BulkActionsToolbar
+              count={selectionCount}
+              onClear={clearSelection}
+              actions={bulkActions}
+              selectAll={{
+                totalCount: allSelectableRiskIds.length,
+                onSelectAll: () => setAllSelected(allSelectableRiskIds),
+              }}
+            />
           )}
-          {!hidePagination && (
-            <TableFooter>
-              <TableRow>
-                <TableCell
-                  colSpan={filteredColumns.length + (canRunBulkActions ? 1 : 0)}
-                  sx={{ border: "none", p: 0 }}
-                >
-                  <Box
-                    sx={{
-                      display: "flex",
-                      flexDirection: "row",
-                      justifyContent: "space-between",
-                      alignItems: "center",
-                      paddingX: theme.spacing(4),
-                    }}
-                  >
-                    <Typography
-                      sx={{
-                        paddingX: theme.spacing(2),
-                        fontSize: 12,
-                        opacity: 0.7,
-                        color: theme.palette.text.tertiary,
-                        whiteSpace: "nowrap",
-                      }}
+          <TableContainer>
+            <Table
+              sx={{
+                ...singleTheme.tableStyles.primary.frame,
+              }}
+            >
+              <SortableTableHead
+                columns={filteredColumns}
+                sortConfig={sortConfig}
+                onSort={handleSort}
+                selection={
+                  canRunBulkActions
+                    ? {
+                        allSelected: allSelected && selectableRows.length > 0,
+                        someSelected,
+                        onToggleAll: toggleAll,
+                      }
+                    : undefined
+                }
+              />
+              <VWProjectRisksTableBody
+                rows={sortedRows}
+                page={hidePagination ? 0 : page}
+                rowsPerPage={hidePagination ? sortedRows.length : rowsPerPage}
+                setSelectedRow={setSelectedRow}
+                setAnchor={setAnchor}
+                onDeleteRisk={onDeleteRisk}
+                flashRow={flashRow}
+                sortConfig={sortConfig}
+                visibleColumns={visibleColumns}
+                customFieldDefs={customFieldDefs}
+                selection={
+                  canRunBulkActions ? { isSelected, onToggle: toggleSelection } : undefined
+                }
+              />
+              {!hidePagination && (
+                <TableFooter>
+                  <TableRow>
+                    <TableCell
+                      colSpan={filteredColumns.length + (canRunBulkActions ? 1 : 0)}
+                      sx={{ border: "none", p: 0 }}
                     >
-                      Showing {getRange} of {sortedRows?.length} project risk(s)
-                    </Typography>
-                    <Box sx={{ display: "flex", alignItems: "center" }}>
-                      <TablePagination
-                        component="div"
-                        count={sortedRows?.length}
-                        page={validPage}
-                        onPageChange={handleChangePage}
-                        rowsPerPage={rowsPerPage}
-                        rowsPerPageOptions={[5, 10, 15, 20, 25]}
-                        onRowsPerPageChange={handleChangeRowsPerPage}
-                        ActionsComponent={(props) => <TablePaginationActions {...props} />}
-                        labelRowsPerPage="Project risks per page"
-                        labelDisplayedRows={({ page, count }) =>
-                          `Page ${page + 1} of ${Math.max(0, Math.ceil(count / rowsPerPage))}`
-                        }
+                      <Box
                         sx={{
-                          "mt": theme.spacing(6),
-                          "color": theme.palette.text.secondary,
-                          "& .MuiSelect-select": {
-                            width: theme.spacing(10),
-                            borderRadius: theme.shape.borderRadius,
-                            border: `1px solid ${theme.palette.border.light}`,
-                            padding: theme.spacing(4),
-                          },
-                          "& .MuiTablePagination-selectIcon": {
-                            width: "24px",
-                            height: "fit-content",
-                          },
+                          display: "flex",
+                          flexDirection: "row",
+                          justifyContent: "space-between",
+                          alignItems: "center",
+                          paddingX: theme.spacing(4),
                         }}
-                        slotProps={{
-                          select: {
-                            MenuProps: {
-                              keepMounted: true,
-                              PaperProps: {
-                                className: "pagination-dropdown",
+                      >
+                        <Typography
+                          sx={{
+                            paddingX: theme.spacing(2),
+                            fontSize: 12,
+                            opacity: 0.7,
+                            color: theme.palette.text.tertiary,
+                            whiteSpace: "nowrap",
+                          }}
+                        >
+                          Showing {getRange} of {sortedRows?.length} project risk(s)
+                        </Typography>
+                        <Box sx={{ display: "flex", alignItems: "center" }}>
+                          <TablePagination
+                            component="div"
+                            count={sortedRows?.length}
+                            page={validPage}
+                            onPageChange={handleChangePage}
+                            rowsPerPage={rowsPerPage}
+                            rowsPerPageOptions={[5, 10, 15, 20, 25]}
+                            onRowsPerPageChange={handleChangeRowsPerPage}
+                            ActionsComponent={(props) => <TablePaginationActions {...props} />}
+                            labelRowsPerPage="Project risks per page"
+                            labelDisplayedRows={({ page, count }) =>
+                              `Page ${page + 1} of ${Math.max(0, Math.ceil(count / rowsPerPage))}`
+                            }
+                            sx={{
+                              "mt": theme.spacing(6),
+                              "color": theme.palette.text.secondary,
+                              "& .MuiSelect-select": {
+                                width: theme.spacing(10),
+                                borderRadius: theme.shape.borderRadius,
+                                border: `1px solid ${theme.palette.border.light}`,
+                                padding: theme.spacing(4),
+                              },
+                              "& .MuiTablePagination-selectIcon": {
+                                width: "24px",
+                                height: "fit-content",
+                              },
+                            }}
+                            slotProps={{
+                              select: {
+                                MenuProps: {
+                                  keepMounted: true,
+                                  PaperProps: {
+                                    className: "pagination-dropdown",
+                                    sx: {
+                                      mt: 0,
+                                      mb: theme.spacing(2),
+                                    },
+                                  },
+                                  transformOrigin: {
+                                    vertical: "bottom",
+                                    horizontal: "left",
+                                  },
+                                  anchorOrigin: { vertical: "top", horizontal: "left" },
+                                  sx: { mt: theme.spacing(-2) },
+                                },
+                                inputProps: { id: "pagination-dropdown" },
+                                IconComponent: SelectorVertical,
                                 sx: {
-                                  mt: 0,
-                                  mb: theme.spacing(2),
+                                  "ml": theme.spacing(4),
+                                  "mr": theme.spacing(12),
+                                  "minWidth": theme.spacing(20),
+                                  "textAlign": "left",
+                                  "&.Mui-focused > div": {
+                                    backgroundColor: theme.palette.background.main,
+                                  },
                                 },
                               },
-                              transformOrigin: {
-                                vertical: "bottom",
-                                horizontal: "left",
-                              },
-                              anchorOrigin: { vertical: "top", horizontal: "left" },
-                              sx: { mt: theme.spacing(-2) },
-                            },
-                            inputProps: { id: "pagination-dropdown" },
-                            IconComponent: SelectorVertical,
-                            sx: {
-                              "ml": theme.spacing(4),
-                              "mr": theme.spacing(12),
-                              "minWidth": theme.spacing(20),
-                              "textAlign": "left",
-                              "&.Mui-focused > div": {
-                                backgroundColor: theme.palette.background.main,
-                              },
-                            },
-                          },
-                        }}
-                      />
-                    </Box>
-                  </Box>
-                </TableCell>
-              </TableRow>
-            </TableFooter>
-          )}
-        </Table>
-      </TableContainer>
+                            }}
+                          />
+                        </Box>
+                      </Box>
+                    </TableCell>
+                  </TableRow>
+                </TableFooter>
+              )}
+            </Table>
+          </TableContainer>
+        </Stack>
+      )}
 
       {canRunBulkActions && ownerDialogOpen && (
         <ConfirmationModal
@@ -743,7 +781,7 @@ const VWProjectRisksTable = ({
           isLoading={bulkMutation.isPending}
         />
       )}
-    </Stack>
+    </>
   );
 };
 

--- a/Clients/src/presentation/pages/Framework/FrameworkRisks/index.tsx
+++ b/Clients/src/presentation/pages/Framework/FrameworkRisks/index.tsx
@@ -69,6 +69,7 @@ const FrameworkRisks = ({
       title="Framework risks"
       headerContent={frameworkToggle}
       refreshTrigger={selectedFramework}
+      emptyMessage="No framework risks yet"
     />
   );
 };

--- a/Clients/src/presentation/pages/ModelInventory/DatasetTable.tsx
+++ b/Clients/src/presentation/pages/ModelInventory/DatasetTable.tsx
@@ -31,6 +31,9 @@ import {
 } from "lucide-react";
 import EmptyStateTip from "../../components/EmptyState/EmptyStateTip";
 import { EmptyState } from "../../components/EmptyState";
+import StandardTableHead from "../../components/Table/StandardTableHead";
+import { TableEmptyStateLayout } from "../../components/Table/TableEmptyStateLayout";
+import type { StandardColumn } from "../../../domain/types/standardTable";
 import { DatasetTableProps } from "../../../domain/interfaces/i.dataset";
 import {
   getPaginationRowCount,
@@ -241,6 +244,16 @@ const DatasetTable: React.FC<DatasetTableProps> = ({
     [isVisible],
   );
 
+  const standardTableColumns: StandardColumn[] = useMemo(
+    () =>
+      visibleTableColumns.map((col) => ({
+        id: col.id,
+        label: col.label,
+        sortable: col.sortable,
+      })),
+    [visibleTableColumns],
+  );
+
   const handleRowClick = useCallback(
     (e: React.MouseEvent, datasetId: string) => {
       if ((e.target as HTMLElement).closest("button") || (e.target as HTMLElement).closest("a")) {
@@ -263,27 +276,37 @@ const DatasetTable: React.FC<DatasetTableProps> = ({
 
   if (!data || data.length === 0) {
     return (
-      <EmptyState
-        icon={Database}
-        message="No datasets found. Add a dataset to start tracking your AI training and validation data."
-        showBorder={true}
+      <TableEmptyStateLayout
+        header={
+          <StandardTableHead
+            columns={standardTableColumns}
+            sortConfig={{ key: sortConfig.key, direction: sortConfig.direction }}
+            onSort={handleSort}
+          />
+        }
+        tableSx={{ minWidth: 650, ...singleTheme.tableStyles.primary.frame }}
       >
-        <EmptyStateTip
-          icon={FileSpreadsheet}
-          title="What to document"
-          description="Record dataset name, source, size, format, and the date it was collected or last updated. Include any preprocessing steps applied."
-        />
-        <EmptyStateTip
-          icon={Tag}
-          title="Label data quality"
-          description="Note whether the dataset has been reviewed for bias, completeness, and accuracy. Track any known quality issues or limitations."
-        />
-        <EmptyStateTip
-          icon={Link2}
-          title="Link to models"
-          description="Connect each dataset to the models that use it for training or validation. This creates traceability for audits and impact analysis."
-        />
-      </EmptyState>
+        <EmptyState
+          icon={Database}
+          message="No datasets found. Add a dataset to start tracking your AI training and validation data."
+        >
+          <EmptyStateTip
+            icon={FileSpreadsheet}
+            title="What to document"
+            description="Record dataset name, source, size, format, and the date it was collected or last updated. Include any preprocessing steps applied."
+          />
+          <EmptyStateTip
+            icon={Tag}
+            title="Label data quality"
+            description="Note whether the dataset has been reviewed for bias, completeness, and accuracy. Track any known quality issues or limitations."
+          />
+          <EmptyStateTip
+            icon={Link2}
+            title="Link to models"
+            description="Connect each dataset to the models that use it for training or validation. This creates traceability for audits and impact analysis."
+          />
+        </EmptyState>
+      </TableEmptyStateLayout>
     );
   }
 

--- a/Clients/src/presentation/pages/ModelInventory/ModelRisksTable.tsx
+++ b/Clients/src/presentation/pages/ModelInventory/ModelRisksTable.tsx
@@ -14,6 +14,7 @@ import {
 } from "@mui/material";
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { EmptyState } from "../../components/EmptyState";
+import { TableEmptyStateLayout } from "../../components/Table/TableEmptyStateLayout";
 import CustomizableSkeleton from "../../components/Skeletons";
 import singleTheme from "../../themes/v1SingleTheme";
 import IconButton from "../../components/IconButton";
@@ -504,106 +505,107 @@ const ModelRisksTable: React.FC<ModelRisksTableProps> = ({
     );
   }
 
-  return (
-    <>
-      {/* Empty state outside the table */}
-      {!data || data.length === 0 ? (
+  if (!data || data.length === 0) {
+    return (
+      <TableEmptyStateLayout header={tableHeader}>
         <EmptyState
           icon={ShieldAlert}
           message="There are currently no model risks in this table."
         />
-      ) : (
-        <TableContainer>
-          <Table sx={{ ...singleTheme.tableStyles.primary.frame }}>
-            {tableHeader}
-            {tableBody}
-            {!hidePagination && (
-              <TableFooter>
-                <TableRow
-                  sx={{
-                    "& .MuiTableCell-root.MuiTableCell-footer": {
-                      paddingX: theme.spacing(8),
-                      paddingY: theme.spacing(4),
-                    },
-                  }}
-                >
-                  <TableCell
-                    sx={{
-                      paddingX: theme.spacing(2),
-                      fontSize: 12,
-                      opacity: 0.7,
-                    }}
-                  >
-                    Showing {getRange} of {dataLength} model risk(s)
-                  </TableCell>
-                  <TablePagination
-                    count={dataLength}
-                    page={page}
-                    onPageChange={handleChangePage}
-                    rowsPerPage={rowsPerPage}
-                    rowsPerPageOptions={[5, 10, 15, 25]}
-                    onRowsPerPageChange={handleChangeRowsPerPage}
-                    ActionsComponent={(props) => <TablePaginationActions {...props} />}
-                    labelRowsPerPage="Rows per page"
-                    labelDisplayedRows={({ page, count }) =>
-                      `Page ${page + 1} of ${Math.max(0, Math.ceil(count / rowsPerPage))}`
-                    }
-                    slotProps={{
-                      select: {
-                        MenuProps: {
-                          keepMounted: true,
-                          PaperProps: {
-                            className: "pagination-dropdown",
-                            sx: {
-                              mt: 0,
-                              mb: theme.spacing(2),
-                            },
-                          },
-                          transformOrigin: {
-                            vertical: "bottom",
-                            horizontal: "left",
-                          },
-                          anchorOrigin: {
-                            vertical: "top",
-                            horizontal: "left",
-                          },
-                          sx: { mt: theme.spacing(-2) },
-                        },
-                        inputProps: { id: "pagination-dropdown" },
-                        IconComponent: SelectorVertical,
+      </TableEmptyStateLayout>
+    );
+  }
+
+  return (
+    <TableContainer>
+      <Table sx={{ ...singleTheme.tableStyles.primary.frame }}>
+        {tableHeader}
+        {tableBody}
+        {!hidePagination && (
+          <TableFooter>
+            <TableRow
+              sx={{
+                "& .MuiTableCell-root.MuiTableCell-footer": {
+                  paddingX: theme.spacing(8),
+                  paddingY: theme.spacing(4),
+                },
+              }}
+            >
+              <TableCell
+                sx={{
+                  paddingX: theme.spacing(2),
+                  fontSize: 12,
+                  opacity: 0.7,
+                }}
+              >
+                Showing {getRange} of {dataLength} model risk(s)
+              </TableCell>
+              <TablePagination
+                count={dataLength}
+                page={page}
+                onPageChange={handleChangePage}
+                rowsPerPage={rowsPerPage}
+                rowsPerPageOptions={[5, 10, 15, 25]}
+                onRowsPerPageChange={handleChangeRowsPerPage}
+                ActionsComponent={(props) => <TablePaginationActions {...props} />}
+                labelRowsPerPage="Rows per page"
+                labelDisplayedRows={({ page, count }) =>
+                  `Page ${page + 1} of ${Math.max(0, Math.ceil(count / rowsPerPage))}`
+                }
+                slotProps={{
+                  select: {
+                    MenuProps: {
+                      keepMounted: true,
+                      PaperProps: {
+                        className: "pagination-dropdown",
                         sx: {
-                          "ml": theme.spacing(4),
-                          "mr": theme.spacing(12),
-                          "minWidth": theme.spacing(20),
-                          "textAlign": "left",
-                          "&.Mui-focused > div": {
-                            backgroundColor: theme.palette.background.main,
-                          },
+                          mt: 0,
+                          mb: theme.spacing(2),
                         },
                       },
-                    }}
-                    sx={{
-                      "mt": theme.spacing(6),
-                      "color": theme.palette.text.secondary,
-                      "& .MuiSelect-icon": {
-                        width: "24px",
-                        height: "fit-content",
+                      transformOrigin: {
+                        vertical: "bottom",
+                        horizontal: "left",
                       },
-                      "& .MuiSelect-select": {
-                        width: theme.spacing(10),
-                        borderRadius: theme.shape.borderRadius,
-                        border: `1px solid ${theme.palette.border.light}`,
-                        padding: theme.spacing(4),
+                      anchorOrigin: {
+                        vertical: "top",
+                        horizontal: "left",
                       },
-                    }}
-                  />
-                </TableRow>
-              </TableFooter>
-            )}
-          </Table>
-        </TableContainer>
-      )}
-    </>
+                      sx: { mt: theme.spacing(-2) },
+                    },
+                    inputProps: { id: "pagination-dropdown" },
+                    IconComponent: SelectorVertical,
+                    sx: {
+                      "ml": theme.spacing(4),
+                      "mr": theme.spacing(12),
+                      "minWidth": theme.spacing(20),
+                      "textAlign": "left",
+                      "&.Mui-focused > div": {
+                        backgroundColor: theme.palette.background.main,
+                      },
+                    },
+                  },
+                }}
+                sx={{
+                  "mt": theme.spacing(6),
+                  "color": theme.palette.text.secondary,
+                  "& .MuiSelect-icon": {
+                    width: "24px",
+                    height: "fit-content",
+                  },
+                  "& .MuiSelect-select": {
+                    width: theme.spacing(10),
+                    borderRadius: theme.shape.borderRadius,
+                    border: `1px solid ${theme.palette.border.light}`,
+                    padding: theme.spacing(4),
+                  },
+                }}
+              />
+            </TableRow>
+          </TableFooter>
+        )}
+      </Table>
+    </TableContainer>
   );
 };
 

--- a/Clients/src/presentation/pages/ModelInventory/evidenceHubTable.tsx
+++ b/Clients/src/presentation/pages/ModelInventory/evidenceHubTable.tsx
@@ -41,6 +41,7 @@ import { User } from "../../../domain/types/User";
 import { getAllEntities } from "../../../application/repository/entity.repository";
 import { EmptyState } from "../../components/EmptyState";
 import EmptyStateTip from "../../components/EmptyState/EmptyStateTip";
+import { TableEmptyStateLayout } from "../../components/Table/TableEmptyStateLayout";
 import { FileIcon } from "../../components/FileIcon";
 import EvidenceQualityBadge from "../../components/EvidenceQualityBadge";
 import EvidenceAnalysisPanel from "../../components/EvidenceAnalysisPanel";
@@ -413,300 +414,281 @@ const EvidenceHubTable: React.FC<EvidenceHubTableProps> = ({
     return `${start} - ${end}`;
   }, [page, rowsPerPage, sortedData?.length]);
 
+  const tableHeader = useMemo(
+    () => (
+      <SortableTableHead
+        columns={visibleTableColumns}
+        sortConfig={sortConfig}
+        onSort={handleSort}
+        theme={theme}
+      />
+    ),
+    [visibleTableColumns, sortConfig, handleSort, theme],
+  );
+
   const tableBody = useMemo(
     () => (
       <TableBody>
-        {sortedData?.length ? (
-          sortedData
-            .slice(
-              hidePagination ? 0 : page * rowsPerPage,
-              hidePagination ? Math.min(sortedData.length, 100) : page * rowsPerPage + rowsPerPage,
-            )
-            .map((evidence) => (
-              <TableRow
-                key={evidence.id}
-                sx={{
-                  ...singleTheme.tableStyles.primary.body.row,
-                  ...tableRowHoverStyle,
-                  ...(deletingId === evidence.id && tableRowDeletingStyle),
-                }}
-                // onClick={(e) => {
-                //   e.stopPropagation();
-                //   onEdit?.(Number(evidence.id));
-                // }}
-              >
-                {isColVisible("evidence_name") && (
-                  <TableCell sx={singleTheme.tableStyles.primary.body.cell}>
-                    <Stack direction="column" spacing={0.5}>
+        {sortedData
+          ?.slice(
+            hidePagination ? 0 : page * rowsPerPage,
+            hidePagination ? Math.min(sortedData.length, 100) : page * rowsPerPage + rowsPerPage,
+          )
+          .map((evidence) => (
+            <TableRow
+              key={evidence.id}
+              sx={{
+                ...singleTheme.tableStyles.primary.body.row,
+                ...tableRowHoverStyle,
+                ...(deletingId === evidence.id && tableRowDeletingStyle),
+              }}
+              // onClick={(e) => {
+              //   e.stopPropagation();
+              //   onEdit?.(Number(evidence.id));
+              // }}
+            >
+              {isColVisible("evidence_name") && (
+                <TableCell sx={singleTheme.tableStyles.primary.body.cell}>
+                  <Stack direction="column" spacing={0.5}>
+                    <Box
+                      sx={{
+                        display: "flex",
+                        alignItems: "center",
+                        gap: "8px",
+                      }}
+                    >
+                      <FileIcon
+                        fileName={
+                          evidence.evidence_files && evidence.evidence_files.length > 0
+                            ? ((evidence.evidence_files[0] as any).filename ??
+                              (evidence.evidence_files[0] as any).fileName ??
+                              "")
+                            : ""
+                        }
+                      />
+                      {evidence.evidence_name}
+                    </Box>
+                    {evidence.evidence_files && evidence.evidence_files.length > 1 && (
                       <Box
                         sx={{
                           display: "flex",
-                          alignItems: "center",
-                          gap: "8px",
+                          flexWrap: "wrap",
+                          gap: "4px",
+                          pl: "24px",
                         }}
                       >
-                        <FileIcon
-                          fileName={
-                            evidence.evidence_files && evidence.evidence_files.length > 0
-                              ? ((evidence.evidence_files[0] as any).filename ??
-                                (evidence.evidence_files[0] as any).fileName ??
-                                "")
-                              : ""
-                          }
-                        />
-                        {evidence.evidence_name}
+                        {evidence.evidence_files.map((f: any, idx: number) => {
+                          const name = f.filename ?? f.fileName ?? `File ${idx + 1}`;
+                          return (
+                            <Tooltip key={`${f.id}-${idx}`} title={`Preview ${name}`}>
+                              <Chip
+                                label={name}
+                                size="small"
+                                clickable
+                                onClick={(e) => {
+                                  e.stopPropagation();
+                                  onPreview?.(evidence.id || 0, idx);
+                                }}
+                                sx={{
+                                  "height": 20,
+                                  "fontSize": 11,
+                                  "maxWidth": 180,
+                                  "& .MuiChip-label": {
+                                    overflow: "hidden",
+                                    textOverflow: "ellipsis",
+                                  },
+                                }}
+                              />
+                            </Tooltip>
+                          );
+                        })}
                       </Box>
-                      {evidence.evidence_files && evidence.evidence_files.length > 1 && (
-                        <Box
-                          sx={{
-                            display: "flex",
-                            flexWrap: "wrap",
-                            gap: "4px",
-                            pl: "24px",
-                          }}
-                        >
-                          {evidence.evidence_files.map((f: any, idx: number) => {
-                            const name = f.filename ?? f.fileName ?? `File ${idx + 1}`;
-                            return (
-                              <Tooltip key={`${f.id}-${idx}`} title={`Preview ${name}`}>
-                                <Chip
-                                  label={name}
-                                  size="small"
-                                  clickable
-                                  onClick={(e) => {
-                                    e.stopPropagation();
-                                    onPreview?.(evidence.id || 0, idx);
-                                  }}
-                                  sx={{
-                                    "height": 20,
-                                    "fontSize": 11,
-                                    "maxWidth": 180,
-                                    "& .MuiChip-label": {
-                                      overflow: "hidden",
-                                      textOverflow: "ellipsis",
-                                    },
-                                  }}
-                                />
-                              </Tooltip>
-                            );
-                          })}
-                        </Box>
-                      )}
-                    </Stack>
-                  </TableCell>
-                )}
-                {isColVisible("evidence_type") && (
-                  <TableCell sx={singleTheme.tableStyles.primary.body.cell}>
-                    <TooltipCell value={evidence.evidence_type} />
-                  </TableCell>
-                )}
-                {isColVisible("mapped_models") && (
-                  <TableCell sx={singleTheme.tableStyles.primary.body.cell}>
-                    <TooltipCell
-                      value={
-                        evidence.mapped_model_ids?.length
-                          ? evidence.mapped_model_ids
-                              .map((id) => modelMap.get(id) || `Model ${id}`)
-                              .join(", ")
-                          : "-"
-                      }
-                    />
-                  </TableCell>
-                )}
-                {isColVisible("mapped_trainings") && (
-                  <TableCell sx={singleTheme.tableStyles.primary.body.cell}>
-                    <TooltipCell
-                      value={
-                        evidence.mapped_training_ids?.length
-                          ? evidence.mapped_training_ids
-                              .map((id) => trainingMap.get(id) || `Training ${id}`)
-                              .join(", ")
-                          : "-"
-                      }
-                    />
-                  </TableCell>
-                )}
-                {isColVisible("tags") && (
-                  <TableCell sx={singleTheme.tableStyles.primary.body.cell}>
-                    {evidence.tags && evidence.tags.length > 0 ? (
-                      <Box sx={{ display: "flex", flexWrap: "wrap", gap: "2px" }}>
-                        {evidence.tags.slice(0, 2).map((tag) => (
+                    )}
+                  </Stack>
+                </TableCell>
+              )}
+              {isColVisible("evidence_type") && (
+                <TableCell sx={singleTheme.tableStyles.primary.body.cell}>
+                  <TooltipCell value={evidence.evidence_type} />
+                </TableCell>
+              )}
+              {isColVisible("mapped_models") && (
+                <TableCell sx={singleTheme.tableStyles.primary.body.cell}>
+                  <TooltipCell
+                    value={
+                      evidence.mapped_model_ids?.length
+                        ? evidence.mapped_model_ids
+                            .map((id) => modelMap.get(id) || `Model ${id}`)
+                            .join(", ")
+                        : "-"
+                    }
+                  />
+                </TableCell>
+              )}
+              {isColVisible("mapped_trainings") && (
+                <TableCell sx={singleTheme.tableStyles.primary.body.cell}>
+                  <TooltipCell
+                    value={
+                      evidence.mapped_training_ids?.length
+                        ? evidence.mapped_training_ids
+                            .map((id) => trainingMap.get(id) || `Training ${id}`)
+                            .join(", ")
+                        : "-"
+                    }
+                  />
+                </TableCell>
+              )}
+              {isColVisible("tags") && (
+                <TableCell sx={singleTheme.tableStyles.primary.body.cell}>
+                  {evidence.tags && evidence.tags.length > 0 ? (
+                    <Box sx={{ display: "flex", flexWrap: "wrap", gap: "2px" }}>
+                      {evidence.tags.slice(0, 2).map((tag) => (
+                        <Chip
+                          key={tag}
+                          label={tag}
+                          size="small"
+                          sx={{ height: 20, fontSize: 11 }}
+                        />
+                      ))}
+                      {evidence.tags.length > 2 && (
+                        <Tooltip title={evidence.tags.slice(2).join(", ")}>
                           <Chip
-                            key={tag}
-                            label={tag}
+                            label={`+${evidence.tags.length - 2}`}
                             size="small"
                             sx={{ height: 20, fontSize: 11 }}
                           />
-                        ))}
-                        {evidence.tags.length > 2 && (
-                          <Tooltip title={evidence.tags.slice(2).join(", ")}>
-                            <Chip
-                              label={`+${evidence.tags.length - 2}`}
-                              size="small"
-                              sx={{ height: 20, fontSize: 11 }}
-                            />
-                          </Tooltip>
-                        )}
-                      </Box>
-                    ) : (
-                      "-"
-                    )}
-                  </TableCell>
-                )}
-                {isColVisible("frameworks") && (
-                  <TableCell sx={singleTheme.tableStyles.primary.body.cell}>
-                    {evidence.framework_ids && evidence.framework_ids.length > 0 ? (
-                      <TooltipCell value={evidence.framework_ids.join(", ")} />
-                    ) : (
-                      "-"
-                    )}
-                  </TableCell>
-                )}
-                {isColVisible("reviewer") && (
-                  <TableCell sx={singleTheme.tableStyles.primary.body.cell}>
-                    {evidence.reviewer_id
-                      ? userMap.get(evidence.reviewer_id.toString()) || "-"
-                      : "-"}
-                  </TableCell>
-                )}
-                {isColVisible("retention_policy") && (
-                  <TableCell sx={singleTheme.tableStyles.primary.body.cell}>
-                    {evidence.retention_policy ? evidence.retention_policy.replace(/_/g, " ") : "-"}
-                  </TableCell>
-                )}
-                {isColVisible("uploaded_by") && (
-                  <TableCell sx={singleTheme.tableStyles.primary.body.cell}>
-                    <TooltipCell
-                      value={
-                        evidence.evidence_files && evidence.evidence_files.length > 0
-                          ? userMap.get(evidence.evidence_files[0].uploaded_by.toString()) || "-"
-                          : "-"
-                      }
-                    />
-                  </TableCell>
-                )}
-                {isColVisible("uploaded_on") && (
-                  <TableCell sx={singleTheme.tableStyles.primary.body.cell}>
-                    {(() => {
-                      const f = evidence.evidence_files?.[0] as any;
-                      const d = f?.upload_date ?? f?.uploaded_time;
-                      return d ? displayFormattedDate(d) : "-";
-                    })()}
-                  </TableCell>
-                )}
-                {isColVisible("expiry_date") && (
-                  <TableCell sx={singleTheme.tableStyles.primary.body.cell}>
-                    {evidence.expiry_date ? displayFormattedDate(evidence.expiry_date) : "-"}
-                  </TableCell>
-                )}
-                {isColVisible("quality") && (
-                  <TableCell sx={singleTheme.tableStyles.primary.body.cell}>
-                    {(() => {
-                      const fileId = evidence.evidence_files?.[0]?.id;
-                      const score = fileId ? qualityMap.get(Number(fileId)) : undefined;
-                      const analysis = fileId ? qualityAnalysisMap.get(Number(fileId)) : undefined;
-                      return score != null ? (
-                        <EvidenceQualityBadge
-                          score={score}
-                          onClick={
-                            analysis
-                              ? (e) => {
-                                  e.stopPropagation();
-                                  setSelectedAnalysis(analysis);
-                                }
-                              : undefined
-                          }
-                        />
-                      ) : (
-                        <Typography sx={{ fontSize: 11, color: palette.text.disabled }}>
-                          -
-                        </Typography>
-                      );
-                    })()}
-                  </TableCell>
-                )}
-                <TableCell sx={singleTheme.tableStyles.primary.body.cell}>
-                  <Stack direction="row" spacing={1}>
-                    {evidence.evidence_files?.[0]?.id && (
-                      <Tooltip
-                        title={
-                          qualityMap.has(Number(evidence.evidence_files[0].id))
-                            ? "Re-analyze with AI"
-                            : "Analyze with AI"
-                        }
-                      >
-                        <Box
-                          component="button"
-                          onClick={(e: React.MouseEvent) => {
-                            e.stopPropagation();
-                            const fileId = Number(evidence.evidence_files[0].id);
-                            if (fileId) triggerAnalysis.mutate(fileId);
-                          }}
-                          sx={{
-                            "display": "flex",
-                            "alignItems": "center",
-                            "justifyContent": "center",
-                            "width": 28,
-                            "height": 28,
-                            "borderRadius": "6px",
-                            "border": "1px solid",
-                            "borderColor": triggerAnalysis.isPending ? "#ccc" : "#7C3AED",
-                            "backgroundColor": triggerAnalysis.isPending ? "#f5f5f5" : "#F5F3FF",
-                            "color": triggerAnalysis.isPending ? "#999" : "#7C3AED",
-                            "cursor": triggerAnalysis.isPending ? "wait" : "pointer",
-                            "padding": 0,
-                            "&:hover": {
-                              backgroundColor: triggerAnalysis.isPending ? "#f5f5f5" : "#EDE9FE",
-                            },
-                          }}
-                          disabled={triggerAnalysis.isPending}
-                        >
-                          <Sparkles size={14} />
-                        </Box>
-                      </Tooltip>
-                    )}
-                    <CustomIconButton
-                      id={evidence.id || 0}
-                      onDelete={() => onDelete?.(evidence.id || 0)}
-                      onEdit={() => {
-                        onEdit?.(evidence.id || 0);
-                      }}
-                      onPreview={onPreview ? () => onPreview(evidence.id || 0) : undefined}
-                      type=""
-                      warningTitle="Delete this evidence?"
-                      warningMessage="When you delete this evidence, all data related to this evidence will be removed. This action is non-recoverable."
-                      onMouseEvent={() => {}}
-                    />
-                  </Stack>
+                        </Tooltip>
+                      )}
+                    </Box>
+                  ) : (
+                    "-"
+                  )}
                 </TableCell>
-              </TableRow>
-            ))
-        ) : (
-          <TableRow>
-            <TableCell colSpan={visibleTableColumns.length} align="center">
-              <EmptyState
-                message="No evidence yet. Upload documents that prove compliance with each requirement."
-                icon={FileCheck}
-              >
-                <EmptyStateTip
-                  icon={FolderOpen}
-                  title="Organize by control category"
-                  description="Group evidence by the controls they support. This makes audit preparation faster and keeps your evidence library structured."
-                />
-                <EmptyStateTip
-                  icon={Shield}
-                  title="What counts as evidence?"
-                  description="Policies, meeting minutes, configuration screenshots, training records, risk assessments, vendor agreements, and change logs."
-                />
-                <EmptyStateTip
-                  icon={Clock}
-                  title="Track expiry dates"
-                  description="Set expiry dates on evidence so you're reminded to update or re-certify documents before they become stale."
-                />
-              </EmptyState>
-            </TableCell>
-          </TableRow>
-        )}
+              )}
+              {isColVisible("frameworks") && (
+                <TableCell sx={singleTheme.tableStyles.primary.body.cell}>
+                  {evidence.framework_ids && evidence.framework_ids.length > 0 ? (
+                    <TooltipCell value={evidence.framework_ids.join(", ")} />
+                  ) : (
+                    "-"
+                  )}
+                </TableCell>
+              )}
+              {isColVisible("reviewer") && (
+                <TableCell sx={singleTheme.tableStyles.primary.body.cell}>
+                  {evidence.reviewer_id ? userMap.get(evidence.reviewer_id.toString()) || "-" : "-"}
+                </TableCell>
+              )}
+              {isColVisible("retention_policy") && (
+                <TableCell sx={singleTheme.tableStyles.primary.body.cell}>
+                  {evidence.retention_policy ? evidence.retention_policy.replace(/_/g, " ") : "-"}
+                </TableCell>
+              )}
+              {isColVisible("uploaded_by") && (
+                <TableCell sx={singleTheme.tableStyles.primary.body.cell}>
+                  <TooltipCell
+                    value={
+                      evidence.evidence_files && evidence.evidence_files.length > 0
+                        ? userMap.get(evidence.evidence_files[0].uploaded_by.toString()) || "-"
+                        : "-"
+                    }
+                  />
+                </TableCell>
+              )}
+              {isColVisible("uploaded_on") && (
+                <TableCell sx={singleTheme.tableStyles.primary.body.cell}>
+                  {(() => {
+                    const f = evidence.evidence_files?.[0] as any;
+                    const d = f?.upload_date ?? f?.uploaded_time;
+                    return d ? displayFormattedDate(d) : "-";
+                  })()}
+                </TableCell>
+              )}
+              {isColVisible("expiry_date") && (
+                <TableCell sx={singleTheme.tableStyles.primary.body.cell}>
+                  {evidence.expiry_date ? displayFormattedDate(evidence.expiry_date) : "-"}
+                </TableCell>
+              )}
+              {isColVisible("quality") && (
+                <TableCell sx={singleTheme.tableStyles.primary.body.cell}>
+                  {(() => {
+                    const fileId = evidence.evidence_files?.[0]?.id;
+                    const score = fileId ? qualityMap.get(Number(fileId)) : undefined;
+                    const analysis = fileId ? qualityAnalysisMap.get(Number(fileId)) : undefined;
+                    return score != null ? (
+                      <EvidenceQualityBadge
+                        score={score}
+                        onClick={
+                          analysis
+                            ? (e) => {
+                                e.stopPropagation();
+                                setSelectedAnalysis(analysis);
+                              }
+                            : undefined
+                        }
+                      />
+                    ) : (
+                      <Typography sx={{ fontSize: 11, color: palette.text.disabled }}>-</Typography>
+                    );
+                  })()}
+                </TableCell>
+              )}
+              <TableCell sx={singleTheme.tableStyles.primary.body.cell}>
+                <Stack direction="row" spacing={1}>
+                  {evidence.evidence_files?.[0]?.id && (
+                    <Tooltip
+                      title={
+                        qualityMap.has(Number(evidence.evidence_files[0].id))
+                          ? "Re-analyze with AI"
+                          : "Analyze with AI"
+                      }
+                    >
+                      <Box
+                        component="button"
+                        onClick={(e: React.MouseEvent) => {
+                          e.stopPropagation();
+                          const fileId = Number(evidence.evidence_files[0].id);
+                          if (fileId) triggerAnalysis.mutate(fileId);
+                        }}
+                        sx={{
+                          "display": "flex",
+                          "alignItems": "center",
+                          "justifyContent": "center",
+                          "width": 28,
+                          "height": 28,
+                          "borderRadius": "6px",
+                          "border": "1px solid",
+                          "borderColor": triggerAnalysis.isPending ? "#ccc" : "#7C3AED",
+                          "backgroundColor": triggerAnalysis.isPending ? "#f5f5f5" : "#F5F3FF",
+                          "color": triggerAnalysis.isPending ? "#999" : "#7C3AED",
+                          "cursor": triggerAnalysis.isPending ? "wait" : "pointer",
+                          "padding": 0,
+                          "&:hover": {
+                            backgroundColor: triggerAnalysis.isPending ? "#f5f5f5" : "#EDE9FE",
+                          },
+                        }}
+                        disabled={triggerAnalysis.isPending}
+                      >
+                        <Sparkles size={14} />
+                      </Box>
+                    </Tooltip>
+                  )}
+                  <CustomIconButton
+                    id={evidence.id || 0}
+                    onDelete={() => onDelete?.(evidence.id || 0)}
+                    onEdit={() => {
+                      onEdit?.(evidence.id || 0);
+                    }}
+                    onPreview={onPreview ? () => onPreview(evidence.id || 0) : undefined}
+                    type=""
+                    warningTitle="Delete this evidence?"
+                    warningMessage="When you delete this evidence, all data related to this evidence will be removed. This action is non-recoverable."
+                    onMouseEvent={() => {}}
+                  />
+                </Stack>
+              </TableCell>
+            </TableRow>
+          ))}
       </TableBody>
     ),
     [
@@ -736,16 +718,38 @@ const EvidenceHubTable: React.FC<EvidenceHubTableProps> = ({
     );
   }
 
+  if (!data || data.length === 0) {
+    return (
+      <TableEmptyStateLayout header={tableHeader}>
+        <EmptyState
+          message="No evidence yet. Upload documents that prove compliance with each requirement."
+          icon={FileCheck}
+        >
+          <EmptyStateTip
+            icon={FolderOpen}
+            title="Organize by control category"
+            description="Group evidence by the controls they support. This makes audit preparation faster and keeps your evidence library structured."
+          />
+          <EmptyStateTip
+            icon={Shield}
+            title="What counts as evidence?"
+            description="Policies, meeting minutes, configuration screenshots, training records, risk assessments, vendor agreements, and change logs."
+          />
+          <EmptyStateTip
+            icon={Clock}
+            title="Track expiry dates"
+            description="Set expiry dates on evidence so you're reminded to update or re-certify documents before they become stale."
+          />
+        </EmptyState>
+      </TableEmptyStateLayout>
+    );
+  }
+
   return (
     <>
       <TableContainer sx={{ overflowX: "auto" }}>
         <Table sx={singleTheme.tableStyles.primary.frame}>
-          <SortableTableHead
-            columns={visibleTableColumns}
-            sortConfig={sortConfig}
-            onSort={handleSort}
-            theme={theme}
-          />
+          {tableHeader}
           {tableBody}
           {paginated && !hidePagination && data && data.length > 0 && (
             <TableFooter>

--- a/Clients/src/presentation/pages/ModelInventory/modelInventoryTable.tsx
+++ b/Clients/src/presentation/pages/ModelInventory/modelInventoryTable.tsx
@@ -40,6 +40,7 @@ import { useStandardTable } from "../../../application/hooks/useStandardTable";
 import type { StandardColumn } from "../../../domain/types/standardTable";
 import StandardTableHead from "../../components/Table/StandardTableHead";
 import StandardTablePagination from "../../components/Table/StandardTablePagination";
+import { TableEmptyStateLayout } from "../../components/Table/TableEmptyStateLayout";
 import { useCustomFieldDefinitions } from "../../../application/hooks/useCustomFields";
 import { formatCustomFieldValue } from "../../components/CustomFieldsSection/formatCustomFieldValue";
 
@@ -539,26 +540,36 @@ const ModelInventoryTable: React.FC<ModelInventoryTableProps> = ({
 
   if (!data || data.length === 0) {
     return (
-      <EmptyState
-        icon={Cpu}
-        message="No models registered yet. Maintain a complete inventory of all AI models your organization uses."
+      <TableEmptyStateLayout
+        header={
+          <StandardTableHead
+            columns={visibleTableColumns}
+            sortConfig={sortConfig}
+            onSort={handleSort}
+          />
+        }
       >
-        <EmptyStateTip
-          icon={Layers}
-          title="What counts as a model?"
-          description="Any machine learning model, large language model, computer vision system, or automated decision-making tool. Include both internal and third-party models."
-        />
-        <EmptyStateTip
-          icon={BarChart3}
-          title="Track model status"
-          description="Record each model's status: approved, restricted, pending, blocked, or rejected. This gives auditors visibility into your governance coverage."
-        />
-        <EmptyStateTip
-          icon={Link2}
-          title="Link to vendors and risks"
-          description="Connect each model to its provider and associated risks. This creates a full traceability map for your audit."
-        />
-      </EmptyState>
+        <EmptyState
+          icon={Cpu}
+          message="No models registered yet. Maintain a complete inventory of all AI models your organization uses."
+        >
+          <EmptyStateTip
+            icon={Layers}
+            title="What counts as a model?"
+            description="Any machine learning model, large language model, computer vision system, or automated decision-making tool. Include both internal and third-party models."
+          />
+          <EmptyStateTip
+            icon={BarChart3}
+            title="Track model status"
+            description="Record each model's status: approved, restricted, pending, blocked, or rejected. This gives auditors visibility into your governance coverage."
+          />
+          <EmptyStateTip
+            icon={Link2}
+            title="Link to vendors and risks"
+            description="Connect each model to its provider and associated risks. This creates a full traceability map for your audit."
+          />
+        </EmptyState>
+      </TableEmptyStateLayout>
     );
   }
 

--- a/Clients/src/presentation/types/interfaces/i.risk.ts
+++ b/Clients/src/presentation/types/interfaces/i.risk.ts
@@ -75,6 +75,10 @@ export interface IVWProjectRisksTable {
   canRunBulkActions?: boolean;
   /** Called after a successful bulk action so the parent can refetch and surface a notification. */
   onBulkActionSuccess?: (action: "set_owner" | "set_category" | "archive", count: number) => void;
+  /** Custom empty-state message (e.g. framework vs use-case risks). */
+  emptyMessage?: string;
+  /** Show contextual EmptyStateTip blocks below the empty message. */
+  showEmptyTips?: boolean;
 }
 
 /**
@@ -121,4 +125,8 @@ export interface IRisksViewProps {
   refreshTrigger?: number;
   // When true, hides edit/delete actions and shows guidance to use centralized risk management
   readOnly?: boolean;
+  /** Custom empty-state message for the risks table. */
+  emptyMessage?: string;
+  /** Show contextual tips in the risks table empty state. */
+  showEmptyTips?: boolean;
 }


### PR DESCRIPTION

## Describe your changes

Standardize empty table states with visible headers and EmptyState below framework and Model inventory pages 


## Write your issue number after "Fixes "

Fixes #4177 

## Please ensure all items are checked off before requesting a review:

- [x] I deployed the code locally.
- [x] I have performed a self-review of my code.
- [x] I have included the issue # in the PR.
- [x] I have labelled the PR correctly.
- [x] The issue I am working on is assigned to me.
- [x] I have avoided using hardcoded values to ensure scalability and maintain consistency across the application.
- [x] I have ensured that font sizes, color choices, and other UI elements are referenced from the theme.
- [x] My pull request is focused and addresses a single, specific feature.
- [x] If there are UI changes, I have attached a screenshot or video to this PR.
- [ ] If I added or modified an API endpoint, the change is reflected in the generated OpenAPI spec (`npm run generate:swagger`).
- [ ] If the endpoint requires authentication, it uses `authenticateJWT` and the generated spec declares `bearerAuth` security.
- [ ] I ran `npm run check:api-drift` and committed the regenerated `swagger.yaml` and `endpoints.ts`.

<img width="2198" height="840" alt="Screenshot 2026-06-23 at 7 09 03 PM" src="https://github.com/user-attachments/assets/b7b8d508-1726-45b9-
<img width="2191" height="794" alt="Screenshot 2026-06-23 at 7 08 37 PM" src="https://github.com/user-attachments/assets/f5ae29f2-490d-4b2f-aa01-580758bc113f" />
<img width="2172" height="1008" alt="Screenshot 2026-06-23 at 7 08 30 PM" src="https://github.com/user-attachments/assets/45a84e30-9efa-4511-a8e8-a8ffe421bd79" />
<img width="2212" height="824" alt="Screenshot 2026-06-23 at 7 08 18 PM" src="https://github.com/user-attachments/assets/079a12f3-6b27-49db-8dca-b0e5d6e74b11" />
<img width="2215" height="1141" alt="Screenshot 2026-06-23 at 7 08 08 PM" src="https://github.com/user-attachments/assets/16e8a28c-e2d2-45d3-a3ed-a1052581e45a" />

