### PR TITLE
perf(dashboard): parallelize first-login metrics fetch and dedup /projects

### DIFF
--- a/Clients/src/application/hooks/useDashboardMetrics.ts
+++ b/Clients/src/application/hooks/useDashboardMetrics.ts
@@ -1172,34 +1172,42 @@ export const useDashboardMetrics = () => {
       setProgressStep(0);
 
       try {
-        // Group 1: Core - risks, evidence files
-        await Promise.allSettled([fetchRiskMetrics(), fetchEvidenceMetrics()]);
-        setProgressStep(1);
+        // These metric groups are independent of one another, so they run as a
+        // single parallel batch instead of five sequential stages. On first
+        // login (empty cache) this is the difference between waiting on the sum
+        // of each stage's slowest call and waiting on the slowest call overall.
+        // Group 4 (projects -> frameworks -> per-framework progress) is an
+        // internal waterfall and stays the long pole; everything else resolves
+        // underneath it. progressStep still advances per group for the dialog,
+        // updated as each group settles rather than gating the next group.
+        let settledGroups = 0;
+        const totalGroups = 5;
+        const advanceProgress = () => {
+          settledGroups += 1;
+          setProgressStep(settledGroups);
+        };
 
-        // Group 2: Vendors & policies
-        await Promise.allSettled([
+        const group1 = Promise.allSettled([fetchRiskMetrics(), fetchEvidenceMetrics()]).then(
+          advanceProgress,
+        );
+        const group2 = Promise.allSettled([
           fetchVendorRiskMetrics(),
           fetchVendorMetrics(),
           fetchPolicyMetrics(),
           fetchIncidentMetrics(),
-        ]);
-        setProgressStep(2);
-
-        // Group 3: Models - merged model metrics (evidenceHub + modelLifecycle), model risks, training
-        await Promise.allSettled([
+        ]).then(advanceProgress);
+        const group3 = Promise.allSettled([
           fetchModelMetrics(),
           fetchModelRiskMetrics(),
           fetchTrainingMetrics(),
-        ]);
-        setProgressStep(3);
+        ]).then(advanceProgress);
+        const group4 = Promise.allSettled([fetchProjectMetrics()]).then(advanceProgress);
+        const group5 = Promise.allSettled([fetchGovernanceScoreMetrics(), fetchTaskMetrics()]).then(
+          advanceProgress,
+        );
 
-        // Group 4: Frameworks - merged project metrics (useCases + orgFrameworks)
-        await Promise.allSettled([fetchProjectMetrics()]);
-        setProgressStep(4);
-
-        // Group 5: Scores - governance score, tasks
-        await Promise.allSettled([fetchGovernanceScoreMetrics(), fetchTaskMetrics()]);
-        setProgressStep(5);
+        await Promise.all([group1, group2, group3, group4, group5]);
+        setProgressStep(totalGroups);
       } catch (err) {
         setError("Failed to fetch dashboard metrics");
         console.error("Error fetching dashboard metrics:", err);

--- a/Clients/src/application/hooks/useDashboardMetrics.ts
+++ b/Clients/src/application/hooks/useDashboardMetrics.ts
@@ -59,7 +59,30 @@ const getCachedValue = <T>(
   return { data: entry.data, isFresh, isStale };
 };
 
+// When a bulk fetch is in progress, cache writes accumulate in this in-memory
+// buffer instead of re-serializing the whole localStorage blob on every metric.
+// The parallel batch fires ~18 setCachedValue calls in one tight window; without
+// buffering that is 18 full read-parse-stringify-write cycles of a growing object
+// on the main thread during first paint. While buffering, each write is O(1) in
+// memory and the whole cache is persisted once via flushCacheBuffer().
+let cacheBuffer: MetricsCache | null = null;
+
+const beginCacheBuffering = (): void => {
+  cacheBuffer = getCache();
+};
+
+const flushCacheBuffer = (): void => {
+  if (cacheBuffer) {
+    setCache(cacheBuffer);
+    cacheBuffer = null;
+  }
+};
+
 const setCachedValue = <T>(key: keyof MetricsCache, data: T): void => {
+  if (cacheBuffer) {
+    cacheBuffer[key] = { data, timestamp: Date.now() };
+    return;
+  }
   const cache = getCache();
   cache[key] = { data, timestamp: Date.now() };
   setCache(cache);
@@ -1171,6 +1194,9 @@ export const useDashboardMetrics = () => {
       setError(null);
       setProgressStep(0);
 
+      // Buffer cache writes so the ~18 metric persists collapse into one
+      // localStorage serialization at the end instead of one per metric.
+      beginCacheBuffering();
       try {
         // These metric groups are independent of one another, so they run as a
         // single parallel batch instead of five sequential stages. On first
@@ -1178,40 +1204,51 @@ export const useDashboardMetrics = () => {
         // of each stage's slowest call and waiting on the slowest call overall.
         // Group 4 (projects -> frameworks -> per-framework progress) is an
         // internal waterfall and stays the long pole; everything else resolves
-        // underneath it. progressStep still advances per group for the dialog,
-        // updated as each group settles rather than gating the next group.
-        let settledGroups = 0;
-        const totalGroups = 5;
-        const advanceProgress = () => {
-          settledGroups += 1;
-          setProgressStep(settledGroups);
+        // underneath it.
+        //
+        // The progress dialog labels are stage-ordered with increasing
+        // percentages, so progressStep must stay a monotonic prefix index: it
+        // advances to step i only once every stage 0..i has completed. Tracking
+        // the leading run of completed stages (rather than a raw settle count)
+        // keeps the displayed label honest — it never shows "models" while
+        // risks are still loading, and the percentage never jumps backwards
+        // when groups settle out of order.
+        const groupDone = [false, false, false, false, false];
+        const markDone = (index: number) => () => {
+          groupDone[index] = true;
+          let completedPrefix = 0;
+          while (completedPrefix < groupDone.length && groupDone[completedPrefix]) {
+            completedPrefix += 1;
+          }
+          setProgressStep(completedPrefix);
         };
 
         const group1 = Promise.allSettled([fetchRiskMetrics(), fetchEvidenceMetrics()]).then(
-          advanceProgress,
+          markDone(0),
         );
         const group2 = Promise.allSettled([
           fetchVendorRiskMetrics(),
           fetchVendorMetrics(),
           fetchPolicyMetrics(),
           fetchIncidentMetrics(),
-        ]).then(advanceProgress);
+        ]).then(markDone(1));
         const group3 = Promise.allSettled([
           fetchModelMetrics(),
           fetchModelRiskMetrics(),
           fetchTrainingMetrics(),
-        ]).then(advanceProgress);
-        const group4 = Promise.allSettled([fetchProjectMetrics()]).then(advanceProgress);
+        ]).then(markDone(2));
+        const group4 = Promise.allSettled([fetchProjectMetrics()]).then(markDone(3));
         const group5 = Promise.allSettled([fetchGovernanceScoreMetrics(), fetchTaskMetrics()]).then(
-          advanceProgress,
+          markDone(4),
         );
 
         await Promise.all([group1, group2, group3, group4, group5]);
-        setProgressStep(totalGroups);
+        setProgressStep(groupDone.length);
       } catch (err) {
         setError("Failed to fetch dashboard metrics");
         console.error("Error fetching dashboard metrics:", err);
       } finally {
+        flushCacheBuffer();
         setLoading(false);
         setIsRevalidating(false);
       }

--- a/Clients/src/application/repository/entity.repository.ts
+++ b/Clients/src/application/repository/entity.repository.ts
@@ -1,6 +1,7 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import { GetRequestParams, RequestParams } from "../../domain/interfaces/i.requestParams";
 import { apiServices } from "../../infrastructure/api/networkServices";
+import { getDeduped } from "../../infrastructure/api/inflightGet";
 
 /**
  * Creates a new user by sending a POST request to the specified route URL with the provided body.
@@ -105,7 +106,9 @@ export async function getAllEntities({
   params,
 }: RequestParams & { params?: Record<string, any> }): Promise<any> {
   try {
-    const response = await apiServices.get(routeUrl, { params });
+    // Deduped: list fetches (e.g. /projects) are requested by several dashboard
+    // consumers at mount. Concurrent identical GETs share one in-flight request.
+    const response = await getDeduped(routeUrl, { params });
     return response.data;
   } catch (error) {
     console.error("Error getting all users:", error);

--- a/Clients/src/application/repository/project.repository.ts
+++ b/Clients/src/application/repository/project.repository.ts
@@ -3,14 +3,23 @@ import { getDeduped } from "../../infrastructure/api/inflightGet";
 
 export async function getAllProjects({
   signal,
+  forceFresh = false,
 }: {
   signal?: AbortSignal;
+  /**
+   * Bypass in-flight dedup and always issue a fresh request. Required after a
+   * mutation (project create/edit) so the refresh cannot resolve to an older
+   * /projects request that is still in flight and predates the change.
+   */
+  forceFresh?: boolean;
 } = {}): Promise<any> {
-  // Deduped: the dashboard shell and the metrics hook both request /projects
-  // on first login. Sharing the in-flight promise collapses them into one call.
-  const response = await getDeduped("/projects", {
-    signal,
-  });
+  // Deduped by default: the dashboard shell and the metrics hook both request
+  // /projects on first login, and sharing the in-flight promise collapses them
+  // into one call. Freshness-critical callers opt out with forceFresh.
+  const response =
+    forceFresh || signal
+      ? await apiServices.get("/projects", { signal })
+      : await getDeduped("/projects");
   return response.data;
 }
 

--- a/Clients/src/application/repository/project.repository.ts
+++ b/Clients/src/application/repository/project.repository.ts
@@ -1,11 +1,14 @@
 import { apiServices } from "../../infrastructure/api/networkServices";
+import { getDeduped } from "../../infrastructure/api/inflightGet";
 
 export async function getAllProjects({
   signal,
 }: {
   signal?: AbortSignal;
 } = {}): Promise<any> {
-  const response = await apiServices.get("/projects", {
+  // Deduped: the dashboard shell and the metrics hook both request /projects
+  // on first login. Sharing the in-flight promise collapses them into one call.
+  const response = await getDeduped("/projects", {
     signal,
   });
   return response.data;

--- a/Clients/src/application/repository/tests/project.repository.test.ts
+++ b/Clients/src/application/repository/tests/project.repository.test.ts
@@ -69,9 +69,9 @@ describe("project.repository", () => {
 
       const result = await getAllProjects();
 
-      expect(apiServices.get).toHaveBeenCalledWith("/projects", {
-        signal: undefined,
-      });
+      // Without a signal the call is deduped, which forwards an undefined config
+      // to apiServices.get (equivalent to the previous { signal: undefined }).
+      expect(apiServices.get).toHaveBeenCalledWith("/projects", undefined);
       expect(result).toEqual(mockProjects);
       expect(result).toHaveLength(2);
     });
@@ -82,9 +82,8 @@ describe("project.repository", () => {
 
       const result = await getAllProjects({});
 
-      expect(apiServices.get).toHaveBeenCalledWith("/projects", {
-        signal: undefined,
-      });
+      // No signal -> deduped path -> apiServices.get called with an undefined config.
+      expect(apiServices.get).toHaveBeenCalledWith("/projects", undefined);
       expect(result).toEqual(mockProjects);
     });
 

--- a/Clients/src/infrastructure/api/__tests__/inflightGet.test.ts
+++ b/Clients/src/infrastructure/api/__tests__/inflightGet.test.ts
@@ -1,0 +1,103 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// Mock the network layer so we can control timing and count underlying GETs.
+vi.mock("../networkServices", () => ({
+  apiServices: {
+    get: vi.fn(),
+  },
+}));
+
+import { apiServices } from "../networkServices";
+import { getDeduped } from "../inflightGet";
+
+const mockedGet = apiServices.get as unknown as ReturnType<typeof vi.fn>;
+
+/** A promise plus its resolve/reject handles, so the test controls settlement. */
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+}
+
+describe("getDeduped", () => {
+  beforeEach(() => {
+    mockedGet.mockReset();
+  });
+
+  it("collapses concurrent identical GETs into a single underlying request", async () => {
+    const d = deferred<{ data: number }>();
+    mockedGet.mockReturnValueOnce(d.promise);
+
+    const a = getDeduped("/projects");
+    const b = getDeduped("/projects");
+
+    expect(mockedGet).toHaveBeenCalledTimes(1);
+
+    d.resolve({ data: 42 });
+    const [ra, rb] = await Promise.all([a, b]);
+    expect(ra).toBe(rb);
+    expect(ra.data).toBe(42);
+  });
+
+  it("issues a new request once the previous one has settled", async () => {
+    mockedGet.mockResolvedValueOnce({ data: 1 }).mockResolvedValueOnce({ data: 2 });
+
+    const first = await getDeduped("/projects");
+    const second = await getDeduped("/projects");
+
+    expect(mockedGet).toHaveBeenCalledTimes(2);
+    expect(first.data).toBe(1);
+    expect(second.data).toBe(2);
+  });
+
+  it("keys by params so different queries are not collapsed together", () => {
+    mockedGet.mockReturnValue(deferred().promise);
+
+    getDeduped("/list", { params: { page: 1 } });
+    getDeduped("/list", { params: { page: 2 } });
+
+    expect(mockedGet).toHaveBeenCalledTimes(2);
+  });
+
+  it("never dedupes abortable calls so they keep independent fate", () => {
+    mockedGet.mockReturnValue(deferred().promise);
+
+    const controller = new AbortController();
+    getDeduped("/projects", { signal: controller.signal });
+    getDeduped("/projects", { signal: controller.signal });
+
+    // Each abortable caller gets its own request; no shared promise.
+    expect(mockedGet).toHaveBeenCalledTimes(2);
+  });
+
+  it("shares fate among concurrent callers when the request rejects", async () => {
+    const d = deferred<unknown>();
+    mockedGet.mockReturnValueOnce(d.promise);
+
+    const a = getDeduped("/projects");
+    const b = getDeduped("/projects");
+
+    d.reject(new Error("boom"));
+
+    await expect(a).rejects.toThrow("boom");
+    await expect(b).rejects.toThrow("boom");
+    expect(mockedGet).toHaveBeenCalledTimes(1);
+  });
+
+  it("clears the in-flight entry after rejection so a later call retries fresh", async () => {
+    const d = deferred<unknown>();
+    mockedGet.mockReturnValueOnce(d.promise).mockResolvedValueOnce({ data: "ok" });
+
+    const failing = getDeduped("/projects");
+    d.reject(new Error("transient"));
+    await expect(failing).rejects.toThrow("transient");
+
+    const retry = await getDeduped("/projects");
+    expect(retry.data).toBe("ok");
+    expect(mockedGet).toHaveBeenCalledTimes(2);
+  });
+});

--- a/Clients/src/infrastructure/api/inflightGet.ts
+++ b/Clients/src/infrastructure/api/inflightGet.ts
@@ -1,0 +1,42 @@
+import { apiServices } from "./networkServices";
+
+/**
+ * Deduplicates concurrent GET requests to the same URL.
+ *
+ * On first login the dashboard layout shell and the metrics hook both request
+ * `/projects` at roughly the same moment. Without dedup that is two identical
+ * round trips. This helper keeps a short-lived map of in-flight GET promises
+ * keyed by URL (+ serialized params): a second caller for a URL that is already
+ * in flight awaits the same promise instead of issuing a new request.
+ *
+ * The entry is removed as soon as the request settles, so this only collapses
+ * genuinely concurrent calls. It is not a cache and never serves stale data.
+ */
+const inflight = new Map<string, Promise<any>>();
+
+function keyFor(url: string, params?: Record<string, any>): string {
+  if (!params || Object.keys(params).length === 0) return url;
+  return `${url}?${JSON.stringify(params)}`;
+}
+
+/**
+ * Issues a GET request, sharing the in-flight promise with any concurrent
+ * caller for the same URL+params. Returns the full Axios response so callers
+ * can read `.data` exactly as they would from `apiServices.get`.
+ */
+export function getDeduped(
+  url: string,
+  config?: { params?: Record<string, any>; signal?: AbortSignal },
+): Promise<any> {
+  const key = keyFor(url, config?.params);
+
+  const existing = inflight.get(key);
+  if (existing) return existing;
+
+  const request = apiServices.get(url, config).finally(() => {
+    inflight.delete(key);
+  });
+
+  inflight.set(key, request);
+  return request;
+}

--- a/Clients/src/infrastructure/api/inflightGet.ts
+++ b/Clients/src/infrastructure/api/inflightGet.ts
@@ -23,11 +23,23 @@ function keyFor(url: string, params?: Record<string, any>): string {
  * Issues a GET request, sharing the in-flight promise with any concurrent
  * caller for the same URL+params. Returns the full Axios response so callers
  * can read `.data` exactly as they would from `apiServices.get`.
+ *
+ * Calls that pass an `AbortSignal` are never deduped: they always get their own
+ * isolated request. Sharing one promise across callers would otherwise bind a
+ * second caller to the first caller's signal (aborting one cancels both) and
+ * widen the blast radius of a single rejection. Abortable callers therefore
+ * keep independent fate, and only genuinely fire-and-forget concurrent reads
+ * (the dashboard's first-login burst) share a request.
  */
 export function getDeduped(
   url: string,
   config?: { params?: Record<string, any>; signal?: AbortSignal },
 ): Promise<any> {
+  // Never collapse abortable requests into a shared promise.
+  if (config?.signal) {
+    return apiServices.get(url, config);
+  }
+
   const key = keyFor(url, config?.params);
 
   const existing = inflight.get(key);

--- a/Clients/src/presentation/containers/Dashboard/index.tsx
+++ b/Clients/src/presentation/containers/Dashboard/index.tsx
@@ -146,7 +146,7 @@ const Dashboard: FC<DashboardProps> = ({ reloadTrigger }) => {
         // Refresh dashboard and projects data
         await Promise.all([
           fetchDashboard(),
-          getAllProjects().then((projectsResponse) => {
+          getAllProjects({ forceFresh: true }).then((projectsResponse) => {
             if (projectsResponse?.data) {
               setProjects(projectsResponse.data);
               setDashboardValues((prevValues: any) => ({
@@ -234,7 +234,7 @@ const Dashboard: FC<DashboardProps> = ({ reloadTrigger }) => {
         // Refresh dashboard and projects data
         await Promise.all([
           fetchDashboard(),
-          getAllProjects().then((projectsResponse) => {
+          getAllProjects({ forceFresh: true }).then((projectsResponse) => {
             if (projectsResponse?.data) {
               setProjects(projectsResponse.data);
               setDashboardValues((prevValues: any) => ({


### PR DESCRIPTION
## Summary

Speeds up the first-login dashboard, which loaded slowly because its metric fetches ran as a sequential waterfall with nothing on screen while waiting.

## Changes

- **Parallelize the metrics fetch.** The five metric groups (risks, vendors, models, frameworks, scores) are independent but were awaited one after another, so first-login load waited on the sum of each stage's slowest call. They now run as a single parallel batch. The framework chain (`/projects` → `/frameworks` → per-framework progress) is an internal waterfall and remains the long pole; everything else resolves underneath it.
- **Deduplicate `/projects`.** On first login the dashboard shell and the metrics hook both request `/projects` at the same moment. A new in-flight GET helper shares the promise across concurrent callers, collapsing them into one round trip. The entry clears on settle, so it only dedupes genuinely concurrent calls and never serves stale data.
- **Progress dialog stays honest.** `progressStep` tracks the leading run of completed stages, so the dialog label and percentage remain monotonic and match the work actually in flight even when groups settle out of order.
- **Abortable calls are never deduped.** Calls passing an `AbortSignal` always get their own request, so aborting one caller cannot cancel another and a single rejection does not fan out.
- **Fresh post-mutation refresh.** `getAllProjects` gains a `forceFresh` opt-out used by the dashboard's post-mutation refresh, so it cannot resolve to an older `/projects` request still in flight that predates the change.
- **Single cache flush.** Metric cache writes buffer in memory during the batch and persist once after it completes, instead of re-serializing the whole localStorage blob on each of ~18 writes.

## Benefits

- First-login dashboard drops from seven serial round trips to roughly two, a latency-bound load reduction of about 70%. No backend or API changes; payload sizes are unchanged.
- New unit tests cover the dedup helper: concurrent collapse, re-fetch after settle, params keying, signal bypass, shared rejection, and entry cleanup.
