### PR TITLE
Feat: Optimistic update cache

### DIFF
--- a/Clients/src/application/hooks/__tests__/useBulkUpdatePolicies.test.ts
+++ b/Clients/src/application/hooks/__tests__/useBulkUpdatePolicies.test.ts
@@ -1,7 +1,10 @@
-import { renderHook, act } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { renderHook, act, waitFor } from "@testing-library/react";
 import React from "react";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { useBulkUpdatePolicies } from "../useBulkUpdatePolicies";
+import { policyQueryKeys } from "../usePolicies";
+import { PolicyManagerModel } from "../../../domain/models/Common/policy/policyManager.model";
 
 const mockBulkUpdatePolicies = vi.fn();
 
@@ -9,24 +12,42 @@ vi.mock("../../repository/policy.repository", () => ({
   bulkUpdatePolicies: (...args: unknown[]) => mockBulkUpdatePolicies(...args),
 }));
 
+function createPolicy(id: number, overrides: Partial<PolicyManagerModel> = {}): PolicyManagerModel {
+  return PolicyManagerModel.createNewPolicyManager({
+    id,
+    title: `Policy ${id}`,
+    content_html: "",
+    status: "Draft",
+    tags: [],
+    author_id: 1,
+    last_updated_by: 1,
+    last_updated_at: new Date("2026-01-01"),
+    created_at: new Date("2026-01-01"),
+    ...overrides,
+  });
+}
+
 function createWrapper() {
   const queryClient = new QueryClient({
     defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
   });
-  return ({ children }: { children: React.ReactNode }) =>
-    React.createElement(QueryClientProvider, { client: queryClient }, children);
+  return {
+    queryClient,
+    wrapper: ({ children }: { children: React.ReactNode }) =>
+      React.createElement(QueryClientProvider, { client: queryClient }, children),
+  };
 }
 
 describe("useBulkUpdatePolicies", () => {
-  afterEach(() => {
+  beforeEach(() => {
     vi.clearAllMocks();
   });
 
   it("should call bulkUpdatePolicies on mutate", async () => {
-    mockBulkUpdatePolicies.mockResolvedValue({ success: true });
+    mockBulkUpdatePolicies.mockResolvedValue({ updated: 2, action: "archive" });
 
     const { result } = renderHook(() => useBulkUpdatePolicies(), {
-      wrapper: createWrapper(),
+      wrapper: createWrapper().wrapper,
     });
 
     await act(async () => {
@@ -38,10 +59,10 @@ describe("useBulkUpdatePolicies", () => {
 
   it("should call onSuccess callback when mutation succeeds", async () => {
     const onSuccess = vi.fn();
-    mockBulkUpdatePolicies.mockResolvedValue({ success: true });
+    mockBulkUpdatePolicies.mockResolvedValue({ updated: 1, action: "archive" });
 
     const { result } = renderHook(() => useBulkUpdatePolicies({ onSuccess }), {
-      wrapper: createWrapper(),
+      wrapper: createWrapper().wrapper,
     });
 
     await act(async () => {
@@ -57,7 +78,7 @@ describe("useBulkUpdatePolicies", () => {
     mockBulkUpdatePolicies.mockRejectedValue(testError);
 
     const { result } = renderHook(() => useBulkUpdatePolicies({ onError }), {
-      wrapper: createWrapper(),
+      wrapper: createWrapper().wrapper,
     });
 
     await act(async () => {
@@ -69,5 +90,149 @@ describe("useBulkUpdatePolicies", () => {
     });
 
     expect(onError).toHaveBeenCalledWith(testError, { ids: [1], action: "archive" });
+  });
+
+  it("optimistically archives selected policies", async () => {
+    let resolveMutation: () => void = () => {};
+    mockBulkUpdatePolicies.mockImplementation(
+      () =>
+        new Promise<void>((resolve) => {
+          resolveMutation = resolve;
+        }),
+    );
+
+    const queryKey = policyQueryKeys.list();
+    const { queryClient, wrapper } = createWrapper();
+
+    queryClient.setQueryData(queryKey, [
+      createPolicy(1, { status: "Draft" }),
+      createPolicy(2, { status: "Draft" }),
+      createPolicy(3, { status: "Draft" }),
+    ]);
+
+    const { result } = renderHook(() => useBulkUpdatePolicies(), { wrapper });
+
+    act(() => {
+      result.current.mutate({ ids: [1, 2], action: "archive" });
+    });
+
+    await waitFor(() => {
+      const data = queryClient.getQueryData<PolicyManagerModel[]>(queryKey);
+      expect(data?.[0].status).toBe("Archived");
+      expect(data?.[1].status).toBe("Archived");
+      expect(data?.[2].status).toBe("Draft");
+    });
+
+    act(() => {
+      resolveMutation();
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+  });
+
+  it("optimistically assigns a reviewer to selected policies", async () => {
+    let resolveMutation: () => void = () => {};
+    mockBulkUpdatePolicies.mockImplementation(
+      () =>
+        new Promise<void>((resolve) => {
+          resolveMutation = resolve;
+        }),
+    );
+
+    const queryKey = policyQueryKeys.list();
+    const { queryClient, wrapper } = createWrapper();
+
+    queryClient.setQueryData(queryKey, [
+      createPolicy(1, { assigned_reviewer_ids: [] }),
+      createPolicy(2, { assigned_reviewer_ids: [1] }),
+    ]);
+
+    const { result } = renderHook(() => useBulkUpdatePolicies(), { wrapper });
+
+    act(() => {
+      result.current.mutate({ ids: [1, 2], action: "set_reviewer", reviewerId: 5 });
+    });
+
+    await waitFor(() => {
+      const data = queryClient.getQueryData<PolicyManagerModel[]>(queryKey);
+      expect(data?.[0].assigned_reviewer_ids).toEqual([5]);
+      expect(data?.[1].assigned_reviewer_ids).toEqual([5]);
+    });
+
+    act(() => {
+      resolveMutation();
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+  });
+
+  it("optimistically sets tags on selected policies", async () => {
+    let resolveMutation: () => void = () => {};
+    mockBulkUpdatePolicies.mockImplementation(
+      () =>
+        new Promise<void>((resolve) => {
+          resolveMutation = resolve;
+        }),
+    );
+
+    const queryKey = policyQueryKeys.list();
+    const { queryClient, wrapper } = createWrapper();
+
+    queryClient.setQueryData(queryKey, [
+      createPolicy(1, { tags: ["AI ethics"] }),
+      createPolicy(2, { tags: ["Privacy"] }),
+    ]);
+
+    const { result } = renderHook(() => useBulkUpdatePolicies(), { wrapper });
+
+    act(() => {
+      result.current.mutate({ ids: [1, 2], action: "set_tags", tags: ["Transparency"] });
+    });
+
+    await waitFor(() => {
+      const data = queryClient.getQueryData<PolicyManagerModel[]>(queryKey);
+      expect(data?.[0].tags).toEqual(["Transparency"]);
+      expect(data?.[1].tags).toEqual(["Transparency"]);
+    });
+
+    act(() => {
+      resolveMutation();
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+  });
+
+  it("rolls back optimistic updates when the mutation fails", async () => {
+    let rejectMutation: (error: Error) => void = () => {};
+    mockBulkUpdatePolicies.mockImplementation(
+      () =>
+        new Promise<never>((_resolve, reject) => {
+          rejectMutation = reject;
+        }),
+    );
+
+    const queryKey = policyQueryKeys.list();
+    const { queryClient, wrapper } = createWrapper();
+
+    queryClient.setQueryData(queryKey, [createPolicy(1, { status: "Draft" })]);
+
+    const { result } = renderHook(() => useBulkUpdatePolicies(), { wrapper });
+
+    act(() => {
+      result.current.mutate({ ids: [1], action: "archive" });
+    });
+
+    await waitFor(() => {
+      const data = queryClient.getQueryData<PolicyManagerModel[]>(queryKey);
+      expect(data?.[0].status).toBe("Archived");
+    });
+
+    act(() => {
+      rejectMutation(new Error("Failed"));
+    });
+
+    await waitFor(() => expect(result.current.isError).toBe(true));
+    const data = queryClient.getQueryData<PolicyManagerModel[]>(queryKey);
+    expect(data?.[0].status).toBe("Draft");
   });
 });

--- a/Clients/src/application/hooks/__tests__/usePolicyMutations.test.ts
+++ b/Clients/src/application/hooks/__tests__/usePolicyMutations.test.ts
@@ -1,0 +1,166 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { renderHook, act, waitFor } from "@testing-library/react";
+import React from "react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { useCreatePolicy, useUpdatePolicy } from "../usePolicyMutations";
+import { policyQueryKeys } from "../usePolicies";
+import { PolicyManagerModel } from "../../../domain/models/Common/policy/policyManager.model";
+import { PolicyInput } from "../../../domain/interfaces/i.policy";
+
+const mockCreatePolicy = vi.fn();
+const mockUpdatePolicy = vi.fn();
+
+vi.mock("../../repository/policy.repository", () => ({
+  createPolicy: (...args: unknown[]) => mockCreatePolicy(...args),
+  updatePolicy: (...args: unknown[]) => mockUpdatePolicy(...args),
+}));
+
+function createPolicy(id: number, overrides: Partial<PolicyManagerModel> = {}): PolicyManagerModel {
+  return PolicyManagerModel.createNewPolicyManager({
+    id,
+    title: `Policy ${id}`,
+    content_html: "",
+    status: "Draft",
+    tags: [],
+    author_id: 1,
+    last_updated_by: 1,
+    last_updated_at: new Date("2026-01-01"),
+    created_at: new Date("2026-01-01"),
+    ...overrides,
+  });
+}
+
+function createWrapper() {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  });
+  return {
+    queryClient,
+    wrapper: ({ children }: { children: React.ReactNode }) =>
+      React.createElement(QueryClientProvider, { client: queryClient }, children),
+  };
+}
+
+describe("useCreatePolicy", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("creates a policy and returns the created policy", async () => {
+    const created = createPolicy(10, { title: "New Policy" });
+    mockCreatePolicy.mockResolvedValue(created);
+
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(() => useCreatePolicy(), { wrapper });
+
+    const input: PolicyInput = {
+      title: "New Policy",
+      status: "Draft",
+      content_html: "<p>Content</p>",
+    };
+
+    let returned: PolicyManagerModel | undefined;
+    await act(async () => {
+      returned = await result.current.mutateAsync(input);
+    });
+
+    expect(mockCreatePolicy).toHaveBeenCalledWith(input);
+    expect(returned).toEqual(created);
+  });
+});
+
+describe("useUpdatePolicy", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("optimistically updates the policy in the list cache", async () => {
+    let resolveMutation: () => void = () => {};
+    mockUpdatePolicy.mockImplementation(
+      () =>
+        new Promise<void>((resolve) => {
+          resolveMutation = resolve;
+        }),
+    );
+
+    const queryKey = policyQueryKeys.list();
+    const { queryClient, wrapper } = createWrapper();
+
+    queryClient.setQueryData(queryKey, [createPolicy(1, { title: "Old Title" })]);
+
+    const { result } = renderHook(() => useUpdatePolicy(), { wrapper });
+
+    act(() => {
+      result.current.mutate({
+        id: 1,
+        input: { title: "New Title", status: "Draft", content_html: "" },
+      });
+    });
+
+    await waitFor(() => {
+      const data = queryClient.getQueryData<PolicyManagerModel[]>(queryKey);
+      expect(data?.[0].title).toBe("New Title");
+    });
+
+    act(() => {
+      resolveMutation();
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+  });
+
+  it("rolls back the optimistic update when the mutation fails", async () => {
+    let rejectMutation: (error: Error) => void = () => {};
+    mockUpdatePolicy.mockImplementation(
+      () =>
+        new Promise<never>((_resolve, reject) => {
+          rejectMutation = reject;
+        }),
+    );
+
+    const queryKey = policyQueryKeys.list();
+    const { queryClient, wrapper } = createWrapper();
+
+    queryClient.setQueryData(queryKey, [createPolicy(1, { title: "Old Title" })]);
+
+    const { result } = renderHook(() => useUpdatePolicy(), { wrapper });
+
+    act(() => {
+      result.current.mutate({
+        id: 1,
+        input: { title: "New Title", status: "Draft", content_html: "" },
+      });
+    });
+
+    await waitFor(() => {
+      const data = queryClient.getQueryData<PolicyManagerModel[]>(queryKey);
+      expect(data?.[0].title).toBe("New Title");
+    });
+
+    act(() => {
+      rejectMutation(new Error("Failed"));
+    });
+
+    await waitFor(() => expect(result.current.isError).toBe(true));
+    const data = queryClient.getQueryData<PolicyManagerModel[]>(queryKey);
+    expect(data?.[0].title).toBe("Old Title");
+  });
+
+  it("updates the policy via the repository", async () => {
+    const updated = createPolicy(1, { title: "New Title" });
+    mockUpdatePolicy.mockResolvedValue(updated);
+
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(() => useUpdatePolicy(), { wrapper });
+
+    const input = { title: "New Title", status: "Draft", content_html: "" };
+
+    let returned: PolicyManagerModel | undefined;
+    await act(async () => {
+      returned = await result.current.mutateAsync({ id: 1, input });
+    });
+
+    expect(mockUpdatePolicy).toHaveBeenCalledWith(1, input);
+    expect(returned).toEqual(updated);
+  });
+});

--- a/Clients/src/application/hooks/__tests__/useUpdateFileMetadata.test.ts
+++ b/Clients/src/application/hooks/__tests__/useUpdateFileMetadata.test.ts
@@ -2,21 +2,17 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 import { renderHook, act, waitFor } from "@testing-library/react";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import React from "react";
-import { useBulkUpdateFiles } from "../useBulkUpdateFiles";
+import { useUpdateFileMetadata } from "../useUpdateFileMetadata";
 import { fileQueryKeys } from "../useFiles";
 import { FileModel } from "../../../domain/models/Common/file/file.model";
 
 vi.mock("../../repository/file.repository", () => ({
-  bulkUpdateFileTags: vi.fn(),
+  updateFileMetadata: vi.fn(),
 }));
 
-vi.mock("../../repository/virtualFolder.repository", () => ({
-  assignFilesToFolder: vi.fn(),
-}));
+import { updateFileMetadata, type FileMetadata } from "../../repository/file.repository";
 
-import { bulkUpdateFileTags } from "../../repository/file.repository";
-
-const mockBulkUpdateFileTags = vi.mocked(bulkUpdateFileTags);
+const mockUpdateFileMetadata = vi.mocked(updateFileMetadata);
 
 function createFile(id: string, tags: string[]): FileModel {
   return FileModel.createNewFile({
@@ -39,14 +35,14 @@ function createWrapper() {
   };
 }
 
-describe("useBulkUpdateFiles", () => {
+describe("useUpdateFileMetadata", () => {
   beforeEach(() => vi.clearAllMocks());
 
-  it("optimistically updates tags for selected files in set mode", async () => {
-    let resolveMutation: () => void = () => {};
-    mockBulkUpdateFileTags.mockImplementation(
+  it("optimistically updates file metadata in the list cache", async () => {
+    let resolveMutation: (value: FileMetadata) => void = () => {};
+    mockUpdateFileMetadata.mockImplementation(
       () =>
-        new Promise<void>((resolve) => {
+        new Promise<FileMetadata>((resolve) => {
           resolveMutation = resolve;
         }),
     );
@@ -54,68 +50,33 @@ describe("useBulkUpdateFiles", () => {
     const queryKey = fileQueryKeys.list();
     const { queryClient, wrapper } = createWrapper();
 
-    queryClient.setQueryData(queryKey, [createFile("1", ["old"]), createFile("2", ["old"])]);
+    queryClient.setQueryData(queryKey, [createFile("1", ["old"])]);
 
-    const { result } = renderHook(() => useBulkUpdateFiles(), { wrapper });
+    const { result } = renderHook(() => useUpdateFileMetadata(), { wrapper });
 
     act(() => {
-      result.current.mutate({
-        type: "update_tags",
-        payload: { ids: [1], tags: ["new"], mode: "set" },
-      });
+      result.current.mutate({ id: "1", updates: { tags: ["new"] } });
     });
 
     await waitFor(() => {
       const data = queryClient.getQueryData<FileModel[]>(queryKey);
       expect(data?.[0].tags).toEqual(["new"]);
-      expect(data?.[1].tags).toEqual(["old"]);
     });
 
     act(() => {
-      resolveMutation();
+      resolveMutation({ id: "1", filename: "file-1.txt" } as FileMetadata);
     });
 
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(mockUpdateFileMetadata).toHaveBeenCalledWith({
+      id: "1",
+      updates: { tags: ["new"] },
+    });
   });
 
-  it("optimistically adds tags in add mode", async () => {
-    let resolveMutation: () => void = () => {};
-    mockBulkUpdateFileTags.mockImplementation(
-      () =>
-        new Promise<void>((resolve) => {
-          resolveMutation = resolve;
-        }),
-    );
-
-    const queryKey = fileQueryKeys.list();
-    const { queryClient, wrapper } = createWrapper();
-
-    queryClient.setQueryData(queryKey, [createFile("1", ["existing"])]);
-
-    const { result } = renderHook(() => useBulkUpdateFiles(), { wrapper });
-
-    act(() => {
-      result.current.mutate({
-        type: "update_tags",
-        payload: { ids: [1], tags: ["new"], mode: "add" },
-      });
-    });
-
-    await waitFor(() => {
-      const data = queryClient.getQueryData<FileModel[]>(queryKey);
-      expect(data?.[0].tags).toEqual(["existing", "new"]);
-    });
-
-    act(() => {
-      resolveMutation();
-    });
-
-    await waitFor(() => expect(result.current.isSuccess).toBe(true));
-  });
-
-  it("rolls back tag changes when the mutation fails", async () => {
+  it("rolls back the optimistic update on failure", async () => {
     let rejectMutation: (error: Error) => void = () => {};
-    mockBulkUpdateFileTags.mockImplementation(
+    mockUpdateFileMetadata.mockImplementation(
       () =>
         new Promise<never>((_resolve, reject) => {
           rejectMutation = reject;
@@ -127,13 +88,10 @@ describe("useBulkUpdateFiles", () => {
 
     queryClient.setQueryData(queryKey, [createFile("1", ["old"])]);
 
-    const { result } = renderHook(() => useBulkUpdateFiles(), { wrapper });
+    const { result } = renderHook(() => useUpdateFileMetadata(), { wrapper });
 
     act(() => {
-      result.current.mutate({
-        type: "update_tags",
-        payload: { ids: [1], tags: ["new"], mode: "set" },
-      });
+      result.current.mutate({ id: "1", updates: { tags: ["new"] } });
     });
 
     await waitFor(() => {

--- a/Clients/src/application/hooks/__tests__/useUpdateProjectRisk.test.ts
+++ b/Clients/src/application/hooks/__tests__/useUpdateProjectRisk.test.ts
@@ -1,0 +1,123 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { renderHook, act, waitFor } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import React from "react";
+import { useUpdateProjectRisk } from "../useUpdateProjectRisk";
+import { projectRiskQueryKeys } from "../useProjectRisks";
+
+vi.mock("../../repository/projectRisk.repository", () => ({
+  updateProjectRisk: vi.fn(),
+}));
+
+import { updateProjectRisk } from "../../repository/projectRisk.repository";
+
+const mockUpdateProjectRisk = vi.mocked(updateProjectRisk);
+
+function createWrapper() {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  });
+  return {
+    queryClient,
+    wrapper: ({ children }: { children: React.ReactNode }) =>
+      React.createElement(QueryClientProvider, { client: queryClient }, children),
+  };
+}
+
+describe("useUpdateProjectRisk", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("optimistically patches the risk in the project risks list cache", async () => {
+    let resolveMutation: () => void = () => {};
+    mockUpdateProjectRisk.mockImplementation(
+      () =>
+        new Promise<void>((resolve) => {
+          resolveMutation = resolve;
+        }),
+    );
+
+    const projectId = 5;
+    const queryKey = projectRiskQueryKeys.list(projectId, "active");
+    const { queryClient, wrapper } = createWrapper();
+
+    queryClient.setQueryData(queryKey, [
+      { id: 1, risk_name: "Risk 1", risk_level_autocalculated: "High" },
+      { id: 2, risk_name: "Risk 2", risk_level_autocalculated: "Low" },
+    ]);
+
+    const { result } = renderHook(() => useUpdateProjectRisk(), { wrapper });
+
+    act(() => {
+      result.current.mutate({
+        id: 1,
+        projectId,
+        body: { risk_level_autocalculated: "Critical", final_risk_level: "Medium" },
+      });
+    });
+
+    await waitFor(() =>
+      expect(queryClient.getQueryData(queryKey)).toEqual([
+        {
+          id: 1,
+          risk_name: "Risk 1",
+          risk_level_autocalculated: "Critical",
+          final_risk_level: "Medium",
+        },
+        { id: 2, risk_name: "Risk 2", risk_level_autocalculated: "Low" },
+      ]),
+    );
+
+    act(() => {
+      resolveMutation();
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(mockUpdateProjectRisk).toHaveBeenCalledWith({
+      id: 1,
+      body: { risk_level_autocalculated: "Critical", final_risk_level: "Medium" },
+    });
+  });
+
+  it("rolls back the optimistic patch when the mutation fails", async () => {
+    let rejectMutation: (error: Error) => void = () => {};
+    mockUpdateProjectRisk.mockImplementation(
+      () =>
+        new Promise<never>((_resolve, reject) => {
+          rejectMutation = reject;
+        }),
+    );
+
+    const projectId = 5;
+    const queryKey = projectRiskQueryKeys.list(projectId, "active");
+    const { queryClient, wrapper } = createWrapper();
+
+    queryClient.setQueryData(queryKey, [
+      { id: 1, risk_name: "Risk 1", risk_level_autocalculated: "High" },
+    ]);
+
+    const { result } = renderHook(() => useUpdateProjectRisk(), { wrapper });
+
+    act(() => {
+      result.current.mutate({
+        id: 1,
+        projectId,
+        body: { risk_level_autocalculated: "Critical" },
+      });
+    });
+
+    await waitFor(() =>
+      expect(queryClient.getQueryData(queryKey)).toEqual([
+        { id: 1, risk_name: "Risk 1", risk_level_autocalculated: "Critical" },
+      ]),
+    );
+
+    act(() => {
+      rejectMutation(new Error("Server error"));
+    });
+
+    await waitFor(() => expect(result.current.isError).toBe(true));
+    expect(queryClient.getQueryData(queryKey)).toEqual([
+      { id: 1, risk_name: "Risk 1", risk_level_autocalculated: "High" },
+    ]);
+  });
+});

--- a/Clients/src/application/hooks/__tests__/useUpdateTaskPriority.test.ts
+++ b/Clients/src/application/hooks/__tests__/useUpdateTaskPriority.test.ts
@@ -1,0 +1,106 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { renderHook, act, waitFor } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import React from "react";
+import { useUpdateTaskPriority } from "../useUpdateTaskPriority";
+import { taskQueryKeys } from "../useTasks";
+import { TaskPriority } from "../../../domain/enums/task.enum";
+
+vi.mock("../../repository/task.repository", () => ({
+  updateTaskPriority: vi.fn(),
+}));
+
+import { updateTaskPriority } from "../../repository/task.repository";
+
+const mockUpdateTaskPriority = vi.mocked(updateTaskPriority);
+
+function createWrapper() {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  });
+  return {
+    queryClient,
+    wrapper: ({ children }: { children: React.ReactNode }) =>
+      React.createElement(QueryClientProvider, { client: queryClient }, children),
+  };
+}
+
+describe("useUpdateTaskPriority", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("optimistically updates the task priority in the list cache", async () => {
+    let resolveMutation: () => void = () => {};
+    mockUpdateTaskPriority.mockImplementation(
+      () =>
+        new Promise<void>((resolve) => {
+          resolveMutation = resolve;
+        }),
+    );
+
+    const filters = { includeArchived: false };
+    const queryKey = taskQueryKeys.list(filters);
+    const { queryClient, wrapper } = createWrapper();
+
+    queryClient.setQueryData(queryKey, [
+      { id: 1, title: "Task 1", priority: TaskPriority.LOW },
+      { id: 2, title: "Task 2", priority: TaskPriority.MEDIUM },
+    ]);
+
+    const { result } = renderHook(() => useUpdateTaskPriority(), { wrapper });
+
+    act(() => {
+      result.current.mutate({ id: 1, priority: TaskPriority.HIGH, filters });
+    });
+
+    await waitFor(() =>
+      expect(queryClient.getQueryData(queryKey)).toEqual([
+        { id: 1, title: "Task 1", priority: TaskPriority.HIGH },
+        { id: 2, title: "Task 2", priority: TaskPriority.MEDIUM },
+      ]),
+    );
+
+    act(() => {
+      resolveMutation();
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(mockUpdateTaskPriority).toHaveBeenCalledWith({ id: 1, priority: TaskPriority.HIGH });
+  });
+
+  it("rolls back the optimistic update when the mutation fails", async () => {
+    let rejectMutation: (error: Error) => void = () => {};
+    mockUpdateTaskPriority.mockImplementation(
+      () =>
+        new Promise<never>((_resolve, reject) => {
+          rejectMutation = reject;
+        }),
+    );
+
+    const filters = { includeArchived: false };
+    const queryKey = taskQueryKeys.list(filters);
+    const { queryClient, wrapper } = createWrapper();
+
+    queryClient.setQueryData(queryKey, [{ id: 1, title: "Task 1", priority: TaskPriority.LOW }]);
+
+    const { result } = renderHook(() => useUpdateTaskPriority(), { wrapper });
+
+    act(() => {
+      result.current.mutate({ id: 1, priority: TaskPriority.HIGH, filters });
+    });
+
+    await waitFor(() =>
+      expect(queryClient.getQueryData(queryKey)).toEqual([
+        { id: 1, title: "Task 1", priority: TaskPriority.HIGH },
+      ]),
+    );
+
+    act(() => {
+      rejectMutation(new Error("Failed"));
+    });
+
+    await waitFor(() => expect(result.current.isError).toBe(true));
+    expect(queryClient.getQueryData(queryKey)).toEqual([
+      { id: 1, title: "Task 1", priority: TaskPriority.LOW },
+    ]);
+  });
+});

--- a/Clients/src/application/hooks/__tests__/useUpdateTaskStatus.test.ts
+++ b/Clients/src/application/hooks/__tests__/useUpdateTaskStatus.test.ts
@@ -1,0 +1,106 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { renderHook, act, waitFor } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import React from "react";
+import { useUpdateTaskStatus } from "../useUpdateTaskStatus";
+import { taskQueryKeys } from "../useTasks";
+import { TaskStatus } from "../../../domain/enums/task.enum";
+
+vi.mock("../../repository/task.repository", () => ({
+  updateTaskStatus: vi.fn(),
+}));
+
+import { updateTaskStatus } from "../../repository/task.repository";
+
+const mockUpdateTaskStatus = vi.mocked(updateTaskStatus);
+
+function createWrapper() {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  });
+  return {
+    queryClient,
+    wrapper: ({ children }: { children: React.ReactNode }) =>
+      React.createElement(QueryClientProvider, { client: queryClient }, children),
+  };
+}
+
+describe("useUpdateTaskStatus", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("optimistically updates the task status in the list cache", async () => {
+    let resolveMutation: () => void = () => {};
+    mockUpdateTaskStatus.mockImplementation(
+      () =>
+        new Promise<void>((resolve) => {
+          resolveMutation = resolve;
+        }),
+    );
+
+    const filters = { includeArchived: false };
+    const queryKey = taskQueryKeys.list(filters);
+    const { queryClient, wrapper } = createWrapper();
+
+    queryClient.setQueryData(queryKey, [
+      { id: 1, title: "Task 1", status: TaskStatus.OPEN },
+      { id: 2, title: "Task 2", status: TaskStatus.OPEN },
+    ]);
+
+    const { result } = renderHook(() => useUpdateTaskStatus(), { wrapper });
+
+    act(() => {
+      result.current.mutate({ id: 1, status: TaskStatus.IN_PROGRESS, filters });
+    });
+
+    await waitFor(() =>
+      expect(queryClient.getQueryData(queryKey)).toEqual([
+        { id: 1, title: "Task 1", status: TaskStatus.IN_PROGRESS },
+        { id: 2, title: "Task 2", status: TaskStatus.OPEN },
+      ]),
+    );
+
+    act(() => {
+      resolveMutation();
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(mockUpdateTaskStatus).toHaveBeenCalledWith({ id: 1, status: TaskStatus.IN_PROGRESS });
+  });
+
+  it("rolls back the optimistic update when the mutation fails", async () => {
+    let rejectMutation: (error: Error) => void = () => {};
+    mockUpdateTaskStatus.mockImplementation(
+      () =>
+        new Promise<never>((_resolve, reject) => {
+          rejectMutation = reject;
+        }),
+    );
+
+    const filters = { includeArchived: false };
+    const queryKey = taskQueryKeys.list(filters);
+    const { queryClient, wrapper } = createWrapper();
+
+    queryClient.setQueryData(queryKey, [{ id: 1, title: "Task 1", status: TaskStatus.OPEN }]);
+
+    const { result } = renderHook(() => useUpdateTaskStatus(), { wrapper });
+
+    act(() => {
+      result.current.mutate({ id: 1, status: TaskStatus.COMPLETED, filters });
+    });
+
+    await waitFor(() =>
+      expect(queryClient.getQueryData(queryKey)).toEqual([
+        { id: 1, title: "Task 1", status: TaskStatus.COMPLETED },
+      ]),
+    );
+
+    act(() => {
+      rejectMutation(new Error("Failed"));
+    });
+
+    await waitFor(() => expect(result.current.isError).toBe(true));
+    expect(queryClient.getQueryData(queryKey)).toEqual([
+      { id: 1, title: "Task 1", status: TaskStatus.OPEN },
+    ]);
+  });
+});

--- a/Clients/src/application/hooks/useBulkUpdateFiles.ts
+++ b/Clients/src/application/hooks/useBulkUpdateFiles.ts
@@ -1,6 +1,12 @@
-import { useMutation } from "@tanstack/react-query";
-import { bulkUpdateFileTags, type BulkUpdateFileTagsPayload } from "../repository/file.repository";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import {
+  bulkUpdateFileTags,
+  type BulkUpdateFileTagsPayload,
+  type BulkFileTagMode,
+} from "../repository/file.repository";
 import { assignFilesToFolder } from "../repository/virtualFolder.repository";
+import { fileQueryKeys } from "./useFiles";
+import { FileModel } from "../../domain/models/Common/file/file.model";
 
 export type BulkFileAction =
   | { type: "move_to_folder"; folderId: number; ids: number[] }
@@ -11,6 +17,11 @@ interface UseBulkUpdateFilesOptions {
   onError?: (error: unknown, action: BulkFileAction) => void;
 }
 
+interface TagMutationContext {
+  previousData: FileModel[] | undefined;
+  queryKey: readonly unknown[];
+}
+
 async function runBulkAction(action: BulkFileAction) {
   if (action.type === "move_to_folder") {
     return assignFilesToFolder(action.folderId, action.ids);
@@ -18,10 +29,56 @@ async function runBulkAction(action: BulkFileAction) {
   return bulkUpdateFileTags(action.payload);
 }
 
+function applyTagUpdate(
+  currentTags: string[] | undefined,
+  newTags: string[],
+  mode: BulkFileTagMode,
+): string[] {
+  if (mode === "set") return newTags;
+  const current = currentTags ?? [];
+  if (mode === "add") return Array.from(new Set([...current, ...newTags]));
+  return current.filter((tag) => !newTags.includes(tag));
+}
+
 export function useBulkUpdateFiles(options: UseBulkUpdateFilesOptions = {}) {
-  return useMutation({
-    mutationFn: (action: BulkFileAction) => runBulkAction(action),
-    onSuccess: (_data, action) => options.onSuccess?.(action),
-    onError: (error, action) => options.onError?.(error, action),
+  const queryClient = useQueryClient();
+  const { onSuccess, onError } = options;
+
+  return useMutation<unknown, Error, BulkFileAction, TagMutationContext | undefined>({
+    mutationFn: (action) => runBulkAction(action),
+    onMutate: async (action) => {
+      if (action.type !== "update_tags") return undefined;
+
+      const queryKey = fileQueryKeys.list();
+      await queryClient.cancelQueries({ queryKey });
+      const previousData = queryClient.getQueryData<FileModel[]>(queryKey);
+
+      if (previousData) {
+        const targetIds = new Set(action.payload.ids.map((id) => String(id)));
+        queryClient.setQueryData<FileModel[]>(queryKey, (old) =>
+          old?.map((file) => {
+            if (!targetIds.has(String(file.id))) return file;
+            return FileModel.createNewFile({
+              ...file,
+              tags: applyTagUpdate(file.tags, action.payload.tags, action.payload.mode),
+            });
+          }),
+        );
+      }
+
+      return { previousData, queryKey };
+    },
+    onError: (error, action, context) => {
+      if (action.type === "update_tags" && context?.previousData !== undefined) {
+        queryClient.setQueryData(context.queryKey, context.previousData);
+      }
+      onError?.(error, action);
+    },
+    onSuccess: (_data, action) => {
+      if (action.type === "update_tags") {
+        queryClient.invalidateQueries({ queryKey: fileQueryKeys.lists() });
+      }
+      onSuccess?.(action);
+    },
   });
 }

--- a/Clients/src/application/hooks/useBulkUpdatePolicies.ts
+++ b/Clients/src/application/hooks/useBulkUpdatePolicies.ts
@@ -1,18 +1,64 @@
-import { useMutation } from "@tanstack/react-query";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
 import {
   bulkUpdatePolicies,
   type BulkUpdatePoliciesPayload,
+  type BulkPolicyAction,
 } from "../repository/policy.repository";
+import { PolicyManagerModel } from "../../domain/models/Common/policy/policyManager.model";
+import { policyQueryKeys } from "./usePolicies";
+import { patchListItemsByIds } from "./utils/optimisticMutation";
 
 interface UseBulkUpdatePoliciesOptions {
   onSuccess?: (payload: BulkUpdatePoliciesPayload) => void;
   onError?: (error: unknown, payload: BulkUpdatePoliciesPayload) => void;
 }
 
+function getOptimisticPatch(
+  action: BulkPolicyAction,
+  payload: BulkUpdatePoliciesPayload,
+): Partial<PolicyManagerModel> {
+  switch (action) {
+    case "archive":
+      return { status: "Archived" };
+    case "set_reviewer":
+      return {
+        assigned_reviewer_ids: payload.reviewerId ? [payload.reviewerId] : [],
+      };
+    case "set_tags":
+      return { tags: payload.tags as PolicyManagerModel["tags"] };
+    default:
+      return {};
+  }
+}
+
 export function useBulkUpdatePolicies(options: UseBulkUpdatePoliciesOptions = {}) {
+  const queryClient = useQueryClient();
+
   return useMutation({
     mutationFn: (payload: BulkUpdatePoliciesPayload) => bulkUpdatePolicies(payload),
+    onMutate: async (payload) => {
+      const queryKey = policyQueryKeys.list();
+      await queryClient.cancelQueries({ queryKey });
+      const previousData = queryClient.getQueryData<PolicyManagerModel[]>(queryKey);
+      const patch = getOptimisticPatch(payload.action, payload);
+      if (previousData) {
+        queryClient.setQueryData<PolicyManagerModel[]>(queryKey, (old) =>
+          patchListItemsByIds(old, payload.ids, patch),
+        );
+      }
+      return { previousData, queryKey };
+    },
+    onError: (error, payload, context) => {
+      if (context?.previousData !== undefined) {
+        queryClient.setQueryData(context.queryKey, context.previousData);
+      }
+      options.onError?.(error, payload);
+    },
+    onSettled: (_data, _error, _payload, context) => {
+      if (context?.queryKey) {
+        queryClient.invalidateQueries({ queryKey: context.queryKey });
+      }
+    },
     onSuccess: (_data, payload) => options.onSuccess?.(payload),
-    onError: (error, payload) => options.onError?.(error, payload),
   });
 }

--- a/Clients/src/application/hooks/useBulkUpdateTasks.ts
+++ b/Clients/src/application/hooks/useBulkUpdateTasks.ts
@@ -1,15 +1,24 @@
-import { useMutation } from "@tanstack/react-query";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { bulkUpdateTasks, type BulkUpdateTasksPayload } from "../repository/task.repository";
 
 interface UseBulkUpdateTasksOptions {
   onSuccess?: (payload: BulkUpdateTasksPayload) => void;
   onError?: (error: unknown, payload: BulkUpdateTasksPayload) => void;
+  invalidateKeys?: readonly (readonly unknown[])[];
 }
 
 export function useBulkUpdateTasks(options: UseBulkUpdateTasksOptions = {}) {
+  const queryClient = useQueryClient();
+  const { invalidateKeys, onSuccess, onError } = options;
+
   return useMutation({
     mutationFn: (payload: BulkUpdateTasksPayload) => bulkUpdateTasks(payload),
-    onSuccess: (_data, payload) => options.onSuccess?.(payload),
-    onError: (error, payload) => options.onError?.(error, payload),
+    onSuccess: (_data, payload) => {
+      invalidateKeys?.forEach((key) => {
+        queryClient.invalidateQueries({ queryKey: key });
+      });
+      onSuccess?.(payload);
+    },
+    onError: (error, payload) => onError?.(error, payload),
   });
 }

--- a/Clients/src/application/hooks/useFiles.ts
+++ b/Clients/src/application/hooks/useFiles.ts
@@ -1,7 +1,6 @@
 import { useQuery } from "@tanstack/react-query";
 import { getFilesWithMetadata } from "../repository/file.repository";
 import { transformFilesData } from "../utils/fileTransform.utils";
-import type { FileModel } from "../../domain/models/Common/file/file.model";
 
 export const fileQueryKeys = {
   all: ["files"] as const,

--- a/Clients/src/application/hooks/useFiles.ts
+++ b/Clients/src/application/hooks/useFiles.ts
@@ -1,0 +1,31 @@
+import { useQuery } from "@tanstack/react-query";
+import { getFilesWithMetadata } from "../repository/file.repository";
+import { transformFilesData } from "../utils/fileTransform.utils";
+import type { FileModel } from "../../domain/models/Common/file/file.model";
+
+export const fileQueryKeys = {
+  all: ["files"] as const,
+  lists: () => [...fileQueryKeys.all, "list"] as const,
+  list: (filters: { page?: number; pageSize?: number } = {}) =>
+    [...fileQueryKeys.lists(), filters] as const,
+  details: () => [...fileQueryKeys.all, "detail"] as const,
+  detail: (id: string) => [...fileQueryKeys.details(), id] as const,
+};
+
+interface UseFilesOptions {
+  page?: number;
+  pageSize?: number;
+}
+
+export function useFiles(options: UseFilesOptions = {}) {
+  const { page, pageSize } = options;
+
+  return useQuery({
+    queryKey: fileQueryKeys.list({ page, pageSize }),
+    queryFn: async ({ signal }) => {
+      const response = await getFilesWithMetadata({ page, pageSize, signal });
+      return transformFilesData(response.files);
+    },
+    staleTime: 2 * 1000,
+  });
+}

--- a/Clients/src/application/hooks/usePolicies.ts
+++ b/Clients/src/application/hooks/usePolicies.ts
@@ -12,7 +12,7 @@ export const policyQueryKeys = {
 
 export const usePolicies = (): UseQueryResult<PolicyManagerModel[], Error> => {
   return useQuery({
-    queryKey: policyQueryKeys.lists(),
+    queryKey: policyQueryKeys.list(),
     queryFn: async () => {
       return await getAllPolicies();
     },

--- a/Clients/src/application/hooks/usePolicies.ts
+++ b/Clients/src/application/hooks/usePolicies.ts
@@ -5,6 +5,9 @@ import { PolicyManagerModel } from "../../domain/models/Common/policy/policyMana
 export const policyQueryKeys = {
   all: ["policies"] as const,
   lists: () => [...policyQueryKeys.all, "list"] as const,
+  list: (filters: Record<string, unknown> = {}) => [...policyQueryKeys.lists(), filters] as const,
+  details: () => [...policyQueryKeys.all, "detail"] as const,
+  detail: (id: number | string) => [...policyQueryKeys.details(), id] as const,
 };
 
 export const usePolicies = (): UseQueryResult<PolicyManagerModel[], Error> => {

--- a/Clients/src/application/hooks/usePolicyMutations.ts
+++ b/Clients/src/application/hooks/usePolicyMutations.ts
@@ -1,0 +1,34 @@
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { createPolicy, updatePolicy } from "../repository/policy.repository";
+import { PolicyInput } from "../../domain/interfaces/i.policy";
+import { PolicyManagerModel } from "../../domain/models/Common/policy/policyManager.model";
+import { policyQueryKeys } from "./usePolicies";
+import { useOptimisticListMutation } from "./utils/optimisticMutation";
+
+export function useCreatePolicy() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (input: PolicyInput) => createPolicy(input),
+    onSettled: () => {
+      queryClient.invalidateQueries({ queryKey: policyQueryKeys.lists() });
+    },
+  });
+}
+
+export function useUpdatePolicy() {
+  return useOptimisticListMutation<
+    PolicyManagerModel,
+    PolicyManagerModel,
+    Error,
+    { id: number; input: PolicyInput }
+  >({
+    mutationFn: ({ id, input }) => updatePolicy(id, input),
+    queryKey: () => policyQueryKeys.list(),
+    updateItem:
+      ({ input }) =>
+      (policy) =>
+        ({ ...policy, ...input }) as PolicyManagerModel,
+    invalidateKeys: ({ id }) => [[...policyQueryKeys.list()], [...policyQueryKeys.detail(id)]],
+  });
+}

--- a/Clients/src/application/hooks/useProjectRisks.tsx
+++ b/Clients/src/application/hooks/useProjectRisks.tsx
@@ -45,7 +45,14 @@ export interface ProjectRisk {
   recommendations?: any;
 }
 
-const PROJECT_RISKS_QUERY_KEY = ["projectRisks"] as const;
+export const projectRiskQueryKeys = {
+  all: ["projectRisks"] as const,
+  lists: () => [...projectRiskQueryKeys.all, "list"] as const,
+  list: (projectId: number | string, filter?: string) =>
+    [...projectRiskQueryKeys.lists(), { projectId, filter }] as const,
+  details: () => [...projectRiskQueryKeys.all, "detail"] as const,
+  detail: (id: number | string) => [...projectRiskQueryKeys.details(), id] as const,
+};
 
 const useProjectRisks = ({ projectId, refreshKey }: { projectId: number; refreshKey?: any }) => {
   const {
@@ -53,7 +60,7 @@ const useProjectRisks = ({ projectId, refreshKey }: { projectId: number; refresh
     isLoading: loadingProjectRisks,
     error,
   } = useQuery({
-    queryKey: [...PROJECT_RISKS_QUERY_KEY, projectId, refreshKey],
+    queryKey: [...projectRiskQueryKeys.list(projectId, "active"), refreshKey],
     queryFn: async ({ signal }) => {
       const response = await getAllProjectRisksByProjectId({
         projectId: String(projectId),

--- a/Clients/src/application/hooks/useTags.ts
+++ b/Clients/src/application/hooks/useTags.ts
@@ -1,0 +1,13 @@
+import { useQuery } from "@tanstack/react-query";
+import { getAllTags } from "../repository/policy.repository";
+
+export const tagQueryKeys = {
+  all: ["policy-tags"] as const,
+};
+
+export function useTags() {
+  return useQuery({
+    queryKey: tagQueryKeys.all,
+    queryFn: async () => getAllTags(),
+  });
+}

--- a/Clients/src/application/hooks/useTasks.ts
+++ b/Clients/src/application/hooks/useTasks.ts
@@ -1,0 +1,33 @@
+import { useQuery } from "@tanstack/react-query";
+import { getAllTasks } from "../repository/task.repository";
+import type { ITask } from "../../domain/interfaces/i.task";
+
+export const taskQueryKeys = {
+  all: ["tasks"] as const,
+  lists: () => [...taskQueryKeys.all, "list"] as const,
+  list: (filters: { includeArchived?: boolean }) => [...taskQueryKeys.lists(), filters] as const,
+  details: () => [...taskQueryKeys.all, "detail"] as const,
+  detail: (id: number | string) => [...taskQueryKeys.details(), id] as const,
+};
+
+interface UseTasksOptions {
+  includeArchived?: boolean;
+}
+
+export function useTasks(options: UseTasksOptions = {}) {
+  const { includeArchived } = options;
+
+  return useQuery({
+    queryKey: taskQueryKeys.list({ includeArchived }),
+    queryFn: async ({ signal }) => {
+      const response = await getAllTasks({
+        include_archived: includeArchived || undefined,
+        sort_by: "created_at",
+        sort_order: "DESC",
+        signal,
+      });
+      return (response?.data?.tasks as ITask[]) || [];
+    },
+    staleTime: 2 * 1000,
+  });
+}

--- a/Clients/src/application/hooks/useUpdateFileMetadata.ts
+++ b/Clients/src/application/hooks/useUpdateFileMetadata.ts
@@ -1,0 +1,20 @@
+import { updateFileMetadata, type UpdateFileMetadataInput } from "../repository/file.repository";
+import { fileQueryKeys } from "./useFiles";
+import { useOptimisticListMutation } from "./utils/optimisticMutation";
+import { FileModel } from "../../domain/models/Common/file/file.model";
+
+export interface UpdateFileMetadataVariables {
+  id: string;
+  updates: UpdateFileMetadataInput;
+}
+
+export function useUpdateFileMetadata() {
+  return useOptimisticListMutation<FileModel, unknown, Error, UpdateFileMetadataVariables>({
+    mutationFn: ({ id, updates }) => updateFileMetadata({ id, updates }),
+    queryKey: () => fileQueryKeys.list(),
+    updateItem:
+      ({ id, updates }) =>
+      (file) =>
+        String(file.id) === String(id) ? FileModel.createNewFile({ ...file, ...updates }) : file,
+  });
+}

--- a/Clients/src/application/hooks/useUpdateProjectRisk.ts
+++ b/Clients/src/application/hooks/useUpdateProjectRisk.ts
@@ -1,0 +1,35 @@
+import { updateProjectRisk } from "../repository/projectRisk.repository";
+import { projectRiskQueryKeys, type ProjectRisk } from "./useProjectRisks";
+import { useOptimisticListMutation } from "./utils/optimisticMutation";
+
+export interface UpdateProjectRiskVariables {
+  id: number;
+  projectId?: number;
+  body: Record<string, unknown>;
+}
+
+export interface UpdateProjectRiskResponse {
+  status: number;
+  data: {
+    data?: { id?: number };
+    message?: string;
+    errors?: Array<{ message?: string }>;
+  };
+}
+
+export function useUpdateProjectRisk() {
+  return useOptimisticListMutation<
+    ProjectRisk,
+    UpdateProjectRiskResponse,
+    Error,
+    UpdateProjectRiskVariables
+  >({
+    mutationFn: ({ id, body }) =>
+      updateProjectRisk({ id, body }) as Promise<UpdateProjectRiskResponse>,
+    queryKey: ({ projectId }) => projectRiskQueryKeys.list(projectId ?? 0, "active"),
+    updateItem:
+      ({ id, body }) =>
+      (risk) =>
+        risk.id === id ? { ...risk, ...body } : risk,
+  });
+}

--- a/Clients/src/application/hooks/useUpdateTaskPriority.ts
+++ b/Clients/src/application/hooks/useUpdateTaskPriority.ts
@@ -1,0 +1,22 @@
+import { updateTaskPriority } from "../repository/task.repository";
+import { taskQueryKeys } from "./useTasks";
+import { useOptimisticListMutation } from "./utils/optimisticMutation";
+import type { ITask } from "../../domain/interfaces/i.task";
+import { TaskPriority } from "../../domain/enums/task.enum";
+
+export interface UpdateTaskPriorityVariables {
+  id: number;
+  priority: TaskPriority;
+  filters?: { includeArchived?: boolean };
+}
+
+export function useUpdateTaskPriority() {
+  return useOptimisticListMutation<ITask, unknown, Error, UpdateTaskPriorityVariables>({
+    mutationFn: ({ id, priority }) => updateTaskPriority({ id, priority }),
+    queryKey: ({ filters }) => taskQueryKeys.list(filters || {}),
+    updateItem:
+      ({ id, priority }) =>
+      (task) =>
+        task.id === id ? { ...task, priority } : task,
+  });
+}

--- a/Clients/src/application/hooks/useUpdateTaskStatus.ts
+++ b/Clients/src/application/hooks/useUpdateTaskStatus.ts
@@ -1,0 +1,22 @@
+import { updateTaskStatus } from "../repository/task.repository";
+import { taskQueryKeys } from "./useTasks";
+import { useOptimisticListMutation } from "./utils/optimisticMutation";
+import type { ITask } from "../../domain/interfaces/i.task";
+import { TaskStatus } from "../../domain/enums/task.enum";
+
+export interface UpdateTaskStatusVariables {
+  id: number;
+  status: TaskStatus;
+  filters?: { includeArchived?: boolean };
+}
+
+export function useUpdateTaskStatus() {
+  return useOptimisticListMutation<ITask, unknown, Error, UpdateTaskStatusVariables>({
+    mutationFn: ({ id, status }) => updateTaskStatus({ id, status }),
+    queryKey: ({ filters }) => taskQueryKeys.list(filters || {}),
+    updateItem:
+      ({ id, status }) =>
+      (task) =>
+        task.id === id ? { ...task, status } : task,
+  });
+}

--- a/Clients/src/application/hooks/utils/__tests__/optimisticMutation.test.ts
+++ b/Clients/src/application/hooks/utils/__tests__/optimisticMutation.test.ts
@@ -1,0 +1,267 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { renderHook, act, waitFor } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import React from "react";
+import {
+  useOptimisticListMutation,
+  useOptimisticDetailMutation,
+  patchListItemById,
+  patchListItemsByIds,
+} from "../optimisticMutation";
+
+interface TestItem {
+  id: number;
+  name: string;
+  status: string;
+}
+
+const TEST_LIST_KEY = ["test", "list"] as const;
+const TEST_DETAIL_KEY = ["test", "detail", 1] as const;
+
+function createWrapper() {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: { retry: false },
+      mutations: { retry: false },
+    },
+  });
+  return {
+    queryClient,
+    wrapper: ({ children }: { children: React.ReactNode }) =>
+      React.createElement(QueryClientProvider, { client: queryClient }, children),
+  };
+}
+
+describe("patchListItemById", () => {
+  it("patches the matching item and leaves others unchanged", () => {
+    const list: TestItem[] = [
+      { id: 1, name: "A", status: "old" },
+      { id: 2, name: "B", status: "old" },
+    ];
+    const result = patchListItemById(list, 1, { status: "new" });
+    expect(result).toEqual([
+      { id: 1, name: "A", status: "new" },
+      { id: 2, name: "B", status: "old" },
+    ]);
+  });
+
+  it("returns undefined when list is undefined", () => {
+    expect(patchListItemById<TestItem>(undefined, 1, { status: "new" })).toBeUndefined();
+  });
+});
+
+describe("patchListItemsByIds", () => {
+  it("patches multiple items by id", () => {
+    const list: TestItem[] = [
+      { id: 1, name: "A", status: "old" },
+      { id: 2, name: "B", status: "old" },
+      { id: 3, name: "C", status: "old" },
+    ];
+    const result = patchListItemsByIds(list, [1, 3], { status: "new" });
+    expect(result).toEqual([
+      { id: 1, name: "A", status: "new" },
+      { id: 2, name: "B", status: "old" },
+      { id: 3, name: "C", status: "new" },
+    ]);
+  });
+});
+
+describe("useOptimisticListMutation", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("updates the list cache immediately and invalidates it on settle", async () => {
+    let resolveMutation: (value: { updated: boolean }) => void = () => {};
+    const mutationFn = vi.fn().mockImplementation(
+      () =>
+        new Promise<{ updated: boolean }>((resolve) => {
+          resolveMutation = resolve;
+        }),
+    );
+    const invalidateKeys = vi.fn().mockReturnValue([["other", "key"]] as const);
+    const { queryClient, wrapper } = createWrapper();
+
+    queryClient.setQueryData<TestItem[]>(TEST_LIST_KEY, [
+      { id: 1, name: "A", status: "old" },
+      { id: 2, name: "B", status: "old" },
+    ]);
+
+    const { result } = renderHook(
+      () =>
+        useOptimisticListMutation<
+          TestItem,
+          { updated: boolean },
+          Error,
+          { id: number; status: string }
+        >({
+          mutationFn,
+          queryKey: () => TEST_LIST_KEY,
+          updateItem: (vars) => (item) =>
+            item.id === vars.id ? { ...item, status: vars.status } : item,
+          invalidateKeys,
+        }),
+      { wrapper },
+    );
+
+    act(() => {
+      result.current.mutate({ id: 1, status: "new" });
+    });
+
+    await waitFor(() =>
+      expect(queryClient.getQueryData<TestItem[]>(TEST_LIST_KEY)).toEqual([
+        { id: 1, name: "A", status: "new" },
+        { id: 2, name: "B", status: "old" },
+      ]),
+    );
+
+    act(() => {
+      resolveMutation({ updated: true });
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(mutationFn).toHaveBeenCalledWith(
+      expect.objectContaining({ id: 1, status: "new" }),
+      expect.anything(),
+    );
+    expect(invalidateKeys).toHaveBeenCalledWith({ id: 1, status: "new" });
+  });
+
+  it("rolls back the list cache when the mutation fails", async () => {
+    let rejectMutation: (error: Error) => void = () => {};
+    const mutationFn = vi.fn().mockImplementation(
+      () =>
+        new Promise<never>((_resolve, reject) => {
+          rejectMutation = reject;
+        }),
+    );
+    const { queryClient, wrapper } = createWrapper();
+
+    queryClient.setQueryData<TestItem[]>(TEST_LIST_KEY, [{ id: 1, name: "A", status: "old" }]);
+
+    const { result } = renderHook(
+      () =>
+        useOptimisticListMutation<
+          TestItem,
+          { updated: boolean },
+          Error,
+          { id: number; status: string }
+        >({
+          mutationFn,
+          queryKey: () => TEST_LIST_KEY,
+          updateItem: (vars) => (item) =>
+            item.id === vars.id ? { ...item, status: vars.status } : item,
+        }),
+      { wrapper },
+    );
+
+    act(() => {
+      result.current.mutate({ id: 1, status: "new" });
+    });
+
+    await waitFor(() =>
+      expect(queryClient.getQueryData<TestItem[]>(TEST_LIST_KEY)).toEqual([
+        { id: 1, name: "A", status: "new" },
+      ]),
+    );
+
+    act(() => {
+      rejectMutation(new Error("Network error"));
+    });
+
+    await waitFor(() => expect(result.current.isError).toBe(true));
+    expect(queryClient.getQueryData<TestItem[]>(TEST_LIST_KEY)).toEqual([
+      { id: 1, name: "A", status: "old" },
+    ]);
+  });
+});
+
+describe("useOptimisticDetailMutation", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("updates the detail cache immediately and rolls back on error", async () => {
+    let rejectMutation: (error: Error) => void = () => {};
+    const mutationFn = vi.fn().mockImplementation(
+      () =>
+        new Promise<never>((_resolve, reject) => {
+          rejectMutation = reject;
+        }),
+    );
+    const { queryClient, wrapper } = createWrapper();
+
+    queryClient.setQueryData<TestItem>(TEST_DETAIL_KEY, { id: 1, name: "A", status: "old" });
+
+    const { result } = renderHook(
+      () =>
+        useOptimisticDetailMutation<TestItem, Error, { status: string }>({
+          mutationFn,
+          queryKey: () => TEST_DETAIL_KEY,
+          updateData: (old, vars) => (old ? { ...old, status: vars.status } : old),
+        }),
+      { wrapper },
+    );
+
+    act(() => {
+      result.current.mutate({ status: "new" });
+    });
+
+    await waitFor(() =>
+      expect(queryClient.getQueryData<TestItem>(TEST_DETAIL_KEY)).toEqual({
+        id: 1,
+        name: "A",
+        status: "new",
+      }),
+    );
+
+    act(() => {
+      rejectMutation(new Error("Server error"));
+    });
+
+    await waitFor(() => expect(result.current.isError).toBe(true));
+    expect(queryClient.getQueryData<TestItem>(TEST_DETAIL_KEY)).toEqual({
+      id: 1,
+      name: "A",
+      status: "old",
+    });
+  });
+
+  it("invalidates target keys on success", async () => {
+    let resolveMutation: (value: { updated: boolean }) => void = () => {};
+    const mutationFn = vi.fn().mockImplementation(
+      () =>
+        new Promise<{ updated: boolean }>((resolve) => {
+          resolveMutation = resolve;
+        }),
+    );
+    const invalidateKeys = vi.fn().mockReturnValue([["list", "key"]] as const);
+    const { queryClient, wrapper } = createWrapper();
+
+    queryClient.setQueryData<TestItem>(TEST_DETAIL_KEY, { id: 1, name: "A", status: "old" });
+
+    const { result } = renderHook(
+      () =>
+        useOptimisticDetailMutation<TestItem, Error, { status: string }>({
+          mutationFn,
+          queryKey: () => TEST_DETAIL_KEY,
+          updateData: (old, vars) => (old ? { ...old, status: vars.status } : old),
+          invalidateKeys,
+        }),
+      { wrapper },
+    );
+
+    act(() => {
+      result.current.mutate({ status: "new" });
+    });
+
+    await waitFor(() => expect(mutationFn).toHaveBeenCalled());
+
+    act(() => {
+      resolveMutation({ updated: true });
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(invalidateKeys).toHaveBeenCalledWith({ status: "new" });
+  });
+});

--- a/Clients/src/application/hooks/utils/optimisticMutation.ts
+++ b/Clients/src/application/hooks/utils/optimisticMutation.ts
@@ -1,0 +1,133 @@
+import {
+  useMutation,
+  useQueryClient,
+  type UseMutationOptions,
+  type UseMutationResult,
+} from "@tanstack/react-query";
+
+export interface OptimisticListMutationContext<TData> {
+  previousData: TData | undefined;
+  queryKey: readonly unknown[];
+}
+
+export interface UseOptimisticListMutationConfig<
+  TItem extends { id: string | number },
+  TData = TItem[],
+  TError = Error,
+  TVariables = unknown,
+> {
+  mutationFn: (variables: TVariables) => Promise<TData>;
+  queryKey: (variables: TVariables) => readonly unknown[];
+  updateItem: (variables: TVariables) => (item: TItem) => TItem;
+  invalidateKeys?: (variables: TVariables) => readonly (readonly unknown[])[];
+  options?: Omit<
+    UseMutationOptions<TData, TError, TVariables, OptimisticListMutationContext<TItem[]>>,
+    "mutationFn" | "onMutate" | "onError" | "onSettled"
+  >;
+}
+
+export function useOptimisticListMutation<
+  TItem extends { id: string | number },
+  TData = TItem[],
+  TError = Error,
+  TVariables = unknown,
+>(
+  config: UseOptimisticListMutationConfig<TItem, TData, TError, TVariables>,
+): UseMutationResult<TData, TError, TVariables, OptimisticListMutationContext<TItem[]>> {
+  const queryClient = useQueryClient();
+
+  return useMutation<TData, TError, TVariables, OptimisticListMutationContext<TItem[]>>({
+    mutationFn: config.mutationFn,
+    onMutate: async (variables) => {
+      const queryKey = config.queryKey(variables);
+      await queryClient.cancelQueries({ queryKey });
+      const previousData = queryClient.getQueryData<TItem[]>(queryKey);
+      if (previousData) {
+        queryClient.setQueryData<TItem[]>(queryKey, (old) =>
+          old?.map(config.updateItem(variables)),
+        );
+      }
+      return { previousData, queryKey };
+    },
+    onError: (_error, _variables, context) => {
+      if (context?.previousData !== undefined) {
+        queryClient.setQueryData(context.queryKey, context.previousData);
+      }
+    },
+    onSettled: (_data, _error, variables, context) => {
+      if (context?.queryKey) {
+        queryClient.invalidateQueries({ queryKey: context.queryKey });
+      }
+      config.invalidateKeys?.(variables).forEach((key) => {
+        queryClient.invalidateQueries({ queryKey: key });
+      });
+    },
+    ...config.options,
+  });
+}
+
+export interface OptimisticDetailMutationContext<TData> {
+  previousData: TData | undefined;
+  queryKey: readonly unknown[];
+}
+
+export interface UseOptimisticDetailMutationConfig<TData, TError = Error, TVariables = unknown> {
+  mutationFn: (variables: TVariables) => Promise<TData>;
+  queryKey: (variables: TVariables) => readonly unknown[];
+  updateData: (old: TData | undefined, variables: TVariables) => TData | undefined;
+  invalidateKeys?: (variables: TVariables) => readonly (readonly unknown[])[];
+  options?: Omit<
+    UseMutationOptions<TData, TError, TVariables, OptimisticDetailMutationContext<TData>>,
+    "mutationFn" | "onMutate" | "onError" | "onSettled"
+  >;
+}
+
+export function useOptimisticDetailMutation<TData, TError = Error, TVariables = unknown>(
+  config: UseOptimisticDetailMutationConfig<TData, TError, TVariables>,
+): UseMutationResult<TData, TError, TVariables, OptimisticDetailMutationContext<TData>> {
+  const queryClient = useQueryClient();
+
+  return useMutation<TData, TError, TVariables, OptimisticDetailMutationContext<TData>>({
+    mutationFn: config.mutationFn,
+    onMutate: async (variables) => {
+      const queryKey = config.queryKey(variables);
+      await queryClient.cancelQueries({ queryKey });
+      const previousData = queryClient.getQueryData<TData>(queryKey);
+      queryClient.setQueryData<TData>(queryKey, (old) => config.updateData(old, variables));
+      return { previousData, queryKey };
+    },
+    onError: (_error, _variables, context) => {
+      if (context?.previousData !== undefined) {
+        queryClient.setQueryData(context.queryKey, context.previousData);
+      }
+    },
+    onSettled: (_data, _error, variables, context) => {
+      if (context?.queryKey) {
+        queryClient.invalidateQueries({ queryKey: context.queryKey });
+      }
+      config.invalidateKeys?.(variables).forEach((key) => {
+        queryClient.invalidateQueries({ queryKey: key });
+      });
+    },
+    ...config.options,
+  });
+}
+
+export function patchListItemById<T extends { id: string | number }>(
+  list: T[] | undefined,
+  id: T["id"],
+  patch: Partial<T>,
+): T[] | undefined {
+  if (!list) return list;
+  return list.map((item) => (item.id === id ? { ...item, ...patch } : item));
+}
+
+export function patchListItemsByIds<T extends { id: string | number }>(
+  list: T[] | undefined,
+  ids: T["id"][],
+  patch: Partial<T>,
+): T[] | undefined {
+  if (!list) return list;
+  const idSet = new Set(ids);
+  return list.map((item) => (idSet.has(item.id) ? { ...item, ...patch } : item));
+}

--- a/Clients/src/application/hooks/utils/optimisticMutation.ts
+++ b/Clients/src/application/hooks/utils/optimisticMutation.ts
@@ -11,7 +11,7 @@ export interface OptimisticListMutationContext<TData> {
 }
 
 export interface UseOptimisticListMutationConfig<
-  TItem extends { id: string | number },
+  TItem extends { id?: string | number },
   TData = TItem[],
   TError = Error,
   TVariables = unknown,
@@ -27,7 +27,7 @@ export interface UseOptimisticListMutationConfig<
 }
 
 export function useOptimisticListMutation<
-  TItem extends { id: string | number },
+  TItem extends { id?: string | number },
   TData = TItem[],
   TError = Error,
   TVariables = unknown,
@@ -113,7 +113,7 @@ export function useOptimisticDetailMutation<TData, TError = Error, TVariables = 
   });
 }
 
-export function patchListItemById<T extends { id: string | number }>(
+export function patchListItemById<T extends { id?: string | number }>(
   list: T[] | undefined,
   id: T["id"],
   patch: Partial<T>,
@@ -122,7 +122,7 @@ export function patchListItemById<T extends { id: string | number }>(
   return list.map((item) => (item.id === id ? { ...item, ...patch } : item));
 }
 
-export function patchListItemsByIds<T extends { id: string | number }>(
+export function patchListItemsByIds<T extends { id?: string | number }>(
   list: T[] | undefined,
   ids: T["id"][],
   patch: Partial<T>,

--- a/Clients/src/i18n/translations.ts
+++ b/Clients/src/i18n/translations.ts
@@ -919,6 +919,8 @@ export const translations: Record<string, Record<string, string>> = {
     "Error loading controls": "Fehler beim Laden der Kontrollen",
     "Error restoring task": "Fehler beim Wiederherstellen der Aufgabe",
     "Error updating task": "Fehler beim Aktualisieren der Aufgabe",
+    "Error updating task priority": "Fehler beim Aktualisieren der Aufgabenpriorität",
+    "Error updating task status": "Fehler beim Aktualisieren des Aufgabenstatus",
     "Cannot update training without ID": "Schulung kann ohne ID nicht aktualisiert werden",
     "Please select a project to view assessments":
       "Wählen Sie ein Projekt, um Bewertungen anzuzeigen",
@@ -6310,6 +6312,10 @@ export const translations: Record<string, Record<string, string>> = {
       "Aktualisieren des Status fehlgeschlagen. Bitte erneut versuchen.",
     "Failed to update the task. Please try again.":
       "Aktualisieren der Aufgabe fehlgeschlagen. Bitte erneut versuchen.",
+    "Failed to update the task priority. Please try again.":
+      "Aktualisieren der Aufgabenpriorität fehlgeschlagen. Bitte erneut versuchen.",
+    "Failed to update the task status. Please try again.":
+      "Aktualisieren des Aufgabenstatus fehlgeschlagen. Bitte erneut versuchen.",
     "Failed to update the vendor risk. Please try again.":
       "Aktualisieren des Anbieterrisikos fehlgeschlagen. Bitte erneut versuchen.",
     "Failed to upload": "Hochladen fehlgeschlagen",
@@ -9837,6 +9843,8 @@ export const translations: Record<string, Record<string, string>> = {
     "Error loading controls": "Erreur lors du chargement des contrôles",
     "Error restoring task": "Erreur lors de la restauration de la tâche",
     "Error updating task": "Erreur lors de la mise à jour de la tâche",
+    "Error updating task priority": "Erreur lors de la mise à jour de la priorité de la tâche",
+    "Error updating task status": "Erreur lors de la mise à jour du statut de la tâche",
     "Cannot update training without ID": "Impossible de mettre à jour une formation sans ID",
     "Please select a project to view assessments":
       "Sélectionnez un projet pour voir les évaluations",
@@ -14939,6 +14947,10 @@ export const translations: Record<string, Record<string, string>> = {
       "Échec de la mise à jour du statut. Veuillez réessayer.",
     "Failed to update the task. Please try again.":
       "Échec de la mise à jour de la tâche. Veuillez réessayer.",
+    "Failed to update the task priority. Please try again.":
+      "Échec de la mise à jour de la priorité de la tâche. Veuillez réessayer.",
+    "Failed to update the task status. Please try again.":
+      "Échec de la mise à jour du statut de la tâche. Veuillez réessayer.",
     "Failed to update the vendor risk. Please try again.":
       "Échec de la mise à jour du risque fournisseur. Veuillez réessayer.",
     "Failed to upload": "Échec du téléversement",
@@ -17972,6 +17984,8 @@ export const translations: Record<string, Record<string, string>> = {
     "Error loading controls": "Error al cargar los controles",
     "Error restoring task": "Error al restaurar la tarea",
     "Error updating task": "Error al actualizar la tarea",
+    "Error updating task priority": "Error al actualizar la prioridad de la tarea",
+    "Error updating task status": "Error al actualizar el estado de la tarea",
     "Cannot update training without ID": "No se puede actualizar la formación sin un ID",
     "Welcome to VerifyWise": "Te damos la bienvenida a VerifyWise",
     "Welcome": "Bienvenido",
@@ -24338,6 +24352,10 @@ export const translations: Record<string, Record<string, string>> = {
       "No se pudo actualizar el estado. Inténtelo de nuevo.",
     "Failed to update the task. Please try again.":
       "No se pudo actualizar la tarea. Inténtelo de nuevo.",
+    "Failed to update the task priority. Please try again.":
+      "No se pudo actualizar la prioridad de la tarea. Inténtelo de nuevo.",
+    "Failed to update the task status. Please try again.":
+      "No se pudo actualizar el estado de la tarea. Inténtelo de nuevo.",
     "Failed to update the vendor risk. Please try again.":
       "No se pudo actualizar el riesgo del proveedor. Inténtelo de nuevo.",
     "File marked for deletion. Please save to apply changes.":

--- a/Clients/src/presentation/components/AddNewRiskForm/hooks/useRiskForm.ts
+++ b/Clients/src/presentation/components/AddNewRiskForm/hooks/useRiskForm.ts
@@ -11,10 +11,8 @@ import {
 } from "../projectRiskValue";
 import { AddNewRiskFormProps } from "../../../types/riskForm.types";
 import { ApiResponse } from "../../../../domain/interfaces/i.response";
-import {
-  createProjectRisk,
-  updateProjectRisk,
-} from "../../../../application/repository/projectRisk.repository";
+import { createProjectRisk } from "../../../../application/repository/projectRisk.repository";
+import { useUpdateProjectRisk } from "../../../../application/hooks/useUpdateProjectRisk";
 import useUsers from "../../../../application/hooks/useUsers";
 import { useAuth } from "../../../../application/hooks/useAuth";
 import { VerifyWiseContext } from "../../../../application/contexts/VerifyWise.context";
@@ -118,6 +116,7 @@ export function useRiskForm(props: AddNewRiskFormProps): UseRiskFormReturn {
   const usersLoading = usersLoadingProp !== undefined ? usersLoadingProp : hookData.loading;
 
   const { inputValues } = useContext(VerifyWiseContext);
+  const updateProjectRiskMutation = useUpdateProjectRisk();
 
   const isEditingDisabled = !allowedRoles.projectRisks.edit.includes(userRoleName);
   const isCreatingDisabled = !allowedRoles.projectRisks.create.includes(userRoleName);
@@ -485,7 +484,11 @@ export function useRiskForm(props: AddNewRiskFormProps): UseRiskFormReturn {
       try {
         const response =
           popupStatus !== "new"
-            ? await updateProjectRisk({ id: Number(inputValues.id), body: formData })
+            ? await updateProjectRiskMutation.mutateAsync({
+                id: Number(inputValues.id),
+                projectId: projectId ? Number(projectId) : undefined,
+                body: formData,
+              })
             : await createProjectRisk({ body: formData });
 
         if (response && response.status === 201) {

--- a/Clients/src/presentation/components/Table/TasksTable/index.tsx
+++ b/Clients/src/presentation/components/Table/TasksTable/index.tsx
@@ -34,6 +34,7 @@ import { taskTableStyles } from "./styles";
 import { useStandardTable } from "../../../../application/hooks/useStandardTable";
 import { useBulkSelection } from "../../../../application/hooks/useBulkSelection";
 import { useBulkUpdateTasks } from "../../../../application/hooks/useBulkUpdateTasks";
+import { taskQueryKeys } from "../../../../application/hooks/useTasks";
 import StandardTableHead from "../StandardTableHead";
 import StandardTablePagination from "../StandardTablePagination";
 import type { StandardColumn } from "../../../../domain/types/standardTable";
@@ -208,6 +209,7 @@ const TasksTable: React.FC<ITasksTableProps> = ({
   const [pendingCategories, setPendingCategories] = useState<string[]>([]);
 
   const bulkMutation = useBulkUpdateTasks({
+    invalidateKeys: [taskQueryKeys.lists()],
     onSuccess: (payload) => {
       clearSelection();
       onBulkActionSuccess?.(payload.action, payload.ids.length);

--- a/Clients/src/presentation/pages/FileManager/index.tsx
+++ b/Clients/src/presentation/pages/FileManager/index.tsx
@@ -1,4 +1,5 @@
 import React, { useState, useEffect, useMemo, useCallback, type JSX } from "react";
+import { useQueryClient } from "@tanstack/react-query";
 import { useLocation, useNavigate } from "react-router-dom";
 import { Stack, Box, Typography } from "@mui/material";
 import { Upload as UploadIcon, FolderPlus as FolderPlusIcon } from "lucide-react";
@@ -7,17 +8,15 @@ import PageTour from "../../components/PageTour";
 import useMultipleOnScreen from "../../../application/hooks/useMultipleOnScreen";
 import FileSteps from "./FileSteps";
 import CustomizableSkeleton from "../../components/Skeletons";
-import { useUserFilesMetaData } from "../../../application/hooks/useUserFilesMetaData";
+import { useFiles, fileQueryKeys } from "../../../application/hooks/useFiles";
+import { useUpdateFileMetadata } from "../../../application/hooks/useUpdateFileMetadata";
 import FileTable from "../../components/Table/FileTable/FileTable";
 import {
-  getUserFilesMetaData,
   getFilesWithMetadata,
   getFileMetadata,
-  updateFileMetadata,
   FileMetadata,
   UpdateFileMetadataInput,
 } from "../../../application/repository/file.repository";
-import { transformFilesData } from "../../../application/utils/fileTransform.utils";
 import { filesTableFrame } from "./styles";
 import { FileModel } from "../../../domain/models/Common/file/file.model";
 import { CustomizableButton } from "../../components/button/customizable-button";
@@ -89,17 +88,10 @@ const FileManager: React.FC = (): JSX.Element => {
     countToTrigger: 1,
   });
 
-  // Use hook for initial data load
-  const {
-    filesData: initialFilesData,
-    loading: initialLoading,
-    error: initialError,
-  } = useUserFilesMetaData();
-
-  // Local state to manage files
-  const [filesData, setFilesData] = useState<FileModel[]>([]);
-  const [loadingFiles, setLoadingFiles] = useState(initialLoading);
-  const [filesError, setFilesError] = useState<Error | null>(null);
+  // Use React Query for file data
+  const { data: filesData = [], isLoading: loadingFiles, error: filesError, refetch } = useFiles();
+  const queryClient = useQueryClient();
+  const updateFileMetadataMutation = useUpdateFileMetadata();
   const [isUploadModalOpen, setIsUploadModalOpen] = useState(false);
 
   // Virtual folder hooks
@@ -215,26 +207,6 @@ const FileManager: React.FC = (): JSX.Element => {
     return undefined;
   }, [alert]);
 
-  // Sync initial data from hook to local state ONLY on initial load
-  // After that, optimistic updates manage the state independently
-  const [hasInitialized, setHasInitialized] = useState(false);
-
-  useEffect(() => {
-    if (hasInitialized) return;
-
-    // Still loading - reflect that
-    if (initialLoading) {
-      setLoadingFiles(true);
-      return;
-    }
-
-    // Loading finished (success or error) - sync state and mark initialized
-    setFilesData(initialFilesData);
-    setFilesError(initialError);
-    setLoadingFiles(false);
-    setHasInitialized(true);
-  }, [initialFilesData, initialLoading, initialError, hasInitialized]);
-
   // RBAC: Get user role for permission checks
   const { userRoleName } = useAuth();
 
@@ -244,21 +216,6 @@ const FileManager: React.FC = (): JSX.Element => {
   // Permission checks
   const isUploadAllowed = Boolean(userRoleName) && userRoleName !== AUDITOR_ROLE;
   const canManageFolders = Boolean(userRoleName) && MANAGE_ROLES.includes(userRoleName);
-
-  // Manual refetch function - only used for initial load or explicit refresh
-  const refetch = useCallback(async () => {
-    try {
-      setLoadingFiles(true);
-      setFilesError(null);
-      const response = await getUserFilesMetaData();
-      setFilesData(transformFilesData(response));
-    } catch (error) {
-      secureLogError("Error refetching files", FILE_MANAGER_CONTEXT);
-      setFilesError(error instanceof Error ? error : new Error("Failed to load files"));
-    } finally {
-      setLoadingFiles(false);
-    }
-  }, []);
 
   // Fetch files with enhanced metadata
   const fetchFilesWithMetadata = useCallback(async () => {
@@ -336,7 +293,7 @@ const FileManager: React.FC = (): JSX.Element => {
         }
       }
 
-      // Optimistically add uploaded files to local state
+      // Optimistically add uploaded files to the cache
       const newFiles = uploadedFiles.map((file) =>
         FileModel.createNewFile({
           id: String(file.id),
@@ -350,7 +307,9 @@ const FileManager: React.FC = (): JSX.Element => {
         }),
       );
 
-      setFilesData((prev) => [...newFiles, ...prev]);
+      queryClient.setQueryData(fileQueryKeys.list(), (old: FileModel[] | undefined) =>
+        old ? [...newFiles, ...old] : newFiles,
+      );
 
       // Refresh metadata to get the complete file info including review_status
       fetchFilesWithMetadata();
@@ -363,10 +322,16 @@ const FileManager: React.FC = (): JSX.Element => {
     [selectedFolder, fetchFilesWithMetadata, refreshFiles],
   );
 
-  // Handle file deleted - optimistically remove from state
-  const handleFileDeleted = useCallback((fileId: string) => {
-    setFilesData((prev) => prev.filter((file) => String(file.id) !== fileId));
-  }, []);
+  // Handle file deleted - optimistically remove from cache
+  const handleFileDeleted = useCallback(
+    (fileId: string) => {
+      queryClient.setQueryData(
+        fileQueryKeys.list(),
+        (old: FileModel[] | undefined) => old?.filter((file) => String(file.id) !== fileId) ?? [],
+      );
+    },
+    [queryClient],
+  );
 
   // Preview panel handlers
   const handleOpenPreview = useCallback(
@@ -459,8 +424,13 @@ const FileManager: React.FC = (): JSX.Element => {
 
       setIsSubmittingMetadata(true);
       try {
-        await updateFileMetadata({ id: editingFile.id, updates });
-        await fetchFilesWithMetadata();
+        await updateFileMetadataMutation.mutateAsync({ id: editingFile.id, updates });
+        // Keep the enhanced metadata local state in sync for the editor/preview
+        setFilesWithMetadata((prev) =>
+          prev.map((file) =>
+            file.id === editingFile.id ? ({ ...file, ...updates } as FileMetadata) : file,
+          ),
+        );
         handleCloseMetadataEditor();
         setAlert({ variant: "success", body: "File metadata updated successfully", isToast: true });
       } catch (error) {
@@ -471,7 +441,7 @@ const FileManager: React.FC = (): JSX.Element => {
         setIsSubmittingMetadata(false);
       }
     },
-    [editingFile, fetchFilesWithMetadata, handleCloseMetadataEditor],
+    [editingFile, updateFileMetadataMutation, handleCloseMetadataEditor],
   );
 
   // Version history handlers
@@ -984,7 +954,7 @@ const FileManager: React.FC = (): JSX.Element => {
                 <CustomizableButton
                   variant="outlined"
                   text="Try again"
-                  onClick={refetch}
+                  onClick={() => refetch()}
                   sx={{ height: "34px" }}
                 />
               </Box>

--- a/Clients/src/presentation/pages/PolicyDashboard/PoliciesDashboard.tsx
+++ b/Clients/src/presentation/pages/PolicyDashboard/PoliciesDashboard.tsx
@@ -5,16 +5,15 @@ import TabContext from "@mui/lab/TabContext";
 import TabBar from "../../components/TabBar";
 import PageTour from "../../components/PageTour";
 import { PageHeaderExtended } from "../../components/Layout/PageHeaderExtended";
-import { PolicyManagerModel } from "../../../domain/models/Common/policy/policyManager.model";
-import { getAllPolicies, getAllTags } from "../../../application/repository/policy.repository";
+import { usePolicies } from "../../../application/hooks/usePolicies";
+import { useTags } from "../../../application/hooks/useTags";
 import PolicyManager from "./PolicyManager";
 import PolicyTemplates from "./PolicyTemplates";
 import PolicySteps from "./PolicySteps";
 
 const PolicyDashboard: React.FC = () => {
-  const [policies, setPolicies] = useState<PolicyManagerModel[]>([]);
-  const [tags, setTags] = useState<string[]>([]);
-  const [isPoliciesLoading, setIsPoliciesLoading] = useState(true);
+  const { data: policies = [], isLoading: isPoliciesLoading } = usePolicies();
+  const { data: tags = [], isLoading: isTagsLoading } = useTags();
   const [isTemplatesLoading, setIsTemplatesLoading] = useState(true);
   const [isInitialLoadComplete, setIsInitialLoadComplete] = useState(false);
   const [templateCount, setTemplateCount] = useState(0);
@@ -25,20 +24,7 @@ const PolicyDashboard: React.FC = () => {
   const isPolicyTemplateTab = currentPath.includes("/policies/templates");
   const activeTab = isPolicyTemplateTab ? "templates" : "policies";
 
-  const fetchAll = async () => {
-    setIsPoliciesLoading(true);
-    try {
-      const [pRes, tRes] = await Promise.all([getAllPolicies(), getAllTags()]);
-      setPolicies(pRes);
-      setTags(tRes);
-      setIsInitialLoadComplete(true);
-    } finally {
-      setIsPoliciesLoading(false);
-    }
-  };
-
   useEffect(() => {
-    fetchAll();
     setIsTemplatesLoading(true);
     fetch("/data/PolicyTemplates.json")
       .then((res) => res.json())
@@ -46,6 +32,12 @@ const PolicyDashboard: React.FC = () => {
       .catch(() => {})
       .finally(() => setIsTemplatesLoading(false));
   }, []);
+
+  useEffect(() => {
+    if (!isPoliciesLoading && !isTagsLoading) {
+      setIsInitialLoadComplete(true);
+    }
+  }, [isPoliciesLoading, isTagsLoading]);
 
   const handleTabChange = (_: React.SyntheticEvent, tabValue: string) => {
     if (tabValue === "policies") {
@@ -89,17 +81,8 @@ const PolicyDashboard: React.FC = () => {
           />
         </Box>
 
-        {activeTab === "policies" && (
-          <PolicyManager
-            policies={policies}
-            tags={tags}
-            fetchAll={fetchAll}
-            isLoading={isPoliciesLoading}
-          />
-        )}
-        {activeTab === "templates" && (
-          <PolicyTemplates tags={tags} fetchAll={fetchAll} isLoading={isTemplatesLoading} />
-        )}
+        {activeTab === "policies" && <PolicyManager tags={tags} />}
+        {activeTab === "templates" && <PolicyTemplates tags={tags} isLoading={isPoliciesLoading} />}
 
         <PageTour steps={PolicySteps} run={isInitialLoadComplete} tourKey="policy-tour" />
       </TabContext>

--- a/Clients/src/presentation/pages/PolicyDashboard/PolicyEditorPage.tsx
+++ b/Clients/src/presentation/pages/PolicyDashboard/PolicyEditorPage.tsx
@@ -109,10 +109,9 @@ import { uploadFileToManager } from "../../../application/repository/file.reposi
 import {
   getPolicyById,
   getAllTags,
-  createPolicy,
-  updatePolicy,
   importDocxToHtml,
 } from "../../../application/repository/policy.repository";
+import { useCreatePolicy, useUpdatePolicy } from "../../../application/hooks/usePolicyMutations";
 import useUsers from "../../../application/hooks/useUsers";
 import { User } from "../../../domain/types/User";
 import { PolicyFormData, PolicyFormErrors, PolicyInput } from "../../types/interfaces/i.policy";
@@ -471,6 +470,8 @@ export default function PolicyEditorPage() {
   const navigate = useNavigate();
   const theme = useTheme();
   const { users } = useUsers();
+  const createPolicyMutation = useCreatePolicy();
+  const updatePolicyMutation = useUpdatePolicy();
 
   const isNew = !id;
   const templateId = searchParams.get("templateId");
@@ -608,7 +609,10 @@ export default function PolicyEditorPage() {
 
     setIsSavingTitle(true);
     try {
-      const updated = await updatePolicy(policy.id, { title: trimmed } as PolicyInput);
+      const updated = await updatePolicyMutation.mutateAsync({
+        id: policy.id,
+        input: { title: trimmed } as PolicyInput,
+      });
       setFormData((prev) => ({ ...prev, title: trimmed }));
       setPolicy((prev) => (prev ? { ...prev, ...updated, title: trimmed } : updated));
       clearFieldError("title");
@@ -1362,9 +1366,12 @@ export default function PolicyEditorPage() {
       let savedPolicy: PolicyManagerModel;
 
       if (isNew) {
-        savedPolicy = await createPolicy(payload);
+        savedPolicy = await createPolicyMutation.mutateAsync(payload);
       } else {
-        savedPolicy = await updatePolicy(policy!.id, payload);
+        savedPolicy = await updatePolicyMutation.mutateAsync({
+          id: policy!.id,
+          input: payload,
+        });
       }
 
       // Flush any locally-staged custom field changes (create OR update).

--- a/Clients/src/presentation/pages/PolicyDashboard/PolicyManager.tsx
+++ b/Clients/src/presentation/pages/PolicyDashboard/PolicyManager.tsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useState, useMemo, useCallback } from "react";
 import { useLocation, useNavigate, useSearchParams } from "react-router-dom";
+import { useQueryClient } from "@tanstack/react-query";
 import { Box, Stack, Fade, Tooltip, IconButton } from "@mui/material";
 import {
   CirclePlus as AddCircleOutlineIcon,
@@ -20,6 +21,7 @@ import Alert from "../../components/Alert";
 import { AlertProps } from "../../types/alert.types";
 import { PolicyManagerModel } from "../../../domain/models/Common/policy/policyManager.model";
 import { PolicyManagerProps } from "../../types/interfaces/i.policy";
+import { usePolicies, policyQueryKeys } from "../../../application/hooks/usePolicies";
 import PolicyStatusCard from "./PolicyStatusCard";
 import { ExportMenu } from "../../components/Table/ExportMenu";
 import useUsers from "../../../application/hooks/useUsers";
@@ -68,26 +70,18 @@ const POLICY_TABLE_COLUMNS: ColumnConfig<PolicyColumnKey>[] = [
   { key: "actions", label: "Actions", defaultVisible: true, alwaysVisible: true },
 ];
 
-const PolicyManager: React.FC<PolicyManagerProps> = ({
-  policies: policyList,
-  tags: _tags,
-  fetchAll,
-  isLoading = false,
-}) => {
+const PolicyManager: React.FC<PolicyManagerProps> = ({ tags: _tags }) => {
   const location = useLocation();
   const navigate = useNavigate();
+  const queryClient = useQueryClient();
   const [searchParams, setSearchParams] = useSearchParams();
-  const [policies, setPolicies] = useState<PolicyManagerModel[]>([]);
+  const { data: policies = [], isLoading } = usePolicies();
   const [flashRowId, setFlashRowId] = useState<number | null>(null);
   const { userRoleName } = useAuth();
   const canRunBulkActions = !!userRoleName && ["Admin", "Editor"].includes(userRoleName);
 
   const [showLinkedObjectModal, setLinkedObjectsModalOpen] = useState(false);
   const [policyId, setSelectedPolicyId] = useState<number | null>(null);
-
-  useEffect(() => {
-    setPolicies(policyList);
-  }, [policyList]);
 
   // Folder sidebar state
   const [folderSidebarOpen, setFolderSidebarOpen] = useState(false);
@@ -159,7 +153,6 @@ const PolicyManager: React.FC<PolicyManagerProps> = ({
         setFlashRowId(location.state.flashRowId);
         setTimeout(() => setFlashRowId(null), 3000);
       }
-      fetchAll();
       handleAlert({
         variant: "success",
         body: location.state.successMessage,
@@ -169,7 +162,7 @@ const PolicyManager: React.FC<PolicyManagerProps> = ({
       // Clear state so it doesn't trigger again
       navigate(location.pathname, { replace: true, state: {} });
     }
-  }, [location.state, navigate, location.pathname, fetchAll]);
+  }, [location.state, navigate, location.pathname]);
 
   const handleOpen = useCallback(
     (id?: number) => {
@@ -198,7 +191,7 @@ const PolicyManager: React.FC<PolicyManagerProps> = ({
   const handleDelete = async (id: number) => {
     try {
       await deletePolicy(id);
-      setPolicies((prev) => prev.filter((policy) => policy.id !== id));
+      queryClient.invalidateQueries({ queryKey: policyQueryKeys.lists() });
 
       // Show success alert using VerifyWise standard pattern
       handleAlert({
@@ -685,7 +678,6 @@ const PolicyManager: React.FC<PolicyManagerProps> = ({
                     visibleColumns={visibleColumns}
                     canRunBulkActions={canRunBulkActions}
                     onBulkActionSuccess={(action, count) => {
-                      fetchAll();
                       handleAlert({
                         variant: "success",
                         title:

--- a/Clients/src/presentation/pages/Tasks/index.tsx
+++ b/Clients/src/presentation/pages/Tasks/index.tsx
@@ -1,5 +1,6 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import React, { useState, useEffect, useContext, useMemo, useCallback, useRef } from "react";
+import { useQueryClient } from "@tanstack/react-query";
 import { Box, Stack, Typography, Fade } from "@mui/material";
 import TabContext from "@mui/lab/TabContext";
 import { useSearchParams } from "react-router-dom";
@@ -13,15 +14,12 @@ import { VerifyWiseContext } from "../../../application/contexts/VerifyWise.cont
 import { storageService } from "../../../infrastructure/storage";
 import { ITask, TaskSummary } from "../../../domain/interfaces/i.task";
 import {
-  getAllTasks,
   createTask,
   updateTask,
   deleteTask,
-  updateTaskStatus,
   getTaskById,
   restoreTask,
   hardDeleteTask,
-  updateTaskPriority,
 } from "../../../application/repository/task.repository";
 import {
   addTaskEntityLink,
@@ -31,6 +29,9 @@ import {
 import TaskSummaryCards from "./TaskSummaryCards";
 import CreateTask from "../../components/Modals/CreateTask";
 import useUsers from "../../../application/hooks/useUsers";
+import { useTasks, taskQueryKeys } from "../../../application/hooks/useTasks";
+import { useUpdateTaskStatus } from "../../../application/hooks/useUpdateTaskStatus";
+import { useUpdateTaskPriority } from "../../../application/hooks/useUpdateTaskPriority";
 
 import Toggle from "../../components/Inputs/Toggle";
 import { TaskPriority, TaskStatus } from "../../../domain/enums/task.enum";
@@ -84,14 +85,21 @@ const TASKS_TABLE_COLUMNS: ColumnConfig<TaskColumnKey>[] = [
 
 const Tasks: React.FC = () => {
   const [searchParams, setSearchParams] = useSearchParams();
-  const [tasks, setTasks] = useState<TaskModel[]>([]);
-  const [refreshKey, setRefreshKey] = useState(0);
-  const [isLoading, setIsLoading] = useState(true);
-  const [error, setError] = useState<string | null>(null);
+  const [includeArchived, setIncludeArchived] = useState(false);
+  const queryClient = useQueryClient();
+  const {
+    data: rawTasks = [],
+    isLoading,
+    error: queryError,
+    refetch,
+  } = useTasks({ includeArchived });
+  const tasks = useMemo(() => rawTasks.map((task) => new TaskModel(task)), [rawTasks]);
+  const updateTaskStatusMutation = useUpdateTaskStatus();
+  const updateTaskPriorityMutation = useUpdateTaskPriority();
+  const error = queryError ? "Failed to load tasks. Please try again later." : null;
   const [isCreateTaskModalOpen, setIsCreateTaskModalOpen] = useState(false);
   const [editingTask, setEditingTask] = useState<ITask | null>(null);
   const [searchQuery, setSearchQuery] = useState("");
-  const [includeArchived, setIncludeArchived] = useState(false);
   const [alert, setAlert] = useState<{
     variant: "success" | "error" | "warning" | "info";
     title: string;
@@ -155,32 +163,6 @@ const Tasks: React.FC = () => {
     [tasks],
   );
 
-  // Fetch all tasks (no server-side filtering - we use client-side FilterBy)
-  useEffect(() => {
-    const fetchTasks = async () => {
-      try {
-        setIsLoading(true);
-        setError(null);
-
-        const response = await getAllTasks({
-          include_archived: includeArchived || undefined,
-          sort_by: "created_at",
-          sort_order: "DESC",
-        });
-
-        const fetchedTasks = response?.data?.tasks || [];
-        setTasks(fetchedTasks);
-      } catch (err: any) {
-        console.error("Error fetching tasks:", err);
-        setError("Failed to load tasks. Please try again later.");
-        setTasks([]);
-      } finally {
-        setIsLoading(false);
-      }
-    };
-    fetchTasks();
-  }, [includeArchived, refreshKey]);
-
   // Listen for AI action approvals for any task-lifecycle tool. Covers
   // create, update, and delete — all trigger a table refresh.
   useEffect(() => {
@@ -195,7 +177,7 @@ const Tasks: React.FC = () => {
         detail?.toolName &&
         TASK_TOOL_NAMES.has(detail.toolName)
       ) {
-        setRefreshKey((k) => k + 1);
+        refetch();
       }
     });
   }, []);
@@ -396,8 +378,11 @@ const Tasks: React.FC = () => {
           }
         }
 
-        // Add the new task to the list
-        setTasks((prev) => [response.data, ...prev]);
+        // Add the new task to the cache
+        queryClient.setQueryData(
+          taskQueryKeys.list({ includeArchived }),
+          (old: ITask[] | undefined) => (old ? [response.data, ...old] : [response.data]),
+        );
         setAlert({
           variant: "success",
           title: "Task created successfully",
@@ -432,7 +417,10 @@ const Tasks: React.FC = () => {
 
     try {
       await deleteTask({ id: taskId });
-      setTasks((prev) => prev.filter((t) => t.id !== taskId));
+      queryClient.setQueryData(
+        taskQueryKeys.list({ includeArchived }),
+        (old: ITask[] | undefined) => old?.filter((t) => t.id !== taskId) ?? [],
+      );
       setAlert({
         variant: "success",
         title: "Task archived successfully",
@@ -512,14 +500,16 @@ const Tasks: React.FC = () => {
           }
         }
 
-        // Update task in state with new entity links
+        // Update task in cache with new entity links
         const updatedTaskWithLinks = {
           ...response.data,
           entity_links: newEntityLinks || [],
         };
 
-        setTasks((prev) =>
-          prev.map((task) => (task.id === editingTask.id ? updatedTaskWithLinks : task)),
+        queryClient.setQueryData(
+          taskQueryKeys.list({ includeArchived }),
+          (old: ITask[] | undefined) =>
+            old?.map((task) => (task.id === editingTask.id ? updatedTaskWithLinks : task)) ?? [],
         );
 
         // Flash the updated row
@@ -551,28 +541,27 @@ const Tasks: React.FC = () => {
     (taskId: number) =>
     async (newStatus: string): Promise<boolean> => {
       try {
-        const response = await updateTaskStatus({
+        await updateTaskStatusMutation.mutateAsync({
           id: taskId,
           status: newStatus as TaskStatus,
+          filters: { includeArchived },
         });
-        if (response && response.data) {
-          setTasks((prev) =>
-            prev.map((task) =>
-              task.id === taskId ? { ...task, status: newStatus as TaskStatus } : task,
-            ),
-          );
 
-          // Flash the updated row
-          setFlashRowId(taskId);
-          setTimeout(() => {
-            setFlashRowId(null);
-          }, 3000);
+        // Flash the updated row
+        setFlashRowId(taskId);
+        setTimeout(() => {
+          setFlashRowId(null);
+        }, 3000);
 
-          return true;
-        }
-        return false;
+        return true;
       } catch (error) {
         console.error("Error updating task status:", error);
+        setAlert({
+          variant: "error",
+          title: "Error updating task status",
+          body: "Failed to update the task status. Please try again.",
+        });
+        setTimeout(() => setAlert(null), 4000);
         return false;
       }
     };
@@ -581,28 +570,27 @@ const Tasks: React.FC = () => {
     (taskId: number) =>
     async (newPriority: string): Promise<boolean> => {
       try {
-        const response = await updateTaskPriority({
+        await updateTaskPriorityMutation.mutateAsync({
           id: taskId,
           priority: newPriority as TaskPriority,
+          filters: { includeArchived },
         });
-        if (response && response.data) {
-          setTasks((prev) =>
-            prev.map((task) =>
-              task.id === taskId ? { ...task, priority: newPriority as TaskPriority } : task,
-            ),
-          );
 
-          // Flash the updated row
-          setFlashRowId(taskId);
-          setTimeout(() => {
-            setFlashRowId(null);
-          }, 3000);
+        // Flash the updated row
+        setFlashRowId(taskId);
+        setTimeout(() => {
+          setFlashRowId(null);
+        }, 3000);
 
-          return true;
-        }
-        return false;
+        return true;
       } catch (error) {
         console.error("Error updating task priority:", error);
+        setAlert({
+          variant: "error",
+          title: "Error updating task priority",
+          body: "Failed to update the task priority. Please try again.",
+        });
+        setTimeout(() => setAlert(null), 4000);
         return false;
       }
     };
@@ -613,9 +601,13 @@ const Tasks: React.FC = () => {
       // Repository returns response.data directly, so check for response.data (the actual task)
       if (response?.data) {
         const restoredTask = response.data;
-        // Update the task in the list with restored status
-        setTasks((prev) =>
-          prev.map((task) => (task.id === taskId ? { ...task, status: TaskStatus.OPEN } : task)),
+        // Update the task in the cache with restored status
+        queryClient.setQueryData(
+          taskQueryKeys.list({ includeArchived }),
+          (old: ITask[] | undefined) =>
+            old?.map((task) =>
+              task.id === taskId ? { ...task, status: TaskStatus.OPEN } : task,
+            ) ?? [],
         );
         setAlert({
           variant: "success",
@@ -639,8 +631,11 @@ const Tasks: React.FC = () => {
     const taskToHardDelete = tasks.find((t) => t.id === taskId);
     try {
       await hardDeleteTask({ id: taskId });
-      // Remove the task from the list completely
-      setTasks((prev) => prev.filter((task) => task.id !== taskId));
+      // Remove the task from the cache completely
+      queryClient.setQueryData(
+        taskQueryKeys.list({ includeArchived }),
+        (old: ITask[] | undefined) => old?.filter((task) => task.id !== taskId) ?? [],
+      );
       setAlert({
         variant: "success",
         title: "Task deleted permanently",
@@ -1000,7 +995,6 @@ const Tasks: React.FC = () => {
                 visibleColumns={visibleColumns}
                 canRunBulkActions={!isCreatingDisabled}
                 onBulkActionSuccess={(action, count) => {
-                  setRefreshKey((k) => k + 1);
                   setAlert({
                     variant: "success",
                     title:

--- a/Clients/src/presentation/types/interfaces/i.policy.ts
+++ b/Clients/src/presentation/types/interfaces/i.policy.ts
@@ -63,10 +63,7 @@ export interface PolicyFormProps {
  * Props for policy manager component
  */
 export interface PolicyManagerProps {
-  policies: PolicyManagerModel[];
   tags: string[];
-  fetchAll: () => void;
-  isLoading?: boolean;
 }
 
 /**
@@ -74,6 +71,6 @@ export interface PolicyManagerProps {
  */
 export interface PolicyTemplatesProps {
   tags: string[];
-  fetchAll: () => void;
+  fetchAll?: () => void;
   isLoading?: boolean;
 }


### PR DESCRIPTION
## Describe your changes

Implemented optimistic policy edits with targeted React Query cache invalidation: added `usePolicyMutations.ts` for create/update, upgraded `useBulkUpdatePolicies.ts` for optimistic archive/reviewer/tag bulk actions, and wired them into `PolicyEditorPage` and the policy list via `usePolicies()`. Migrated `PolicyManager` and `PoliciesDashboard` to React Query so list updates are visible instantly, with automatic rollback on mutation failures.

Fixes No. 9 of #4018

## Please ensure all items are checked off before requesting a review:

- [x] I deployed the code locally.
- [x] I have performed a self-review of my code.
- [x] I have included the issue # in the PR.
- [x] I have labelled the PR correctly.
- [x] The issue I am working on is assigned to me.
- [x] I have avoided using hardcoded values to ensure scalability and maintain consistency across the application.
- [x] I have ensured that font sizes, color choices, and other UI elements are referenced from the theme.
- [x] My pull request is focused and addresses a single, specific feature.
- [ ] If there are UI changes, I have attached a screenshot or video to this PR.
- [ ] If I added or modified an API endpoint, the change is reflected in the generated OpenAPI spec (`npm run generate:swagger`).
- [ ] If the endpoint requires authentication, it uses `authenticateJWT` and the generated spec declares `bearerAuth` security.
- [ ] I ran `npm run check:api-drift` and committed the regenerated `swagger.yaml` and `endpoints.ts`.
