### PR TITLE
Fix: AI Trust Centre Empty States

### DIFF
--- a/Clients/src/i18n/translations.ts
+++ b/Clients/src/i18n/translations.ts
@@ -8712,6 +8712,16 @@ export const translations: Record<string, Record<string, string>> = {
     "Get notified when assessments change": "Benachrichtigung bei Änderungen der Bewertungen",
     "Tracked apps are included in the weekly change digest, so configured recipients hear about score, grade, or policy changes.":
       "Verfolgte Apps sind in der wöchentlichen Änderungsübersicht enthalten, sodass konfigurierte Empfänger über Änderungen an Punktzahl, Note oder Richtlinie informiert werden.",
+    // AI Gateway empty/error states
+    "Click Save draft to create your first version.":
+      "Klicken Sie auf Entwurf speichern, um Ihre erste Version zu erstellen.",
+    "Could not load this run.": "Dieser Lauf konnte nicht geladen werden.",
+    "Create your first version": "Erstellen Sie Ihre erste Version",
+    "Error loading AI Trust Center settings. Please try again.":
+      "Fehler beim Laden der AI Trust Center-Einstellungen. Bitte versuchen Sie es erneut.",
+    "Failed to load invocation details.": "Aufrufdetails konnten nicht geladen werden.",
+    "Refresh": "Aktualisieren",
+    "Select a log to view details.": "Wählen Sie ein Protokoll aus, um Details anzuzeigen.",
   },
 
   fr: {
@@ -17357,6 +17367,16 @@ export const translations: Record<string, Record<string, string>> = {
     "Get notified when assessments change": "Être averti lorsque les évaluations changent",
     "Tracked apps are included in the weekly change digest, so configured recipients hear about score, grade, or policy changes.":
       "Les applications suivies sont incluses dans le récapitulatif hebdomadaire des modifications, afin que les destinataires configurés soient informés des changements de score, de note ou de politique.",
+    // AI Gateway empty/error states
+    "Click Save draft to create your first version.":
+      "Cliquez sur Enregistrer le brouillon pour créer votre première version.",
+    "Could not load this run.": "Impossible de charger cette exécution.",
+    "Create your first version": "Créer votre première version",
+    "Error loading AI Trust Center settings. Please try again.":
+      "Erreur lors du chargement des paramètres du AI Trust Center. Veuillez réessayer.",
+    "Failed to load invocation details.": "Échec du chargement des détails de l'invocation.",
+    "Refresh": "Actualiser",
+    "Select a log to view details.": "Sélectionnez un journal pour voir les détails.",
   },
   es: {
     // AI Trust Index
@@ -25919,5 +25939,15 @@ export const translations: Record<string, Record<string, string>> = {
     "Get notified when assessments change": "Reciba avisos cuando cambien las evaluaciones",
     "Tracked apps are included in the weekly change digest, so configured recipients hear about score, grade, or policy changes.":
       "Las aplicaciones seguidas se incluyen en el resumen semanal de cambios, de modo que los destinatarios configurados se enteran de los cambios de puntuación, calificación o política.",
+    // AI Gateway empty/error states
+    "Click Save draft to create your first version.":
+      "Haga clic en Guardar borrador para crear su primera versión.",
+    "Could not load this run.": "No se pudo cargar esta ejecución.",
+    "Create your first version": "Crear su primera versión",
+    "Error loading AI Trust Center settings. Please try again.":
+      "Error al cargar la configuración de AI Trust Center. Inténtelo de nuevo.",
+    "Failed to load invocation details.": "No se pudieron cargar los detalles de la invocación.",
+    "Refresh": "Actualizar",
+    "Select a log to view details.": "Seleccione un registro para ver los detalles.",
   },
 };

--- a/Clients/src/presentation/components/Table/AITrustCenterTable/index.tsx
+++ b/Clients/src/presentation/components/Table/AITrustCenterTable/index.tsx
@@ -15,8 +15,8 @@ import {
 } from "@mui/material";
 import singleTheme from "../../../themes/v1SingleTheme";
 import TablePaginationActions from "../../TablePagination";
-import { ChevronsUpDown, ChevronUp, ChevronDown } from "lucide-react";
-import Placeholder from "../../../assets/imgs/empty-state.svg";
+import { ChevronsUpDown, ChevronUp, ChevronDown, Inbox } from "lucide-react";
+import { EmptyState } from "../../EmptyState";
 import { IAITrustCenterTableProps } from "../../../types/interfaces/i.table";
 import CustomizableSkeleton from "../../Skeletons";
 
@@ -37,6 +37,7 @@ const AITrustCenterTable = <T extends { id: number }>({
   isLoading = false,
   paginated = true,
   emptyStateText = "No data found. Add your first item to get started.",
+  emptyStateIcon = Inbox,
   renderRow,
   onRowClick,
   tableId = "ai-trust-center-table",
@@ -302,25 +303,8 @@ const AITrustCenterTable = <T extends { id: number }>({
   );
 
   const emptyState = useMemo(
-    () => (
-      <Stack
-        alignItems="center"
-        justifyContent="center"
-        sx={{
-          border: "1px solid #EEEEEE",
-          borderRadius: "4px",
-          padding: theme.spacing(15, 5),
-          paddingBottom: theme.spacing(20),
-          gap: theme.spacing(10),
-          minHeight: 200,
-          backgroundColor: "background.main",
-        }}
-      >
-        <img src={Placeholder} alt="Empty state" />
-        <Typography sx={{ fontSize: "13px", color: "text.tertiary" }}>{emptyStateText}</Typography>
-      </Stack>
-    ),
-    [theme, emptyStateText],
+    () => <EmptyState icon={emptyStateIcon} message={emptyStateText} />,
+    [emptyStateIcon, emptyStateText],
   );
 
   if (isLoading) {

--- a/Clients/src/presentation/pages/AIGateway/Endpoints/index.tsx
+++ b/Clients/src/presentation/pages/AIGateway/Endpoints/index.tsx
@@ -11,6 +11,8 @@ import {
   TriangleAlert,
   KeyRound,
   Pencil,
+  AlertTriangle,
+  RotateCcw,
 } from "lucide-react";
 import Toggle from "../../../components/Inputs/Toggle";
 import { EmptyState } from "../../../components/EmptyState";
@@ -25,6 +27,7 @@ import { apiServices } from "../../../../infrastructure/api/networkServices";
 import palette from "../../../themes/palette";
 import { useCardSx, ProviderIcon, useGatewayModels, slugify } from "../shared";
 import { displayFormattedDate } from "../../../tools/isoDateToString";
+import CustomizableSkeleton from "../../../components/Skeletons";
 import { SHOW_AI_GATEWAY_PROMPTS } from "../../../../application/config/featureFlags";
 
 interface EndpointForm {
@@ -67,6 +70,7 @@ export default function EndpointsPage() {
   const [apiKeys, setApiKeys] = useState<any[]>([]);
   const [activeGuardrailCount, setActiveGuardrailCount] = useState(0);
   const [loading, setLoading] = useState(true);
+  const [loadError, setLoadError] = useState<string | null>(null);
 
   const [isModalOpen, setIsModalOpen] = useState(false);
   const [editingId, setEditingId] = useState<number | null>(null); // null = create, number = edit
@@ -82,6 +86,8 @@ export default function EndpointsPage() {
   const { providerItems, getModelsForProvider } = useGatewayModels();
 
   const loadData = useCallback(async () => {
+    setLoading(true);
+    setLoadError(null);
     try {
       const [endpointsRes, keysRes, grRes, promptsRes] = await Promise.all([
         apiServices.get<Record<string, any>>("/ai-gateway/endpoints"),
@@ -97,7 +103,7 @@ export default function EndpointsPage() {
       const allRules = grRes?.data?.rules || grRes?.data?.data || [];
       setActiveGuardrailCount(allRules.filter((r: any) => r.is_active).length);
     } catch {
-      // Silently handle
+      setLoadError("Failed to load endpoints. Please try again.");
     } finally {
       setLoading(false);
     }
@@ -227,9 +233,9 @@ export default function EndpointsPage() {
     .map((k) => ({ _id: String(k.id), name: `${k.key_name} (${k.provider})` }));
 
   const promptName = (id: number | null) => {
-    if (!id) return null;
+    if (!id) return undefined;
     const p = prompts.find((pr: any) => pr.id === id);
-    return p?.name || null;
+    return p?.name || undefined;
   };
 
   const isEditing = editingId !== null;
@@ -250,11 +256,16 @@ export default function EndpointsPage() {
       }
     >
       {loading ? (
-        <Box sx={cardSx}>
-          <Typography sx={{ fontSize: 13, color: palette.text.tertiary }}>
-            Loading endpoints...
-          </Typography>
-        </Box>
+        <CustomizableSkeleton variant="rectangular" width="100%" height={400} />
+      ) : loadError ? (
+        <EmptyState icon={AlertTriangle} message={loadError}>
+          <CustomizableButton
+            variant="outlined"
+            text="Retry"
+            icon={<RotateCcw size={16} />}
+            onClick={loadData}
+          />
+        </EmptyState>
       ) : endpoints.length === 0 ? (
         <EmptyState
           icon={Router}

--- a/Clients/src/presentation/pages/AIGateway/Guardrails/index.tsx
+++ b/Clients/src/presentation/pages/AIGateway/Guardrails/index.tsx
@@ -22,6 +22,7 @@ import {
   KeyRound,
   FileCheck,
   Scale,
+  RotateCcw,
 } from "lucide-react";
 import { CustomizableButton } from "../../../components/button/customizable-button";
 import Field from "../../../components/Inputs/Field";
@@ -34,6 +35,7 @@ import EmptyStateTip from "../../../components/EmptyState/EmptyStateTip";
 import { apiServices } from "../../../../infrastructure/api/networkServices";
 import palette from "../../../themes/palette";
 import { sectionTitleSx, useCardSx } from "../shared";
+import CustomizableSkeleton from "../../../components/Skeletons";
 
 // ─── Guardrail Catalog ────────────────────────────────────────────────────────
 
@@ -606,6 +608,7 @@ export default function GuardrailsPage() {
   const activeTab = urlTab === "content-filter" ? "content_filter" : "pii";
   const [rules, setRules] = useState<any[]>([]);
   const [loading, setLoading] = useState(true);
+  const [loadError, setLoadError] = useState<string | null>(null);
 
   // PII modal
   const [isPiiModalOpen, setIsPiiModalOpen] = useState(false);
@@ -646,11 +649,13 @@ export default function GuardrailsPage() {
   const [deleteSubmitting, setDeleteSubmitting] = useState(false);
 
   const loadRules = useCallback(async () => {
+    setLoading(true);
+    setLoadError(null);
     try {
       const res = await apiServices.get<Record<string, any>>("/ai-gateway/guardrails");
       setRules(res?.data?.rules || res?.data?.data || []);
     } catch {
-      // Silently handle
+      setLoadError("Failed to load guardrails. Please try again.");
     } finally {
       setLoading(false);
     }
@@ -943,116 +948,129 @@ export default function GuardrailsPage() {
           }
         />
 
-        <Box sx={{ mt: "16px" }}>
-          {/* ─── PII Detection tab ─────────────────────────────────────── */}
-          {activeTab === "pii" && (
-            <Box sx={cardSx}>
-              <Stack gap="12px">
-                <Stack
-                  direction="row"
-                  justifyContent="space-between"
-                  alignItems="flex-start"
-                  gap="16px"
-                >
-                  <Box flex={1} minWidth={0}>
-                    <Typography sx={sectionTitleSx}>PII detection</Typography>
-                    <Typography sx={{ fontSize: 13, color: palette.text.tertiary, mt: "4px" }}>
-                      Detect and protect personal data such as emails, phone numbers, credit cards,
-                      and names. PII scanning runs in-process within your gateway — no data is sent
-                      to external services.
-                    </Typography>
-                  </Box>
-                  <Box sx={{ flexShrink: 0 }}>
-                    <CustomizableButton
-                      text="Add PII rule"
-                      icon={<CirclePlus size={14} strokeWidth={1.5} />}
-                      onClick={() => {
-                        setPiiForm({ name: "", entity: "EMAIL_ADDRESS", action: "block" });
-                        setIsPiiModalOpen(true);
-                      }}
-                    />
-                  </Box>
-                </Stack>
-
-                {loading ? null : piiRules.length === 0 ? (
-                  <EmptyState
-                    icon={Fingerprint}
-                    message="No PII detection rules configured. Add rules to automatically detect and protect personal data in AI requests."
-                    showBorder
+        {!loading && !loadError && (
+          <Box sx={{ mt: "16px" }}>
+            {/* ─── PII Detection tab ─────────────────────────────────────── */}
+            {activeTab === "pii" && (
+              <Box sx={cardSx}>
+                <Stack gap="12px">
+                  <Stack
+                    direction="row"
+                    justifyContent="space-between"
+                    alignItems="flex-start"
+                    gap="16px"
                   >
-                    <EmptyStateTip
-                      icon={Lock}
-                      title="In-process PII scanning"
-                      description="PII detection runs within your gateway infrastructure. No data is sent to external services for scanning. Supports email, phone, credit card, names, IBAN, Turkish TCKN, and more."
-                    />
-                    <EmptyStateTip
-                      icon={ShieldCheck}
-                      title="Block or mask detected PII"
-                      description="Block requests containing personal data, or mask it with placeholders (e.g., <EMAIL_ADDRESS>) before sending to the LLM. Input is scanned before the model sees it."
-                    />
-                  </EmptyState>
-                ) : (
-                  <Stack gap="8px">{piiRules.map(renderRuleRow)}</Stack>
-                )}
-              </Stack>
-            </Box>
-          )}
+                    <Box flex={1} minWidth={0}>
+                      <Typography sx={sectionTitleSx}>PII detection</Typography>
+                      <Typography sx={{ fontSize: 13, color: palette.text.tertiary, mt: "4px" }}>
+                        Detect and protect personal data such as emails, phone numbers, credit
+                        cards, and names. PII scanning runs in-process within your gateway — no data
+                        is sent to external services.
+                      </Typography>
+                    </Box>
+                    <Box sx={{ flexShrink: 0 }}>
+                      <CustomizableButton
+                        text="Add PII rule"
+                        icon={<CirclePlus size={14} strokeWidth={1.5} />}
+                        onClick={() => {
+                          setPiiForm({ name: "", entity: "EMAIL_ADDRESS", action: "block" });
+                          setIsPiiModalOpen(true);
+                        }}
+                      />
+                    </Box>
+                  </Stack>
 
-          {/* ─── Content Filter tab ────────────────────────────────────── */}
-          {activeTab === "content_filter" && (
-            <Box sx={cardSx}>
-              <Stack gap="12px">
-                <Stack
-                  direction="row"
-                  justifyContent="space-between"
-                  alignItems="flex-start"
-                  gap="16px"
-                >
-                  <Box flex={1} minWidth={0}>
-                    <Typography sx={sectionTitleSx}>Content filter</Typography>
-                    <Typography sx={{ fontSize: 13, color: palette.text.tertiary, mt: "4px" }}>
-                      Block or mask content matching specific keywords or regex patterns. Use
-                      keywords for exact terms and regex for format detection (e.g., project codes,
-                      internal URLs).
-                    </Typography>
-                  </Box>
-                  <Box sx={{ flexShrink: 0 }}>
-                    <CustomizableButton
-                      text="Add filter rule"
-                      icon={<CirclePlus size={14} strokeWidth={1.5} />}
-                      onClick={() => {
-                        setCfForm({ name: "", type: "keyword", pattern: "", action: "block" });
-                        setCfError("");
-                        setIsCfModalOpen(true);
-                      }}
-                    />
-                  </Box>
+                  {piiRules.length === 0 ? (
+                    <EmptyState
+                      icon={Fingerprint}
+                      message="No PII detection rules configured. Add rules to automatically detect and protect personal data in AI requests."
+                      showBorder
+                    >
+                      <EmptyStateTip
+                        icon={Lock}
+                        title="In-process PII scanning"
+                        description="PII detection runs within your gateway infrastructure. No data is sent to external services for scanning. Supports email, phone, credit card, names, IBAN, Turkish TCKN, and more."
+                      />
+                      <EmptyStateTip
+                        icon={ShieldCheck}
+                        title="Block or mask detected PII"
+                        description="Block requests containing personal data, or mask it with placeholders (e.g., <EMAIL_ADDRESS>) before sending to the LLM. Input is scanned before the model sees it."
+                      />
+                    </EmptyState>
+                  ) : (
+                    <Stack gap="8px">{piiRules.map(renderRuleRow)}</Stack>
+                  )}
                 </Stack>
+              </Box>
+            )}
 
-                {loading ? null : cfRules.length === 0 ? (
-                  <EmptyState
-                    icon={Filter}
-                    message="No content filter rules configured. Add keyword or regex rules to block or mask prohibited content."
-                    showBorder
+            {/* ─── Content Filter tab ────────────────────────────────────── */}
+            {activeTab === "content_filter" && (
+              <Box sx={cardSx}>
+                <Stack gap="12px">
+                  <Stack
+                    direction="row"
+                    justifyContent="space-between"
+                    alignItems="flex-start"
+                    gap="16px"
                   >
-                    <EmptyStateTip
-                      icon={ScanLine}
-                      title="Keyword and regex matching"
-                      description="Block specific words (exact match with word boundaries) or define custom regex patterns to catch formats like internal project codes, employee IDs, or confidential terms."
-                    />
-                    <EmptyStateTip
-                      icon={FileWarning}
-                      title="Runs on every request, zero latency"
-                      description="Content filters execute in-process with no external API calls. Rules are evaluated before the request reaches the LLM provider."
-                    />
-                  </EmptyState>
-                ) : (
-                  <Stack gap="8px">{cfRules.map(renderRuleRow)}</Stack>
-                )}
-              </Stack>
-            </Box>
-          )}
-        </Box>
+                    <Box flex={1} minWidth={0}>
+                      <Typography sx={sectionTitleSx}>Content filter</Typography>
+                      <Typography sx={{ fontSize: 13, color: palette.text.tertiary, mt: "4px" }}>
+                        Block or mask content matching specific keywords or regex patterns. Use
+                        keywords for exact terms and regex for format detection (e.g., project
+                        codes, internal URLs).
+                      </Typography>
+                    </Box>
+                    <Box sx={{ flexShrink: 0 }}>
+                      <CustomizableButton
+                        text="Add filter rule"
+                        icon={<CirclePlus size={14} strokeWidth={1.5} />}
+                        onClick={() => {
+                          setCfForm({ name: "", type: "keyword", pattern: "", action: "block" });
+                          setCfError("");
+                          setIsCfModalOpen(true);
+                        }}
+                      />
+                    </Box>
+                  </Stack>
+
+                  {cfRules.length === 0 ? (
+                    <EmptyState
+                      icon={Filter}
+                      message="No content filter rules configured. Add keyword or regex rules to block or mask prohibited content."
+                      showBorder
+                    >
+                      <EmptyStateTip
+                        icon={ScanLine}
+                        title="Keyword and regex matching"
+                        description="Block specific words (exact match with word boundaries) or define custom regex patterns to catch formats like internal project codes, employee IDs, or confidential terms."
+                      />
+                      <EmptyStateTip
+                        icon={FileWarning}
+                        title="Runs on every request, zero latency"
+                        description="Content filters execute in-process with no external API calls. Rules are evaluated before the request reaches the LLM provider."
+                      />
+                    </EmptyState>
+                  ) : (
+                    <Stack gap="8px">{cfRules.map(renderRuleRow)}</Stack>
+                  )}
+                </Stack>
+              </Box>
+            )}
+          </Box>
+        )}
+        {loading && <CustomizableSkeleton variant="rectangular" width="100%" height={400} />}
+        {loadError && (
+          <EmptyState icon={AlertTriangle} message={loadError}>
+            <CustomizableButton
+              variant="outlined"
+              text="Retry"
+              icon={<RotateCcw size={16} />}
+              onClick={loadRules}
+            />
+          </EmptyState>
+        )}
       </TabContext>
 
       {/* ─── Add PII Rule Modal ─────────────────────────────────────────── */}

--- a/Clients/src/presentation/pages/AIGateway/Logs/index.tsx
+++ b/Clients/src/presentation/pages/AIGateway/Logs/index.tsx
@@ -20,6 +20,8 @@ import {
   RefreshCw,
   ChevronsUpDown,
   KeyRound,
+  AlertTriangle,
+  RotateCcw,
 } from "lucide-react";
 import { Tooltip as MuiTooltip } from "@mui/material";
 import { CustomizableButton } from "../../../components/button/customizable-button";
@@ -35,6 +37,7 @@ import { apiServices } from "../../../../infrastructure/api/networkServices";
 import { getPaginationRowCount, setPaginationRowCount } from "../../../../application/utils/paginationStorage";
 import palette from "../../../themes/palette";
 import { sectionTitleSx, useCardSx, formatEntityType } from "../shared";
+import CustomizableSkeleton from "../../../components/Skeletons";
 
 const AUTO_REFRESH_INTERVAL_MS = 10_000;
 const SEARCH_DEBOUNCE_MS = 300;
@@ -166,16 +169,18 @@ export default function LogsPage() {
     getPaginationRowCount("aiGatewayGuardrailLogs", GR_DEFAULT_PAGE_SIZE)
   );
   const [grLoading, setGrLoading] = useState(false);
+  const [grError, setGrError] = useState<string | null>(null);
 
   const loadGuardrailLogs = useCallback(async () => {
     setGrLoading(true);
+    setGrError(null);
     try {
       const res = await apiServices.get<Record<string, any>>(`/ai-gateway/guardrails/logs?limit=${grRowsPerPage}&offset=${grPage * grRowsPerPage}`);
       const data = res?.data || {};
       setGrLogs(data.logs || data?.data?.logs || []);
       setGrTotal(data.total || data.logs?.length || 0);
     } catch {
-      // Silently handle
+      setGrError("Failed to load guardrail logs. Please try again.");
     } finally {
       setGrLoading(false);
     }
@@ -189,6 +194,7 @@ export default function LogsPage() {
   const [total, setTotal] = useState(0);
   const [expandedId, setExpandedId] = useState<number | null>(null);
   const [loading, setLoading] = useState(true);
+  const [logsError, setLogsError] = useState<string | null>(null);
   const [page, setPage] = useState(0);
   const [rowsPerPage, setRowsPerPage] = useState(() =>
     getPaginationRowCount("aiGatewayLogs", 25)
@@ -229,6 +235,7 @@ export default function LogsPage() {
   const loadLogs = useCallback(
     async (p: number, rpp: number) => {
       setLoading(true);
+      setLogsError(null);
       try {
         const qs = buildQuery(p, rpp);
         const res = await apiServices.get<Record<string, any>>(`/ai-gateway/spend/logs?${qs}`);
@@ -236,7 +243,7 @@ export default function LogsPage() {
         setLogs(data.rows || []);
         setTotal(data.total || 0);
       } catch {
-        // Silently handle
+        setLogsError("Failed to load request logs. Please try again.");
       } finally {
         setLoading(false);
       }
@@ -311,8 +318,9 @@ export default function LogsPage() {
             </Typography>
           </Stack>
           <CustomizableButton
-            text={(activeLogTab === "requests" ? loading : grLoading) ? "Loading..." : "Refresh"}
+            text="Refresh"
             icon={<RefreshCw size={14} strokeWidth={1.5} />}
+            loading={activeLogTab === "requests" ? loading : grLoading}
             onClick={() => activeLogTab === "requests" ? loadLogs(page, rowsPerPage) : loadGuardrailLogs()}
           />
         </Stack>
@@ -369,7 +377,18 @@ export default function LogsPage() {
         </Stack>
       </Box>
 
-      {!loading && logs.length === 0 && total === 0 && (
+      {logsError ? (
+        <EmptyState icon={AlertTriangle} message={logsError}>
+          <CustomizableButton
+            variant="outlined"
+            text="Retry"
+            icon={<RotateCcw size={16} />}
+            onClick={() => loadLogs(page, rowsPerPage)}
+          />
+        </EmptyState>
+      ) : loading && logs.length === 0 && total === 0 ? (
+        <CustomizableSkeleton variant="rectangular" width="100%" height={400} />
+      ) : !loading && logs.length === 0 && total === 0 ? (
         <EmptyState
           icon={FileText}
           message="No request logs yet. Send requests through the gateway to see detailed logs here."
@@ -381,7 +400,7 @@ export default function LogsPage() {
             description="Each log entry shows the complete prompt sent to the LLM, the model's response, cost, tokens, latency, and any metadata tags attached to the request."
           />
         </EmptyState>
-      )}
+      ) : null}
 
       {hasLogs && (
         <Box sx={cardSx}>
@@ -726,9 +745,22 @@ export default function LogsPage() {
               </Typography>
 
               {grLoading ? (
-                <Typography sx={{ fontSize: 13, color: palette.text.tertiary, py: "16px" }}>Loading...</Typography>
+                <CustomizableSkeleton variant="rectangular" width="100%" height={200} />
+              ) : grError ? (
+                <EmptyState icon={AlertTriangle} message={grError}>
+                  <CustomizableButton
+                    variant="outlined"
+                    text="Retry"
+                    icon={<RotateCcw size={16} />}
+                    onClick={loadGuardrailLogs}
+                  />
+                </EmptyState>
               ) : grLogs.length === 0 ? (
-                <Typography sx={{ fontSize: 13, color: palette.text.tertiary, py: "16px" }}>No guardrail detections in this period.</Typography>
+                <EmptyState
+                  icon={FileText}
+                  message="No guardrail detections in this period."
+                  showBorder={false}
+                />
               ) : (
                 <Stack>
                   {/* Header */}

--- a/Clients/src/presentation/pages/AIGateway/MCPAgentKeys/index.tsx
+++ b/Clients/src/presentation/pages/AIGateway/MCPAgentKeys/index.tsx
@@ -1,6 +1,17 @@
 import { useState, useEffect, useCallback, useRef } from "react";
 import { Box, Typography, Stack, IconButton } from "@mui/material";
-import { CirclePlus, KeyRound, Trash2, Ban, Copy, Check, Shield, Wrench } from "lucide-react";
+import {
+  CirclePlus,
+  KeyRound,
+  Trash2,
+  Ban,
+  Copy,
+  Check,
+  Shield,
+  Wrench,
+  AlertTriangle,
+  RotateCcw,
+} from "lucide-react";
 import { EmptyState } from "../../../components/EmptyState";
 import EmptyStateTip from "../../../components/EmptyState/EmptyStateTip";
 import { CustomizableButton } from "../../../components/button/customizable-button";
@@ -21,6 +32,7 @@ import {
 } from "../shared";
 import MCPTable from "../MCPTable";
 import { displayFormattedDate } from "../../../tools/isoDateToString";
+import CustomizableSkeleton from "../../../components/Skeletons";
 import dayjs from "dayjs";
 
 interface CreateAgentKeyPayload {
@@ -50,6 +62,7 @@ interface AgentKey {
 export default function MCPAgentKeysPage() {
   const [keys, setKeys] = useState<AgentKey[]>([]);
   const [loading, setLoading] = useState(true);
+  const [loadError, setLoadError] = useState<string | null>(null);
 
   // Create modal
   const [isCreateOpen, setIsCreateOpen] = useState(false);
@@ -81,11 +94,13 @@ export default function MCPAgentKeysPage() {
   }, []);
 
   const loadData = useCallback(async () => {
+    setLoading(true);
+    setLoadError(null);
     try {
       const res = await apiServices.get<Record<string, any>>("/ai-gateway/mcp/agent-keys");
       setKeys(res?.data?.data || []);
     } catch {
-      // Silently handle
+      setLoadError("Failed to load agent keys. Please try again.");
     } finally {
       setLoading(false);
     }
@@ -203,26 +218,39 @@ export default function MCPAgentKeysPage() {
 
   const content = (
     <>
-      {!loading && keys.length === 0 && (
-        <EmptyState
-          icon={KeyRound}
-          message="Issue scoped API keys for AI agents to authenticate with MCP servers through the gateway."
-          showBorder
-        >
-          <EmptyStateTip
-            icon={Shield}
-            title="Tool-level access control"
-            description="Each agent key can restrict which MCP tools the agent is allowed or blocked from calling. Combine with rate limits for fine-grained governance."
-          />
-          <EmptyStateTip
-            icon={Wrench}
-            title="Per-key rate limits and expiry"
-            description="Set requests-per-minute limits and expiration dates on each key. When an agent key is revoked, all requests using it are rejected immediately."
+      {loading ? (
+        <CustomizableSkeleton variant="rectangular" width="100%" height={400} />
+      ) : loadError ? (
+        <EmptyState icon={AlertTriangle} message={loadError}>
+          <CustomizableButton
+            variant="outlined"
+            text="Retry"
+            icon={<RotateCcw size={16} />}
+            onClick={loadData}
           />
         </EmptyState>
+      ) : (
+        keys.length === 0 && (
+          <EmptyState
+            icon={KeyRound}
+            message="Issue scoped API keys for AI agents to authenticate with MCP servers through the gateway."
+            showBorder
+          >
+            <EmptyStateTip
+              icon={Shield}
+              title="Tool-level access control"
+              description="Each agent key can restrict which MCP tools the agent is allowed or blocked from calling. Combine with rate limits for fine-grained governance."
+            />
+            <EmptyStateTip
+              icon={Wrench}
+              title="Per-key rate limits and expiry"
+              description="Set requests-per-minute limits and expiration dates on each key. When an agent key is revoked, all requests using it are rejected immediately."
+            />
+          </EmptyState>
+        )
       )}
 
-      {!loading && keys.length > 0 && (
+      {keys.length > 0 && (
         <Box sx={{ px: 3, pb: 3 }}>
           <MCPTable
             id="mcp-agent-keys-table"

--- a/Clients/src/presentation/pages/AIGateway/MCPApprovals/index.tsx
+++ b/Clients/src/presentation/pages/AIGateway/MCPApprovals/index.tsx
@@ -1,7 +1,7 @@
 import { useState, useEffect, useCallback } from "react";
 import { Box, Typography, Stack } from "@mui/material";
 import TabContext from "@mui/lab/TabContext";
-import { CheckCircle, XCircle, ShieldCheck } from "lucide-react";
+import { CheckCircle, XCircle, ShieldCheck, AlertTriangle, RotateCcw } from "lucide-react";
 import TabBar from "../../../components/TabBar";
 import Chip from "../../../components/Chip";
 import Field from "../../../components/Inputs/Field";
@@ -15,6 +15,7 @@ import { sectionTitleSx, useCardSx, MCP_STATUS_COLORS, MCP_STATUS_FALLBACK } fro
 import MCPTable from "../MCPTable";
 import { displayFormattedDate } from "../../../tools/isoDateToString";
 import palette from "../../../themes/palette";
+import CustomizableSkeleton from "../../../components/Skeletons";
 
 interface Approval {
   id: number;
@@ -40,6 +41,7 @@ export default function MCPApprovalsPage() {
   const [pending, setPending] = useState<Approval[]>([]);
   const [history, setHistory] = useState<Approval[]>([]);
   const [loading, setLoading] = useState(true);
+  const [loadError, setLoadError] = useState<string | null>(null);
 
   // Decision modal state
   const [decisionTarget, setDecisionTarget] = useState<{
@@ -50,24 +52,30 @@ export default function MCPApprovalsPage() {
   const [reason, setReason] = useState("");
 
   const loadPending = useCallback(async () => {
+    setLoading(true);
+    setLoadError(null);
     try {
       const res = await apiServices.get<Record<string, any>>("/ai-gateway/mcp/approvals");
       setPending(res?.data?.data || []);
     } catch {
-      // silent
+      setLoadError("Failed to load pending approvals. Please try again.");
     } finally {
       setLoading(false);
     }
   }, []);
 
   const loadHistory = useCallback(async () => {
+    setLoading(true);
+    setLoadError(null);
     try {
       const res = await apiServices.get<Record<string, any>>(
         "/ai-gateway/mcp/approvals/history?limit=50",
       );
       setHistory(res?.data?.data || []);
     } catch {
-      // silent
+      setLoadError("Failed to load approval history. Please try again.");
+    } finally {
+      setLoading(false);
     }
   }, []);
 
@@ -118,8 +126,7 @@ export default function MCPApprovalsPage() {
   };
 
   const isEmpty =
-    !loading &&
-    ((tab === "pending" && pending.length === 0) || (tab === "history" && history.length === 0));
+    (tab === "pending" && pending.length === 0) || (tab === "history" && history.length === 0);
 
   const items = tab === "pending" ? pending : history;
 
@@ -147,7 +154,18 @@ export default function MCPApprovalsPage() {
         </TabContext>
       </Box>
 
-      {isEmpty ? (
+      {loading ? (
+        <CustomizableSkeleton variant="rectangular" width="100%" height={400} />
+      ) : loadError ? (
+        <EmptyState icon={AlertTriangle} message={loadError}>
+          <CustomizableButton
+            variant="outlined"
+            text="Retry"
+            icon={<RotateCcw size={16} />}
+            onClick={() => (tab === "pending" ? loadPending() : loadHistory())}
+          />
+        </EmptyState>
+      ) : isEmpty ? (
         <Box sx={{ px: 3, pt: 2 }}>
           <EmptyState
             icon={ShieldCheck}
@@ -171,7 +189,7 @@ export default function MCPApprovalsPage() {
             {tab === "pending" ? "Pending requests" : "Decision history"}
           </Typography>
 
-          {!loading && tab === "history" ? (
+          {tab === "history" ? (
             <Box sx={{ px: 3, pb: 3 }}>
               <MCPTable
                 id="mcp-approvals-history-table"
@@ -222,136 +240,130 @@ export default function MCPApprovalsPage() {
             </Box>
           ) : (
             <Stack spacing={1.5} sx={{ px: 3, pb: 3 }}>
-              {loading ? (
-                <Typography color="text.secondary" sx={{ py: 2 }}>
-                  Loading...
-                </Typography>
-              ) : (
-                items.map((item) => {
-                  const colors = MCP_STATUS_COLORS[item.status] || {
-                    ...MCP_STATUS_FALLBACK,
-                  };
-                  return (
-                    <Box key={item.id} sx={cardSx}>
-                      <Stack spacing={1.5}>
-                        {/* Top row: tool + status + actions */}
-                        <Stack direction="row" alignItems="center" justifyContent="space-between">
-                          <Stack direction="row" alignItems="center" spacing={2}>
-                            <Typography
-                              sx={{
-                                fontWeight: 600,
-                                fontSize: 14,
-                                fontFamily: "monospace",
-                              }}
-                            >
-                              {item.tool_name}
-                            </Typography>
-                            <Chip
-                              label={item.status}
-                              backgroundColor={colors.bg}
-                              textColor={colors.text}
-                            />
-                            {tab === "pending" && (
-                              <Typography
-                                variant="body2"
-                                sx={{ color: palette.text.disabled, fontSize: 12 }}
-                              >
-                                {getTimeRemaining(item.expires_at)}
-                              </Typography>
-                            )}
-                          </Stack>
-
-                          {tab === "pending" && (
-                            <Stack direction="row" spacing={1}>
-                              <CustomizableButton
-                                text="Approve"
-                                onClick={() =>
-                                  setDecisionTarget({
-                                    id: item.id,
-                                    action: "approve",
-                                    tool_name: item.tool_name,
-                                  })
-                                }
-                                variant="contained"
-                                startIcon={<CheckCircle size={14} />}
-                                sx={{
-                                  "backgroundColor": "#065F46",
-                                  "&:hover": { backgroundColor: "#047857" },
-                                }}
-                              />
-                              <CustomizableButton
-                                text="Deny"
-                                onClick={() =>
-                                  setDecisionTarget({
-                                    id: item.id,
-                                    action: "deny",
-                                    tool_name: item.tool_name,
-                                  })
-                                }
-                                variant="outlined"
-                                startIcon={<XCircle size={14} />}
-                                sx={{
-                                  "color": "#991B1B",
-                                  "borderColor": "#FCA5A5",
-                                  "&:hover": {
-                                    backgroundColor: "#FEF2F2",
-                                    borderColor: "#991B1B",
-                                  },
-                                }}
-                              />
-                            </Stack>
-                          )}
-                        </Stack>
-
-                        {/* Details row */}
-                        <Stack direction="row" spacing={3}>
-                          <Typography variant="body2" color="text.secondary">
-                            Agent:{" "}
-                            <strong>
-                              {item.key_name || item.agent_key_name || `Key #${item.agent_key_id}`}
-                            </strong>
-                          </Typography>
-                          <Typography variant="body2" color="text.secondary">
-                            Requested: {displayFormattedDate(item.created_at)}
-                          </Typography>
-                          {item.decided_at && (
-                            <Typography variant="body2" color="text.secondary">
-                              Decided by: {item.decided_by_name || `User #${item.decided_by}`} at{" "}
-                              {displayFormattedDate(item.decided_at)}
-                            </Typography>
-                          )}
-                        </Stack>
-
-                        {/* Arguments preview */}
-                        {item.arguments && Object.keys(item.arguments).length > 0 && (
-                          <Box
+              {items.map((item) => {
+                const colors = MCP_STATUS_COLORS[item.status] || {
+                  ...MCP_STATUS_FALLBACK,
+                };
+                return (
+                  <Box key={item.id} sx={cardSx}>
+                    <Stack spacing={1.5}>
+                      {/* Top row: tool + status + actions */}
+                      <Stack direction="row" alignItems="center" justifyContent="space-between">
+                        <Stack direction="row" alignItems="center" spacing={2}>
+                          <Typography
                             sx={{
-                              backgroundColor: "#F9FAFB",
-                              borderRadius: 1,
-                              p: 1,
+                              fontWeight: 600,
+                              fontSize: 14,
                               fontFamily: "monospace",
-                              fontSize: 12,
-                              color: palette.text.secondary,
-                              overflow: "hidden",
-                              textOverflow: "ellipsis",
-                              whiteSpace: "nowrap",
                             }}
                           >
-                            {JSON.stringify(item.arguments).slice(0, 200)}
-                          </Box>
-                        )}
+                            {item.tool_name}
+                          </Typography>
+                          <Chip
+                            label={item.status}
+                            backgroundColor={colors.bg}
+                            textColor={colors.text}
+                          />
+                          {tab === "pending" && (
+                            <Typography
+                              variant="body2"
+                              sx={{ color: palette.text.disabled, fontSize: 12 }}
+                            >
+                              {getTimeRemaining(item.expires_at)}
+                            </Typography>
+                          )}
+                        </Stack>
 
-                        {/* Decision reason */}
-                        {item.decision_reason && (
+                        {tab === "pending" && (
+                          <Stack direction="row" spacing={1}>
+                            <CustomizableButton
+                              text="Approve"
+                              onClick={() =>
+                                setDecisionTarget({
+                                  id: item.id,
+                                  action: "approve",
+                                  tool_name: item.tool_name,
+                                })
+                              }
+                              variant="contained"
+                              startIcon={<CheckCircle size={14} />}
+                              sx={{
+                                "backgroundColor": "#065F46",
+                                "&:hover": { backgroundColor: "#047857" },
+                              }}
+                            />
+                            <CustomizableButton
+                              text="Deny"
+                              onClick={() =>
+                                setDecisionTarget({
+                                  id: item.id,
+                                  action: "deny",
+                                  tool_name: item.tool_name,
+                                })
+                              }
+                              variant="outlined"
+                              startIcon={<XCircle size={14} />}
+                              sx={{
+                                "color": "#991B1B",
+                                "borderColor": "#FCA5A5",
+                                "&:hover": {
+                                  backgroundColor: "#FEF2F2",
+                                  borderColor: "#991B1B",
+                                },
+                              }}
+                            />
+                          </Stack>
+                        )}
+                      </Stack>
+
+                      {/* Details row */}
+                      <Stack direction="row" spacing={3}>
+                        <Typography variant="body2" color="text.secondary">
+                          Agent:{" "}
+                          <strong>
+                            {item.key_name || item.agent_key_name || `Key #${item.agent_key_id}`}
+                          </strong>
+                        </Typography>
+                        <Typography variant="body2" color="text.secondary">
+                          Requested: {displayFormattedDate(item.created_at)}
+                        </Typography>
+                        {item.decided_at && (
                           <Typography variant="body2" color="text.secondary">
-                            Reason: {item.decision_reason}
+                            Decided by: {item.decided_by_name || `User #${item.decided_by}`} at{" "}
+                            {displayFormattedDate(item.decided_at)}
                           </Typography>
                         )}
                       </Stack>
-                    </Box>
-                  );
-                })
-              )}
+
+                      {/* Arguments preview */}
+                      {item.arguments && Object.keys(item.arguments).length > 0 && (
+                        <Box
+                          sx={{
+                            backgroundColor: "#F9FAFB",
+                            borderRadius: 1,
+                            p: 1,
+                            fontFamily: "monospace",
+                            fontSize: 12,
+                            color: palette.text.secondary,
+                            overflow: "hidden",
+                            textOverflow: "ellipsis",
+                            whiteSpace: "nowrap",
+                          }}
+                        >
+                          {JSON.stringify(item.arguments).slice(0, 200)}
+                        </Box>
+                      )}
+
+                      {/* Decision reason */}
+                      {item.decision_reason && (
+                        <Typography variant="body2" color="text.secondary">
+                          Reason: {item.decision_reason}
+                        </Typography>
+                      )}
+                    </Stack>
+                  </Box>
+                );
+              })}
             </Stack>
           )}
         </>

--- a/Clients/src/presentation/pages/AIGateway/MCPAuditLog/index.tsx
+++ b/Clients/src/presentation/pages/AIGateway/MCPAuditLog/index.tsx
@@ -1,6 +1,15 @@
 import { useState, useEffect, useCallback } from "react";
 import { Box, Typography, Stack } from "@mui/material";
-import { Activity, AlertTriangle, Clock, Wrench, BarChart3, Info } from "lucide-react";
+import {
+  Activity,
+  AlertTriangle,
+  Clock,
+  Wrench,
+  BarChart3,
+  Info,
+  RotateCcw,
+  SearchX,
+} from "lucide-react";
 import { ResponsiveContainer, BarChart, Bar, XAxis, YAxis, CartesianGrid, Tooltip } from "recharts";
 import { chartTooltipStyle } from "../../../components/Charts/chartEnhancements";
 import Select from "../../../components/Inputs/Select";
@@ -15,6 +24,7 @@ import { Tooltip as MuiTooltip } from "@mui/material";
 import { apiServices } from "../../../../infrastructure/api/networkServices";
 import palette from "../../../themes/palette";
 import { sectionTitleSx, useCardSx, MCP_STATUS_COLORS, MCP_STATUS_FALLBACK } from "../shared";
+import CustomizableSkeleton from "../../../components/Skeletons";
 import MCPTable from "../MCPTable";
 import MCPInvocationDrawer from "../MCPInvocationDrawer";
 import { displayFormattedDate } from "../../../tools/isoDateToString";
@@ -65,6 +75,7 @@ export default function MCPAuditLogPage() {
     { tool_name: string; count: number; avg_latency_ms: number }[]
   >([]);
   const [loading, setLoading] = useState(true);
+  const [loadError, setLoadError] = useState<string | null>(null);
   const [days, setDays] = useState("7");
   const [page, setPage] = useState(1);
   const [total, setTotal] = useState(0);
@@ -73,6 +84,7 @@ export default function MCPAuditLogPage() {
   const [drawerLogId, setDrawerLogId] = useState<number | null>(null);
 
   const loadStats = useCallback(async () => {
+    setLoadError(null);
     try {
       const [statsRes, toolRes] = await Promise.all([
         apiServices.get<Record<string, any>>(`/ai-gateway/mcp/audit/stats?days=${days}`),
@@ -82,12 +94,13 @@ export default function MCPAuditLogPage() {
       const allTools = toolRes?.data?.data || [];
       setToolStats(allTools.sort((a: any, b: any) => b.count - a.count).slice(0, 10));
     } catch {
-      // silent
+      setLoadError("Failed to load audit activity. Please try again.");
     }
   }, [days]);
 
   const loadLogs = useCallback(
     async (pageNum: number) => {
+      setLoadError(null);
       try {
         const newOffset = (pageNum - 1) * PAGE_SIZE;
         let url = `/ai-gateway/mcp/audit/logs?limit=${PAGE_SIZE}&offset=${newOffset}`;
@@ -100,7 +113,7 @@ export default function MCPAuditLogPage() {
         setLogs(data);
         setTotal(totalCount);
       } catch {
-        // silent
+        setLoadError("Failed to load audit logs. Please try again.");
       } finally {
         setLoading(false);
       }
@@ -143,7 +156,22 @@ export default function MCPAuditLogPage() {
         </Box>
       }
     >
-      {isFirstTime ? (
+      {loading ? (
+        <CustomizableSkeleton variant="rectangular" width="100%" height={400} />
+      ) : loadError ? (
+        <EmptyState icon={AlertTriangle} message={loadError}>
+          <CustomizableButton
+            variant="outlined"
+            text="Retry"
+            icon={<RotateCcw size={16} />}
+            onClick={() => {
+              loadStats();
+              setPage(1);
+              loadLogs(1);
+            }}
+          />
+        </EmptyState>
+      ) : isFirstTime ? (
         <Box sx={{ px: 3, pt: 4 }}>
           <EmptyState icon={Activity} message="No audit logs yet" showBorder>
             <EmptyStateTip
@@ -299,14 +327,12 @@ export default function MCPAuditLogPage() {
           <Typography sx={{ ...sectionTitleSx, px: 3, pt: 2, pb: 1 }}>Recent tool calls</Typography>
 
           <Stack spacing={1.5} sx={{ px: 3, pb: 3 }}>
-            {loading ? (
-              <Typography color="text.secondary" sx={{ py: 2 }}>
-                Loading...
-              </Typography>
-            ) : noFilterResults ? (
-              <Typography color="text.secondary" sx={{ py: 3, textAlign: "center" }}>
-                No results matching the current filters.
-              </Typography>
+            {noFilterResults ? (
+              <EmptyState
+                icon={SearchX}
+                message="No results matching the current filters."
+                showBorder={false}
+              />
             ) : (
               <>
                 <MCPTable

--- a/Clients/src/presentation/pages/AIGateway/MCPGuardrails/index.tsx
+++ b/Clients/src/presentation/pages/AIGateway/MCPGuardrails/index.tsx
@@ -1,6 +1,16 @@
 import { useState, useEffect, useCallback, useMemo } from "react";
 import { Box, Typography, Stack, IconButton } from "@mui/material";
-import { CirclePlus, ShieldCheck, Trash2, Pencil, Shield, ScanLine, Lock } from "lucide-react";
+import {
+  CirclePlus,
+  ShieldCheck,
+  Trash2,
+  Pencil,
+  Shield,
+  ScanLine,
+  Lock,
+  AlertTriangle,
+  RotateCcw,
+} from "lucide-react";
 import Toggle from "../../../components/Inputs/Toggle";
 import { EmptyState } from "../../../components/EmptyState";
 import EmptyStateTip from "../../../components/EmptyState/EmptyStateTip";
@@ -12,8 +22,8 @@ import StandardModal from "../../../components/Modals/StandardModal";
 import { PageHeaderExtended } from "../../../components/Layout/PageHeaderExtended";
 import { apiServices } from "../../../../infrastructure/api/networkServices";
 import palette from "../../../themes/palette";
-import { useCardSx } from "../shared";
 import MCPTable from "../MCPTable";
+import CustomizableSkeleton from "../../../components/Skeletons";
 
 // ─── Types ───────────────────────────────────────────────────────────────────
 
@@ -80,9 +90,9 @@ const RULE_TYPE_LABELS: Record<string, string> = {
 // ─── Component ───────────────────────────────────────────────────────────────
 
 export default function MCPGuardrailsPage() {
-  const cardSx = useCardSx();
   const [rules, setRules] = useState<MCPGuardrail[]>([]);
   const [loading, setLoading] = useState(true);
+  const [loadError, setLoadError] = useState<string | null>(null);
 
   // Create / Edit modal
   const [isModalOpen, setIsModalOpen] = useState(false);
@@ -96,11 +106,13 @@ export default function MCPGuardrailsPage() {
   const [deleteSubmitting, setDeleteSubmitting] = useState(false);
 
   const loadData = useCallback(async () => {
+    setLoading(true);
+    setLoadError(null);
     try {
       const res = await apiServices.get<Record<string, any>>("/ai-gateway/mcp/guardrails");
       setRules(res?.data?.data || []);
     } catch {
-      // Silently handle
+      setLoadError("Failed to load guardrails. Please try again.");
     } finally {
       setLoading(false);
     }
@@ -269,11 +281,16 @@ export default function MCPGuardrailsPage() {
       }
     >
       {loading ? (
-        <Box sx={cardSx}>
-          <Typography sx={{ fontSize: 13, color: palette.text.tertiary }}>
-            Loading guardrails...
-          </Typography>
-        </Box>
+        <CustomizableSkeleton variant="rectangular" width="100%" height={400} />
+      ) : loadError ? (
+        <EmptyState icon={AlertTriangle} message={loadError}>
+          <CustomizableButton
+            variant="outlined"
+            text="Retry"
+            icon={<RotateCcw size={16} />}
+            onClick={loadData}
+          />
+        </EmptyState>
       ) : rules.length === 0 ? (
         <EmptyState
           icon={Shield}

--- a/Clients/src/presentation/pages/AIGateway/MCPInvocationDrawer.tsx
+++ b/Clients/src/presentation/pages/AIGateway/MCPInvocationDrawer.tsx
@@ -1,9 +1,12 @@
 import { Box, Drawer, Typography, Stack, IconButton, Divider } from "@mui/material";
-import { X } from "lucide-react";
+import { X, AlertTriangle, RotateCcw } from "lucide-react";
 import { useState, useEffect } from "react";
 import Chip from "../../components/Chip";
+import { CustomizableButton } from "../../components/button/customizable-button";
+import { EmptyState } from "../../components/EmptyState";
 import { apiServices } from "../../../infrastructure/api/networkServices";
 import palette from "../../themes/palette";
+import CustomizableSkeleton from "../../components/Skeletons";
 import {
   MCP_STATUS_COLORS,
   MCP_STATUS_FALLBACK,
@@ -42,16 +45,21 @@ interface AuditLogDetail {
 
 export default function MCPInvocationDrawer({ logId, open, onClose }: InvocationDrawerProps) {
   const [row, setRow] = useState<AuditLogDetail | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState(false);
   const [showRaw, setShowRaw] = useState(false);
 
   useEffect(() => {
     if (!open || !logId) return;
     setRow(null);
+    setError(false);
+    setLoading(true);
     setShowRaw(false);
     apiServices
       .get<Record<string, any>>(`/ai-gateway/mcp/audit/logs/${logId}`)
       .then((res) => setRow((res?.data?.data as AuditLogDetail) || null))
-      .catch(() => setRow(null));
+      .catch(() => setError(true))
+      .finally(() => setLoading(false));
   }, [open, logId]);
 
   const colors = row
@@ -82,9 +90,28 @@ export default function MCPInvocationDrawer({ logId, open, onClose }: Invocation
       onClose={onClose}
       sx={{ "& .MuiDrawer-paper": { width: 520, px: "16px", py: "20px" } }}
     >
-      {!row ? (
-        <Typography sx={{ fontSize: 13, color: palette.text.tertiary }}>Loading…</Typography>
-      ) : (
+      {loading ? (
+        <CustomizableSkeleton variant="rectangular" width="100%" height={200} />
+      ) : error ? (
+        <EmptyState icon={AlertTriangle} message="Failed to load invocation details.">
+          <CustomizableButton
+            variant="outlined"
+            text="Retry"
+            icon={<RotateCcw size={16} />}
+            onClick={() => {
+              if (logId) {
+                setError(false);
+                setLoading(true);
+                apiServices
+                  .get<Record<string, any>>(`/ai-gateway/mcp/audit/logs/${logId}`)
+                  .then((res) => setRow((res?.data?.data as AuditLogDetail) || null))
+                  .catch(() => setError(true))
+                  .finally(() => setLoading(false));
+              }
+            }}
+          />
+        </EmptyState>
+      ) : row ? (
         <Stack gap="20px">
           {/* Header */}
           <Stack direction="row" justifyContent="space-between" alignItems="flex-start" gap="8px">
@@ -200,6 +227,10 @@ export default function MCPInvocationDrawer({ logId, open, onClose }: Invocation
             )}
           </Box>
         </Stack>
+      ) : (
+        <Typography sx={{ fontSize: 13, color: palette.text.tertiary }}>
+          Select a log to view details.
+        </Typography>
       )}
     </Drawer>
   );

--- a/Clients/src/presentation/pages/AIGateway/MCPRuns/RunDetailDrawer.tsx
+++ b/Clients/src/presentation/pages/AIGateway/MCPRuns/RunDetailDrawer.tsx
@@ -64,7 +64,7 @@ export default function RunDetailDrawer({ runId, onClose }: RunDetailDrawerProps
       {loading ? (
         <CustomizableSkeleton variant="rectangular" width="100%" height={200} />
       ) : error ? (
-        <EmptyState icon={AlertTriangle} message="Couldn't load this run.">
+        <EmptyState icon={AlertTriangle} message="Could not load this run.">
           <CustomizableButton
             variant="outlined"
             text="Retry"

--- a/Clients/src/presentation/pages/AIGateway/MCPRuns/RunDetailDrawer.tsx
+++ b/Clients/src/presentation/pages/AIGateway/MCPRuns/RunDetailDrawer.tsx
@@ -1,8 +1,12 @@
-import { useEffect, useState } from "react";
-import { Drawer, Box, Stack, Typography, Divider, CircularProgress } from "@mui/material";
+import { useCallback, useEffect, useState } from "react";
+import { Drawer, Box, Stack, Typography, Divider } from "@mui/material";
+import { AlertTriangle, RotateCcw } from "lucide-react";
 import { apiServices } from "../../../../infrastructure/api/networkServices";
 import Chip from "../../../components/Chip";
+import { CustomizableButton } from "../../../components/button/customizable-button";
+import { EmptyState } from "../../../components/EmptyState";
 import palette from "../../../themes/palette";
+import CustomizableSkeleton from "../../../components/Skeletons";
 
 interface RunEntry {
   kind: "model" | "tool";
@@ -26,26 +30,28 @@ export default function RunDetailDrawer({ runId, onClose }: RunDetailDrawerProps
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState(false);
 
-  useEffect(() => {
+  const loadRun = useCallback(async () => {
     let cancelled = false;
-    (async () => {
-      setLoading(true);
-      setError(false);
-      try {
-        const res = await apiServices.get<Record<string, any>>(
-          `/ai-gateway/mcp/runs/${encodeURIComponent(runId)}`,
-        );
-        if (!cancelled) setEntries(res?.data?.data?.entries ?? []);
-      } catch {
-        if (!cancelled) setError(true);
-      } finally {
-        if (!cancelled) setLoading(false);
-      }
-    })();
+    setLoading(true);
+    setError(false);
+    try {
+      const res = await apiServices.get<Record<string, any>>(
+        `/ai-gateway/mcp/runs/${encodeURIComponent(runId)}`,
+      );
+      if (!cancelled) setEntries(res?.data?.data?.entries ?? []);
+    } catch {
+      if (!cancelled) setError(true);
+    } finally {
+      if (!cancelled) setLoading(false);
+    }
     return () => {
       cancelled = true;
     };
   }, [runId]);
+
+  useEffect(() => {
+    loadRun();
+  }, [loadRun]);
 
   const codeBlockSx = { whiteSpace: "pre-wrap" as const, fontSize: "12px", m: 0 };
 
@@ -55,13 +61,16 @@ export default function RunDetailDrawer({ runId, onClose }: RunDetailDrawerProps
         Run {runId.slice(0, 12)}…
       </Typography>
       {loading ? (
-        <Stack alignItems="center" sx={{ py: "32px" }}>
-          <CircularProgress size={24} />
-        </Stack>
+        <CustomizableSkeleton variant="rectangular" width="100%" height={200} />
       ) : error ? (
-        <Typography sx={{ fontSize: "13px", color: palette.text.tertiary }}>
-          Couldn't load this run.
-        </Typography>
+        <EmptyState icon={AlertTriangle} message="Couldn't load this run.">
+          <CustomizableButton
+            variant="outlined"
+            text="Retry"
+            icon={<RotateCcw size={16} />}
+            onClick={loadRun}
+          />
+        </EmptyState>
       ) : (
         <Stack sx={{ gap: "12px" }}>
           {entries.map((e, i) => (

--- a/Clients/src/presentation/pages/AIGateway/MCPRuns/index.tsx
+++ b/Clients/src/presentation/pages/AIGateway/MCPRuns/index.tsx
@@ -1,12 +1,14 @@
 import { useEffect, useState, useCallback } from "react";
 import { Box, Stack, Typography } from "@mui/material";
-import { Activity } from "lucide-react";
+import { Activity, AlertTriangle, RotateCcw } from "lucide-react";
 import { apiServices } from "../../../../infrastructure/api/networkServices";
 import { PageHeaderExtended } from "../../../components/Layout/PageHeaderExtended";
 import MCPTable, { MCPTableColumn } from "../MCPTable";
 import { EmptyState } from "../../../components/EmptyState";
 import RunDetailDrawer from "./RunDetailDrawer";
 import palette from "../../../themes/palette";
+import { CustomizableButton } from "../../../components/button/customizable-button";
+import CustomizableSkeleton from "../../../components/Skeletons";
 
 interface RunRow {
   agent_run_id: string;
@@ -34,15 +36,19 @@ const COLUMNS: MCPTableColumn[] = [
 export default function MCPRuns() {
   const [rows, setRows] = useState<RunRow[]>([]);
   const [loading, setLoading] = useState(true);
+  const [loadError, setLoadError] = useState<string | null>(null);
   const [selected, setSelected] = useState<string | null>(null);
 
   const load = useCallback(async () => {
     setLoading(true);
+    setLoadError(null);
     try {
       const res = await apiServices.get<Record<string, any>>(
         `/ai-gateway/mcp/runs?limit=${RUNS_LIMIT}&offset=0`,
       );
       setRows(res?.data?.data ?? []);
+    } catch {
+      setLoadError("Failed to load agent runs. Please try again.");
     } finally {
       setLoading(false);
     }
@@ -59,7 +65,18 @@ export default function MCPRuns() {
       helpArticlePath="ai-gateway/mcp-runs"
     >
       <Box sx={{ px: 3, pt: 2 }}>
-        {!loading && rows.length === 0 ? (
+        {loading ? (
+          <CustomizableSkeleton variant="rectangular" width="100%" height={400} />
+        ) : loadError ? (
+          <EmptyState icon={AlertTriangle} message={loadError}>
+            <CustomizableButton
+              variant="outlined"
+              text="Retry"
+              icon={<RotateCcw size={16} />}
+              onClick={load}
+            />
+          </EmptyState>
+        ) : rows.length === 0 ? (
           <EmptyState icon={Activity} message="No agent runs yet" showBorder>
             <Typography variant="body2">
               Runs appear when an agent sends the same run id (header <code>x-vw-agent-run-id</code>{" "}

--- a/Clients/src/presentation/pages/AIGateway/MCPServers/index.tsx
+++ b/Clients/src/presentation/pages/AIGateway/MCPServers/index.tsx
@@ -1,6 +1,15 @@
 import { useState, useEffect, useCallback } from "react";
 import { Box, Typography, Stack, IconButton, Tooltip } from "@mui/material";
-import { CirclePlus, Server, Trash2, Pencil, Search, Activity } from "lucide-react";
+import {
+  CirclePlus,
+  Server,
+  Trash2,
+  Pencil,
+  Search,
+  Activity,
+  AlertTriangle,
+  RotateCcw,
+} from "lucide-react";
 import Toggle from "../../../components/Inputs/Toggle";
 import { EmptyState } from "../../../components/EmptyState";
 import EmptyStateTip from "../../../components/EmptyState/EmptyStateTip";
@@ -12,8 +21,9 @@ import StandardModal from "../../../components/Modals/StandardModal";
 import { PageHeaderExtended } from "../../../components/Layout/PageHeaderExtended";
 import { apiServices } from "../../../../infrastructure/api/networkServices";
 import palette from "../../../themes/palette";
-import { useCardSx, slugify } from "../shared";
+import { slugify } from "../shared";
 import MCPTable from "../MCPTable";
+import CustomizableSkeleton from "../../../components/Skeletons";
 import { displayFormattedDate } from "../../../tools/isoDateToString";
 
 interface ServerForm {
@@ -59,9 +69,9 @@ interface MCPServer {
 }
 
 export default function MCPServersPage() {
-  const cardSx = useCardSx();
   const [servers, setServers] = useState<MCPServer[]>([]);
   const [loading, setLoading] = useState(true);
+  const [loadError, setLoadError] = useState<string | null>(null);
 
   const [isModalOpen, setIsModalOpen] = useState(false);
   const [editingId, setEditingId] = useState<number | null>(null);
@@ -72,11 +82,13 @@ export default function MCPServersPage() {
   const [form, setForm] = useState<ServerForm>({ ...EMPTY_FORM });
 
   const loadData = useCallback(async () => {
+    setLoading(true);
+    setLoadError(null);
     try {
       const res = await apiServices.get<Record<string, any>>("/ai-gateway/mcp/servers");
       setServers(res?.data?.servers || []);
     } catch {
-      // Silently handle
+      setLoadError("Failed to load MCP servers. Please try again.");
     } finally {
       setLoading(false);
     }
@@ -216,11 +228,16 @@ export default function MCPServersPage() {
       }
     >
       {loading ? (
-        <Box sx={cardSx}>
-          <Typography sx={{ fontSize: 13, color: palette.text.tertiary }}>
-            Loading servers...
-          </Typography>
-        </Box>
+        <CustomizableSkeleton variant="rectangular" width="100%" height={400} />
+      ) : loadError ? (
+        <EmptyState icon={AlertTriangle} message={loadError}>
+          <CustomizableButton
+            variant="outlined"
+            text="Retry"
+            icon={<RotateCcw size={16} />}
+            onClick={loadData}
+          />
+        </EmptyState>
       ) : servers.length === 0 ? (
         <EmptyState
           icon={Server}

--- a/Clients/src/presentation/pages/AIGateway/MCPToolCatalog/index.tsx
+++ b/Clients/src/presentation/pages/AIGateway/MCPToolCatalog/index.tsx
@@ -1,16 +1,26 @@
 import { useState, useEffect, useCallback, useMemo } from "react";
 import { Box, Typography, Stack, IconButton } from "@mui/material";
-import { Wrench, Pencil, ShieldAlert, ShieldCheck, AlertTriangle } from "lucide-react";
+import {
+  Wrench,
+  Pencil,
+  ShieldAlert,
+  ShieldCheck,
+  AlertTriangle,
+  RotateCcw,
+  SearchX,
+} from "lucide-react";
 import Toggle from "../../../components/Inputs/Toggle";
 import { EmptyState } from "../../../components/EmptyState";
 import EmptyStateTip from "../../../components/EmptyState/EmptyStateTip";
 import Select from "../../../components/Inputs/Select";
 import StandardModal from "../../../components/Modals/StandardModal";
 import { PageHeaderExtended } from "../../../components/Layout/PageHeaderExtended";
+import { CustomizableButton } from "../../../components/button/customizable-button";
 import { apiServices } from "../../../../infrastructure/api/networkServices";
 import palette from "../../../themes/palette";
 import { useCardSx } from "../shared";
 import MCPTable from "../MCPTable";
+import CustomizableSkeleton from "../../../components/Skeletons";
 
 // ─── Types ───────────────────────────────────────────────────────────────────
 
@@ -56,6 +66,7 @@ export default function MCPToolCatalogPage() {
   const [tools, setTools] = useState<MCPTool[]>([]);
   const [servers, setServers] = useState<any[]>([]);
   const [loading, setLoading] = useState(true);
+  const [loadError, setLoadError] = useState<string | null>(null);
 
   // Filters
   const [filterServer, setFilterServer] = useState("");
@@ -69,6 +80,8 @@ export default function MCPToolCatalogPage() {
   const [form, setForm] = useState<EditForm>({ ...EMPTY_FORM });
 
   const loadData = useCallback(async () => {
+    setLoading(true);
+    setLoadError(null);
     try {
       const [toolsRes, serversRes] = await Promise.all([
         apiServices.get<Record<string, any>>("/ai-gateway/mcp/tools"),
@@ -77,7 +90,7 @@ export default function MCPToolCatalogPage() {
       setTools(toolsRes?.data?.tools || []);
       setServers(serversRes?.data?.servers || []);
     } catch {
-      // Silently handle
+      setLoadError("Failed to load MCP tools. Please try again.");
     } finally {
       setLoading(false);
     }
@@ -294,11 +307,16 @@ export default function MCPToolCatalogPage() {
       )}
 
       {loading ? (
-        <Box sx={cardSx}>
-          <Typography sx={{ fontSize: 13, color: palette.text.tertiary }}>
-            Loading tools...
-          </Typography>
-        </Box>
+        <CustomizableSkeleton variant="rectangular" width="100%" height={400} />
+      ) : loadError ? (
+        <EmptyState icon={AlertTriangle} message={loadError}>
+          <CustomizableButton
+            variant="outlined"
+            text="Retry"
+            icon={<RotateCcw size={16} />}
+            onClick={loadData}
+          />
+        </EmptyState>
       ) : tools.length === 0 ? (
         <EmptyState
           icon={Wrench}
@@ -317,13 +335,11 @@ export default function MCPToolCatalogPage() {
           />
         </EmptyState>
       ) : filteredTools.length === 0 ? (
-        <Box sx={cardSx}>
-          <Typography
-            sx={{ fontSize: 13, color: palette.text.tertiary, textAlign: "center", py: "16px" }}
-          >
-            No tools match the selected filters.
-          </Typography>
-        </Box>
+        <EmptyState
+          icon={SearchX}
+          message="No tools match the selected filters."
+          showBorder={false}
+        />
       ) : (
         <Stack gap="16px">
           {Object.entries(groupedTools).map(([serverName, serverTools]) => (

--- a/Clients/src/presentation/pages/AIGateway/Models/index.tsx
+++ b/Clients/src/presentation/pages/AIGateway/Models/index.tsx
@@ -17,7 +17,9 @@ import {
   Medal,
   Trophy,
   Award,
+  RotateCcw,
 } from "lucide-react";
+import { Alert as MuiAlert } from "@mui/material";
 import Field from "../../../components/Inputs/Field";
 import Select from "../../../components/Inputs/Select";
 import TabBar from "../../../components/TabBar";
@@ -26,6 +28,8 @@ import { PageHeaderExtended } from "../../../components/Layout/PageHeaderExtende
 import { apiServices } from "../../../../infrastructure/api/networkServices";
 import palette from "../../../themes/palette";
 import { sectionTitleSx, useCardSx, ProviderIcon } from "../shared";
+import CustomizableSkeleton from "../../../components/Skeletons";
+import { EmptyState } from "../../../components/EmptyState";
 
 // ─── Types ───────────────────────────────────────────────────────────────────
 
@@ -118,6 +122,8 @@ export default function ModelsPage() {
   ]);
 
   const loadModels = useCallback(async () => {
+    setLoading(true);
+    setError("");
     try {
       const res = await apiServices.get<Record<string, any>>("/ai-gateway/models/catalog");
       setModels(res?.data?.data?.models || res?.data?.models || []);
@@ -421,17 +427,25 @@ export default function ModelsPage() {
 
                 {/* Rows */}
                 {error ? (
-                  <Typography sx={{ p: "16px", fontSize: 13, color: palette.status.error.text }}>
-                    {error}
-                  </Typography>
+                  <Stack alignItems="center" spacing={2} sx={{ py: 4 }}>
+                    <MuiAlert severity="error" sx={{ width: "100%", maxWidth: 600 }}>
+                      {error}
+                    </MuiAlert>
+                    <CustomizableButton
+                      variant="outlined"
+                      text="Retry"
+                      icon={<RotateCcw size={16} />}
+                      onClick={loadModels}
+                    />
+                  </Stack>
                 ) : loading ? (
-                  <Typography sx={{ p: "16px", fontSize: 13, color: palette.text.tertiary }}>
-                    Loading models...
-                  </Typography>
+                  <CustomizableSkeleton variant="rectangular" width="100%" height={400} />
                 ) : pageModels.length === 0 ? (
-                  <Typography sx={{ p: "16px", fontSize: 13, color: palette.text.tertiary }}>
-                    No models match your filters.
-                  </Typography>
+                  <EmptyState
+                    icon={Database}
+                    message="No models match your filters."
+                    showBorder={false}
+                  />
                 ) : (
                   <Stack gap="0px">
                     {pageModels.map((m) => (

--- a/Clients/src/presentation/pages/AIGateway/Prompts/PromptEditor.tsx
+++ b/Clients/src/presentation/pages/AIGateway/Prompts/PromptEditor.tsx
@@ -10,17 +10,21 @@ import {
   Slider,
 } from "@mui/material";
 import {
-  Plus,
-  Trash2,
-  History,
-  Send,
+  AlertTriangle,
+  BookOpen,
+  GitCompareArrows,
   GripVertical,
+  History,
+  Link2,
+  MessageSquare,
+  Plus,
+  RotateCcw,
+  Send,
   Settings2,
+  Tag,
+  Trash2,
   Upload,
   X,
-  GitCompareArrows,
-  Tag,
-  Link2,
 } from "lucide-react";
 import {
   DndContext,
@@ -45,6 +49,9 @@ import Field from "../../../components/Inputs/Field";
 import Select from "../../../components/Inputs/Select";
 import StandardModal from "../../../components/Modals/StandardModal";
 import { PageHeaderExtended } from "../../../components/Layout/PageHeaderExtended";
+import { EmptyState } from "../../../components/EmptyState";
+import EmptyStateTip from "../../../components/EmptyState/EmptyStateTip";
+import CustomizableSkeleton from "../../../components/Skeletons";
 import { apiServices } from "../../../../infrastructure/api/networkServices";
 import { displayFormattedDate } from "../../../tools/isoDateToString";
 import palette from "../../../themes/palette";
@@ -211,6 +218,7 @@ export default function PromptEditorPage() {
 
   const [prompt, setPrompt] = useState<PromptData | null>(null);
   const [loading, setLoading] = useState(true);
+  const [loadError, setLoadError] = useState<string | null>(null);
 
   const idCounter = useRef(1);
   const assignId = () => `msg-${idCounter.current++}`;
@@ -291,6 +299,8 @@ export default function PromptEditorPage() {
 
   const loadPrompt = useCallback(async () => {
     if (!id) return;
+    setLoading(true);
+    setLoadError(null);
     try {
       const [promptRes, versionsRes, endpointsRes, labelsRes] = await Promise.all([
         apiServices.get<Record<string, any>>(`/ai-gateway/prompts/${id}`),
@@ -305,7 +315,7 @@ export default function PromptEditorPage() {
       setLabels(labelsRes?.data?.labels || labelsRes?.data?.data || []);
       if (vers.length > 0) loadVersionIntoEditor(vers[0]);
     } catch {
-      /* silently handle */
+      setLoadError("Failed to load prompt. Please try again.");
     } finally {
       setLoading(false);
     }
@@ -531,15 +541,32 @@ export default function PromptEditorPage() {
     }
   };
 
-  if (loading) return null;
+  if (loading) {
+    return <CustomizableSkeleton variant="rectangular" width="100%" height={400} />;
+  }
+  if (loadError) {
+    return (
+      <Box sx={{ display: "flex", justifyContent: "center", py: 8 }}>
+        <EmptyState icon={AlertTriangle} message={loadError}>
+          <CustomizableButton
+            variant="outlined"
+            text="Retry"
+            icon={<RotateCcw size={16} />}
+            onClick={loadPrompt}
+          />
+        </EmptyState>
+      </Box>
+    );
+  }
   if (!prompt) {
     return (
-      <Box sx={{ p: "16px" }}>
-        <Typography>Prompt not found.</Typography>
-        <CustomizableButton
-          text="Back to prompts"
-          onClick={() => navigate("/ai-gateway/prompts")}
-        />
+      <Box sx={{ display: "flex", justifyContent: "center", py: 8 }}>
+        <EmptyState icon={BookOpen} message="Prompt not found.">
+          <CustomizableButton
+            text="Back to prompts"
+            onClick={() => navigate("/ai-gateway/prompts")}
+          />
+        </EmptyState>
       </Box>
     );
   }
@@ -835,20 +862,21 @@ export default function PromptEditorPage() {
               {/* Chat area */}
               <Box sx={{ flex: 1, overflow: "auto", p: "16px" }}>
                 {chatMessages.length === 0 && (
-                  <Box sx={{ textAlign: "center", py: "64px" }}>
-                    <Typography fontSize={13} color="text.secondary" fontWeight={500}>
-                      Send a message to test this prompt
-                    </Typography>
+                  <EmptyState
+                    icon={MessageSquare}
+                    message="Send a message to test this prompt"
+                    showBorder={false}
+                  >
                     <Typography
                       fontSize={12}
                       color="text.disabled"
-                      mt="8px"
-                      sx={{ maxWidth: 320, mx: "auto" }}
+                      textAlign="center"
+                      sx={{ maxWidth: 320 }}
                     >
                       Your message blocks above will be prepended as context. Type a user message
                       below and the model will respond using your prompt template.
                     </Typography>
-                  </Box>
+                  </EmptyState>
                 )}
                 <Stack spacing="8px">
                   {chatMessages.map((cm, idx) => (
@@ -1251,15 +1279,13 @@ export default function PromptEditorPage() {
               );
             })}
             {versions.length === 0 && (
-              <Box sx={{ textAlign: "center", py: "48px" }}>
-                <History size={32} strokeWidth={1} color={palette.border.dark} />
-                <Typography fontSize={13} color="text.secondary" mt="16px">
-                  No versions yet
-                </Typography>
-                <Typography fontSize={12} color="text.disabled" mt="4px">
-                  Click "Save draft" to create your first version.
-                </Typography>
-              </Box>
+              <EmptyState icon={History} message="No versions yet">
+                <EmptyStateTip
+                  icon={History}
+                  title="Create your first version"
+                  description='Click "Save draft" to create your first version.'
+                />
+              </EmptyState>
             )}
           </Stack>
         </Box>

--- a/Clients/src/presentation/pages/AIGateway/Prompts/PromptEditor.tsx
+++ b/Clients/src/presentation/pages/AIGateway/Prompts/PromptEditor.tsx
@@ -1283,7 +1283,7 @@ export default function PromptEditorPage() {
                 <EmptyStateTip
                   icon={History}
                   title="Create your first version"
-                  description='Click "Save draft" to create your first version.'
+                  description="Click Save draft to create your first version."
                 />
               </EmptyState>
             )}

--- a/Clients/src/presentation/pages/AIGateway/Prompts/VersionDiffModal.tsx
+++ b/Clients/src/presentation/pages/AIGateway/Prompts/VersionDiffModal.tsx
@@ -1,6 +1,8 @@
 import { useMemo } from "react";
 import { Box, Typography, Stack } from "@mui/material";
+import { GitCompareArrows } from "lucide-react";
 import StandardModal from "../../../components/Modals/StandardModal";
+import { EmptyState } from "../../../components/EmptyState";
 import palette from "../../../themes/palette";
 
 interface Message {
@@ -197,11 +199,7 @@ export default function VersionDiffModal({
       </Stack>
 
       {rows.length === 0 && (
-        <Box sx={{ textAlign: "center", py: "32px" }}>
-          <Typography fontSize={13} color="text.secondary">
-            No differences found
-          </Typography>
-        </Box>
+        <EmptyState icon={GitCompareArrows} message="No differences found" showBorder={false} />
       )}
 
       <ConfigDiff a={versionA} b={versionB} />

--- a/Clients/src/presentation/pages/AIGateway/Prompts/index.tsx
+++ b/Clients/src/presentation/pages/AIGateway/Prompts/index.tsx
@@ -13,7 +13,15 @@ import {
   TableRow,
   TablePagination,
 } from "@mui/material";
-import { CirclePlus, Trash2, BookOpen, FileText, Link } from "lucide-react";
+import {
+  CirclePlus,
+  Trash2,
+  BookOpen,
+  FileText,
+  Link,
+  AlertTriangle,
+  RotateCcw,
+} from "lucide-react";
 import { EmptyState } from "../../../components/EmptyState";
 import EmptyStateTip from "../../../components/EmptyState/EmptyStateTip";
 import { CustomizableButton } from "../../../components/button/customizable-button";
@@ -30,6 +38,7 @@ import {
 } from "../../../../application/utils/paginationStorage";
 import { slugify, ProviderIcon, getLabelVariant } from "../shared";
 import singleTheme from "../../../themes/v1SingleTheme";
+import CustomizableSkeleton from "../../../components/Skeletons";
 
 interface Prompt {
   id: number;
@@ -50,6 +59,7 @@ export default function PromptsPage() {
   const navigate = useNavigate();
   const [prompts, setPrompts] = useState<Prompt[]>([]);
   const [loading, setLoading] = useState(true);
+  const [loadError, setLoadError] = useState<string | null>(null);
   const [page, setPage] = useState(0);
   const [rowsPerPage, setRowsPerPage] = useState(() =>
     getPaginationRowCount("aiGatewayPrompts", 10),
@@ -63,6 +73,8 @@ export default function PromptsPage() {
   const [form, setForm] = useState({ name: "", slug: "", description: "" });
 
   const loadData = useCallback(async () => {
+    setLoading(true);
+    setLoadError(null);
     try {
       const res = await apiServices.get<Record<string, any>>("/ai-gateway/prompts");
       const promptList: Prompt[] = res?.data?.prompts || res?.data?.data || [];
@@ -79,7 +91,7 @@ export default function PromptsPage() {
       }
       setPrompts(promptList);
     } catch {
-      /* silently handle */
+      setLoadError("Failed to load prompts. Please try again.");
     } finally {
       setLoading(false);
     }
@@ -206,7 +218,29 @@ export default function PromptsPage() {
         helpArticlePath="ai-gateway/prompts"
         actionButton={actionButton}
       >
-        <Box />
+        <CustomizableSkeleton variant="rectangular" width="100%" height={400} />
+      </PageHeaderExtended>
+    );
+  }
+
+  if (loadError) {
+    return (
+      <PageHeaderExtended
+        title="Prompts"
+        description="Create versioned prompt templates with variables and bind them to endpoints."
+        tipBoxEntity="ai-gateway-prompts"
+        helpArticlePath="ai-gateway/prompts"
+        actionButton={actionButton}
+      >
+        <EmptyState icon={AlertTriangle} message={loadError}>
+          <CustomizableButton
+            variant="outlined"
+            text="Retry"
+            icon={<RotateCcw size={16} />}
+            onClick={loadData}
+          />
+        </EmptyState>
+        {createModal}
       </PageHeaderExtended>
     );
   }

--- a/Clients/src/presentation/pages/AIGateway/Settings/index.tsx
+++ b/Clients/src/presentation/pages/AIGateway/Settings/index.tsx
@@ -16,6 +16,7 @@ import {
   Check,
   X,
   Play,
+  RotateCcw,
 } from "lucide-react";
 import { EmptyState } from "../../../components/EmptyState";
 import EmptyStateTip from "../../../components/EmptyState/EmptyStateTip";
@@ -29,6 +30,7 @@ import { PageHeaderExtended } from "../../../components/Layout/PageHeaderExtende
 import { apiServices } from "../../../../infrastructure/api/networkServices";
 import palette from "../../../themes/palette";
 import { sectionTitleSx, useCardSx, ProviderIcon, TOP_PROVIDERS } from "../shared";
+import CustomizableSkeleton from "../../../components/Skeletons";
 import VirtualKeysTab from "../VirtualKeys/index";
 import { validateApiKeyFormat } from "../../../../application/utils/apiKeyValidation";
 
@@ -131,6 +133,7 @@ export default function AIGatewaySettingsPage() {
   const [apiKeys, setApiKeys] = useState<any[]>([]);
   const [budget, setBudget] = useState<any>(null);
   const [loading, setLoading] = useState(true);
+  const [loadError, setLoadError] = useState<string | null>(null);
   const [providerItems, setProviderItems] = useState(TOP_PROVIDERS);
 
   // API Key modal state
@@ -194,8 +197,12 @@ export default function AIGatewaySettingsPage() {
   const [dismissModalOpen, setDismissModalOpen] = useState(false);
   const [dismissReason, setDismissReason] = useState("");
   const [dismissSubmitting, setDismissSubmitting] = useState(false);
+  const [riskLoading, setRiskLoading] = useState(false);
+  const [riskError, setRiskError] = useState<string | null>(null);
 
   const loadData = useCallback(async () => {
+    setLoading(true);
+    setLoadError(null);
     try {
       const [keysRes, budgetRes, providersRes, gsRes] = await Promise.all([
         apiServices.get<Record<string, any>>("/ai-gateway/keys"),
@@ -240,13 +247,15 @@ export default function AIGatewaySettingsPage() {
         }
       }
     } catch {
-      // Silently handle
+      setLoadError("Failed to load AI Gateway settings. Please try again.");
     } finally {
       setLoading(false);
     }
   }, []);
 
   const loadRiskData = useCallback(async () => {
+    setRiskLoading(true);
+    setRiskError(null);
     try {
       const [settingsRes, suggestionsRes] = await Promise.all([
         apiServices.get<Record<string, any>>("/ai-gateway/risk-settings").catch(() => null),
@@ -260,7 +269,9 @@ export default function AIGatewaySettingsPage() {
         setSuggestions(suggestionsRes.data?.suggestions || suggestionsRes.data);
       }
     } catch {
-      // Silently handle
+      setRiskError("Failed to load risk suggestions. Please try again.");
+    } finally {
+      setRiskLoading(false);
     }
   }, []);
 
@@ -524,734 +535,767 @@ export default function AIGatewaySettingsPage() {
           onChange={(_, v) => navigate(`/ai-gateway/settings/${v}`, { replace: true })}
         />
 
-        <Box sx={{ mt: "16px" }}>
-          {/* ─── API Keys tab ─────────────────────────────────────────── */}
-          {activeTab === "api-keys" && (
-            <Box sx={cardSx}>
-              <Stack gap="12px">
-                <Stack direction="row" justifyContent="space-between" alignItems="flex-start">
-                  <Box>
-                    <Typography sx={sectionTitleSx}>API keys</Typography>
-                    <Typography sx={{ fontSize: 13, color: palette.text.tertiary, mt: "4px" }}>
-                      Provider API keys are encrypted at rest (AES-256-CBC) and only decrypted when
-                      proxying a request.
-                    </Typography>
-                  </Box>
-                  <CustomizableButton
-                    text="Add key"
-                    icon={<CirclePlus size={14} strokeWidth={1.5} />}
-                    onClick={() => {
-                      setKeyForm({ key_name: "", provider: "", api_key: "" });
-                      setKeyError("");
-                      setIsKeyModalOpen(true);
-                    }}
-                  />
-                </Stack>
-
-                {loading ? null : apiKeys.length === 0 ? (
-                  <EmptyState
-                    icon={Key}
-                    message="No API keys configured. Add a provider API key to start creating endpoints."
-                    showBorder
-                  >
-                    <EmptyStateTip
-                      icon={Lock}
-                      title="Keys are encrypted at rest"
-                      description="Your provider API keys are encrypted using AES-256-CBC before being stored. They are only decrypted when proxying a request and are never exposed in logs."
-                    />
-                    <EmptyStateTip
-                      icon={Router}
-                      title="Each endpoint references an API key"
-                      description="After adding a key, create endpoints in the Endpoints tab. Each endpoint uses one API key to authenticate with the LLM provider."
-                    />
-                  </EmptyState>
-                ) : (
-                  <Stack gap="8px">
-                    {apiKeys.map((key) => (
-                      <Stack
-                        key={key.id}
-                        direction="row"
-                        justifyContent="space-between"
-                        alignItems="center"
-                        sx={{
-                          p: "12px 16px",
-                          border: `1px solid ${palette.border.dark}`,
-                          borderRadius: "4px",
-                        }}
-                      >
-                        <Stack direction="row" alignItems="center" gap="10px">
-                          <ProviderIcon provider={key.provider} size={20} />
-                          <Box>
-                            <Typography sx={{ fontSize: 13, fontWeight: 500 }}>
-                              {key.key_name}
-                            </Typography>
-                            <Typography sx={{ fontSize: 12, color: palette.text.tertiary }}>
-                              {key.provider} &middot; {key.masked_key}
-                            </Typography>
-                          </Box>
-                        </Stack>
-                        <Stack direction="row" alignItems="center" gap="8px">
-                          <Typography
-                            sx={{
-                              fontSize: 12,
-                              color: key.is_active
-                                ? palette.status.success.text
-                                : palette.text.disabled,
-                              fontWeight: 500,
-                            }}
-                          >
-                            {key.is_active ? "Active" : "Inactive"}
-                          </Typography>
-                          <IconButton
-                            size="small"
-                            onClick={() => setKeyDeleteTarget(key)}
-                            sx={{ p: 0.5 }}
-                          >
-                            <Trash2 size={14} strokeWidth={1.5} color={palette.text.tertiary} />
-                          </IconButton>
-                        </Stack>
-                      </Stack>
-                    ))}
-                  </Stack>
-                )}
-              </Stack>
-            </Box>
-          )}
-
-          {/* ─── Budget tab ───────────────────────────────────────────── */}
-          {activeTab === "budget" && (
-            <Box sx={cardSx}>
-              <Stack gap="12px">
-                <Stack direction="row" justifyContent="space-between" alignItems="flex-start">
-                  <Box>
-                    <Typography sx={sectionTitleSx}>Budget</Typography>
-                    <Typography sx={{ fontSize: 13, color: palette.text.tertiary, mt: "4px" }}>
-                      Set a monthly spending limit. When hard limit is enabled, requests are
-                      rejected once exceeded.
-                    </Typography>
-                  </Box>
-                  <CustomizableButton
-                    text={budget ? "Edit budget" : "Set budget"}
-                    icon={<Pencil size={14} strokeWidth={1.5} />}
-                    onClick={openBudgetModal}
-                  />
-                </Stack>
-
-                {loading ? null : budget ? (
-                  <Stack gap="12px">
-                    <Stack direction="row" justifyContent="space-between">
-                      <Typography sx={{ fontSize: 13, color: palette.text.tertiary }}>
-                        Monthly limit
-                      </Typography>
-                      <Typography sx={{ fontSize: 13, fontWeight: 500 }}>
-                        ${Number(budget.monthly_limit_usd).toFixed(2)}
-                      </Typography>
-                    </Stack>
-                    <Stack direction="row" justifyContent="space-between">
-                      <Typography sx={{ fontSize: 13, color: palette.text.tertiary }}>
-                        Current spend
-                      </Typography>
-                      <Typography sx={{ fontSize: 13, fontWeight: 500 }}>
-                        ${Number(budget.current_spend_usd).toFixed(4)}
-                      </Typography>
-                    </Stack>
-                    {Number(budget.monthly_limit_usd) > 0 && (
-                      <Box
-                        sx={{
-                          height: 6,
-                          borderRadius: 3,
-                          backgroundColor: palette.border.light,
-                          overflow: "hidden",
-                        }}
-                      >
-                        <Box
-                          sx={{
-                            height: "100%",
-                            width: `${Math.min(100, (Number(budget.current_spend_usd) / Number(budget.monthly_limit_usd)) * 100)}%`,
-                            backgroundColor:
-                              (Number(budget.current_spend_usd) /
-                                Number(budget.monthly_limit_usd)) *
-                                100 >=
-                              budget.alert_threshold_pct
-                                ? palette.status.error.text
-                                : palette.brand.primary,
-                            borderRadius: 3,
-                            transition: "width 0.3s",
-                          }}
-                        />
-                      </Box>
-                    )}
-                    <Stack direction="row" justifyContent="space-between">
-                      <Typography sx={{ fontSize: 13, color: palette.text.tertiary }}>
-                        Alert threshold
-                      </Typography>
-                      <Typography sx={{ fontSize: 13, fontWeight: 500 }}>
-                        {budget.alert_threshold_pct}%
-                      </Typography>
-                    </Stack>
-                    <Stack direction="row" justifyContent="space-between">
-                      <Typography sx={{ fontSize: 13, color: palette.text.tertiary }}>
-                        Hard limit
-                      </Typography>
-                      <Typography sx={{ fontSize: 13, fontWeight: 500 }}>
-                        {budget.is_hard_limit ? "Yes (requests rejected)" : "No (alert only)"}
-                      </Typography>
-                    </Stack>
-                  </Stack>
-                ) : (
-                  <EmptyState
-                    icon={Wallet}
-                    message="No budget configured. All requests are allowed without cost limits."
-                    showBorder
-                  />
-                )}
-              </Stack>
-            </Box>
-          )}
-
-          {/* ─── Virtual keys tab ─────────────────────────────────────── */}
-          {activeTab === "virtual-keys" && <VirtualKeysTab embedded />}
-
-          {/* ─── Guardrail settings tab ───────────────────────────────── */}
-          {activeTab === "guardrails" && (
-            <Stack gap="16px">
-              {/* Save button */}
-              <Stack direction="row" justifyContent="flex-end">
-                <CustomizableButton
-                  text={gsSaving ? "Saving..." : "Save settings"}
-                  onClick={handleSaveGuardrailSettings}
-                  isDisabled={gsSaving}
-                />
-              </Stack>
-
-              {/* Error behavior card */}
-              <Box sx={cardSx}>
-                <Stack gap="8px">
-                  <Typography sx={sectionTitleSx}>Error behavior</Typography>
-                  <Typography sx={{ fontSize: 13, color: palette.text.tertiary }}>
-                    What happens when the guardrail scanner itself fails. "Fail-closed" blocks all
-                    requests for safety. "Fail-open" allows requests through.
-                  </Typography>
-                  <Stack direction="row" gap="16px" mt="8px">
-                    <Box flex={1}>
-                      <Select
-                        id="pii-on-error"
-                        label="PII scan on error"
-                        value={gsForm.pii_on_error}
-                        items={[
-                          { _id: "block", name: "Block request (fail-closed)" },
-                          { _id: "allow", name: "Allow request (fail-open)" },
-                        ]}
-                        onChange={(e) =>
-                          setGsForm((p) => ({ ...p, pii_on_error: e.target.value as string }))
-                        }
-                        getOptionValue={(item) => item._id}
-                      />
-                    </Box>
-                    <Box flex={1}>
-                      <Select
-                        id="cf-on-error"
-                        label="Content filter on error"
-                        value={gsForm.content_filter_on_error}
-                        items={[
-                          { _id: "allow", name: "Allow request (fail-open)" },
-                          { _id: "block", name: "Block request (fail-closed)" },
-                        ]}
-                        onChange={(e) =>
-                          setGsForm((p) => ({
-                            ...p,
-                            content_filter_on_error: e.target.value as string,
-                          }))
-                        }
-                        getOptionValue={(item) => item._id}
-                      />
-                    </Box>
-                  </Stack>
-                </Stack>
-              </Box>
-
-              {/* Replacement text card */}
-              <Box sx={cardSx}>
-                <Stack gap="8px">
-                  <Typography sx={sectionTitleSx}>Replacement text</Typography>
-                  <Typography sx={{ fontSize: 13, color: palette.text.tertiary }}>
-                    When a guardrail masks content, this text replaces the detected value. Use
-                    ENTITY_TYPE in the PII format to include the detected type (e.g.,
-                    &lt;EMAIL_ADDRESS&gt;).
-                  </Typography>
-                  <Stack direction="row" gap="16px" mt="8px">
-                    <Box flex={1}>
-                      <Field
-                        label="PII replacement format"
-                        placeholder="<ENTITY_TYPE>"
-                        value={gsForm.pii_replacement_format}
-                        onChange={(e) =>
-                          setGsForm((p) => ({ ...p, pii_replacement_format: e.target.value }))
-                        }
-                      />
-                    </Box>
-                    <Box flex={1}>
-                      <Field
-                        label="Content filter replacement"
-                        placeholder="[REDACTED]"
-                        value={gsForm.content_filter_replacement}
-                        onChange={(e) =>
-                          setGsForm((p) => ({ ...p, content_filter_replacement: e.target.value }))
-                        }
-                      />
-                    </Box>
-                  </Stack>
-                </Stack>
-              </Box>
-
-              {/* Audit log retention card */}
-              <Box sx={cardSx}>
-                <Stack gap="8px">
-                  <Typography sx={sectionTitleSx}>Audit log retention</Typography>
-                  <Typography sx={{ fontSize: 13, color: palette.text.tertiary }}>
-                    How long to keep guardrail detection logs. These logs record every blocked or
-                    masked request for compliance auditing (EU AI Act Art. 12).
-                  </Typography>
-                  <Box sx={{ maxWidth: 200, mt: "8px" }}>
-                    <Field
-                      label="Retention period (days)"
-                      placeholder="90"
-                      value={gsForm.log_retention_days}
-                      onChange={(e) =>
-                        setGsForm((p) => ({ ...p, log_retention_days: e.target.value }))
-                      }
-                    />
-                  </Box>
-                  <Box sx={{ mt: "8px" }}>
-                    <CustomizableButton
-                      text="Purge old logs"
-                      variant="outlined"
-                      onClick={async () => {
-                        try {
-                          await apiServices.post("/ai-gateway/guardrails/logs/purge");
-                        } catch {
-                          // Silently handle
-                        }
-                      }}
-                    />
-                  </Box>
-                </Stack>
-              </Box>
-
-              {/* Request body logging card */}
-              <Box sx={cardSx}>
-                <Stack gap="8px">
-                  <Typography sx={sectionTitleSx}>Request body logging</Typography>
-                  <Typography sx={{ fontSize: 13, color: palette.text.tertiary }}>
-                    When enabled, full request prompts and LLM responses are stored in the spend
-                    logs. Disabled by default for privacy. Bodies are truncated to 2,048 characters.
-                  </Typography>
-                  <Stack gap="12px" mt="8px">
-                    <Stack direction="row" justifyContent="space-between" alignItems="center">
-                      <Typography sx={{ fontSize: 13 }}>Log request body (prompts)</Typography>
-                      <Toggle
-                        checked={gsForm.log_request_body}
-                        onChange={() =>
-                          setGsForm((p) => ({ ...p, log_request_body: !p.log_request_body }))
-                        }
-                      />
-                    </Stack>
-                    <Stack direction="row" justifyContent="space-between" alignItems="center">
-                      <Typography sx={{ fontSize: 13 }}>Log response body (LLM output)</Typography>
-                      <Toggle
-                        checked={gsForm.log_response_body}
-                        onChange={() =>
-                          setGsForm((p) => ({ ...p, log_response_body: !p.log_response_body }))
-                        }
-                      />
-                    </Stack>
-                  </Stack>
-                </Stack>
-              </Box>
-
-              {/* Spend log cleanup card */}
-              <Box sx={cardSx}>
-                <Stack gap="8px">
-                  <Typography sx={sectionTitleSx}>Spend log cleanup</Typography>
-                  <Typography sx={{ fontSize: 13, color: palette.text.tertiary }}>
-                    Delete old spend log entries based on the retention period above.
-                  </Typography>
-                  <Box sx={{ mt: "8px" }}>
-                    <CustomizableButton
-                      text={spendPurgeResult || "Purge old spend logs"}
-                      variant="outlined"
-                      onClick={async () => {
-                        setSpendPurgeResult("Purging...");
-                        try {
-                          const res = await apiServices.post<Record<string, any>>(
-                            "/ai-gateway/spend/logs/purge",
-                          );
-                          const count = res?.data?.deleted ?? res?.data?.data?.deleted_count ?? 0;
-                          setSpendPurgeResult(
-                            count > 0 ? `Deleted ${count} logs` : "No old logs to purge",
-                          );
-                          if (count > 0) await loadData();
-                          setTimeout(() => setSpendPurgeResult(""), 3000);
-                        } catch {
-                          setSpendPurgeResult("Failed to purge");
-                          setTimeout(() => setSpendPurgeResult(""), 3000);
-                        }
-                      }}
-                    />
-                  </Box>
-                </Stack>
-              </Box>
-              {/* Response cache settings card */}
-              <Box sx={cardSx}>
-                <Stack gap="12px">
-                  <Typography sx={sectionTitleSx}>Response caching</Typography>
-                  <Typography sx={{ fontSize: 13, color: palette.text.tertiary }}>
-                    Cache identical LLM requests to reduce cost and latency. Enable caching globally
-                    here, then toggle it per-endpoint in the Endpoints tab.
-                  </Typography>
-
-                  <Stack direction="row" justifyContent="space-between" alignItems="center">
-                    <Typography sx={{ fontSize: 13 }}>Enable caching globally</Typography>
-                    <Toggle
-                      checked={cacheSettings.cache_global_enabled}
-                      onChange={() =>
-                        setCacheSettings((p) => ({
-                          ...p,
-                          cache_global_enabled: !p.cache_global_enabled,
-                        }))
-                      }
-                    />
-                  </Stack>
-
-                  <Stack direction="row" gap="16px">
-                    <Box sx={{ flex: 1 }}>
-                      <Field
-                        label="Default TTL (seconds)"
-                        placeholder="14400"
-                        value={cacheSettings.cache_default_ttl_seconds}
-                        onChange={(e) =>
-                          setCacheSettings((p) => ({
-                            ...p,
-                            cache_default_ttl_seconds: e.target.value,
-                          }))
-                        }
-                      />
-                    </Box>
-                    <Box sx={{ flex: 1 }}>
-                      <Field
-                        label="Max entries per org"
-                        placeholder="50000"
-                        value={cacheSettings.cache_max_entries_per_org}
-                        onChange={(e) =>
-                          setCacheSettings((p) => ({
-                            ...p,
-                            cache_max_entries_per_org: e.target.value,
-                          }))
-                        }
-                      />
-                    </Box>
-                  </Stack>
-
-                  <Stack direction="row" gap="8px" sx={{ mt: "8px" }}>
-                    <CustomizableButton
-                      text={cacheSaving ? "Saving..." : "Save cache settings"}
-                      variant="contained"
-                      onClick={handleSaveCacheSettings}
-                    />
-                    <CustomizableButton
-                      text={cachePurgeResult || "Purge expired entries"}
-                      variant="outlined"
-                      onClick={async () => {
-                        setCachePurgeResult("Purging...");
-                        try {
-                          const res =
-                            await apiServices.post<Record<string, any>>("/ai-gateway/cache/purge");
-                          const count = res?.data?.deleted ?? 0;
-                          setCachePurgeResult(
-                            count > 0 ? `Deleted ${count} entries` : "No expired entries",
-                          );
-                          setTimeout(() => setCachePurgeResult(""), 3000);
-                        } catch {
-                          setCachePurgeResult("Failed");
-                          setTimeout(() => setCachePurgeResult(""), 3000);
-                        }
-                      }}
-                    />
-                  </Stack>
-                </Stack>
-              </Box>
-            </Stack>
-          )}
-
-          {/* ─── Suggested risks tab ──────────────────────────────────── */}
-          {activeTab === "risks" && (
-            <Stack gap="16px">
-              {/* Detection settings card */}
+        {!loading && !loadError && (
+          <Box sx={{ mt: "16px" }}>
+            {/* ─── API Keys tab ─────────────────────────────────────────── */}
+            {activeTab === "api-keys" && (
               <Box sx={cardSx}>
                 <Stack gap="12px">
                   <Stack direction="row" justifyContent="space-between" alignItems="flex-start">
                     <Box>
-                      <Typography sx={sectionTitleSx}>Risk detection settings</Typography>
+                      <Typography sx={sectionTitleSx}>API keys</Typography>
                       <Typography sx={{ fontSize: 13, color: palette.text.tertiary, mt: "4px" }}>
-                        Configure which risk conditions to monitor. Detection runs daily at 6 AM or
-                        manually below.
+                        Provider API keys are encrypted at rest (AES-256-CBC) and only decrypted
+                        when proxying a request.
                       </Typography>
                     </Box>
-                    <Stack direction="row" gap="8px" alignItems="center">
-                      {detectResult && (
-                        <Typography
-                          sx={{
-                            fontSize: 12,
-                            color: detectResult.includes("found")
-                              ? palette.status.success.text
-                              : palette.text.tertiary,
-                            mr: "4px",
-                          }}
-                        >
-                          {detectResult}
-                        </Typography>
-                      )}
-                      <CustomizableButton
-                        text={detecting ? "Detecting..." : "Run detection now"}
-                        variant="outlined"
-                        icon={<Play size={14} strokeWidth={1.5} />}
-                        onClick={handleRunDetection}
-                        isDisabled={detecting}
-                      />
-                      <CustomizableButton
-                        text={riskSettingsSaving ? "Saving..." : "Save settings"}
-                        onClick={handleSaveRiskSettings}
-                        isDisabled={riskSettingsSaving || !riskSettingsDirty}
-                      />
-                    </Stack>
+                    <CustomizableButton
+                      text="Add key"
+                      icon={<CirclePlus size={14} strokeWidth={1.5} />}
+                      onClick={() => {
+                        setKeyForm({ key_name: "", provider: "", api_key: "" });
+                        setKeyError("");
+                        setIsKeyModalOpen(true);
+                      }}
+                    />
                   </Stack>
 
-                  <Stack gap="0px" mt="4px">
-                    {riskSettings.map((s, idx) => {
-                      const meta = CONDITION_META[s.condition_id];
-                      const thresholdKeys = Object.keys(s.default_threshold);
-                      return (
-                        <Stack
-                          key={s.condition_id}
-                          direction="row"
-                          alignItems="flex-start"
-                          gap="12px"
-                          sx={{
-                            p: "12px 0",
-                            borderTop: idx > 0 ? `1px solid ${palette.border.light}` : "none",
-                            opacity: s.is_enabled ? 1 : 0.55,
-                          }}
-                        >
-                          <Box sx={{ pt: "2px" }}>
-                            <Toggle
-                              checked={s.is_enabled}
-                              onChange={() => handleToggleCondition(s.condition_id, !s.is_enabled)}
-                            />
-                          </Box>
-                          <Box flex={1} minWidth={0}>
-                            <Typography sx={{ fontSize: 13, fontWeight: 500 }}>
-                              {s.label}
-                            </Typography>
-                            {meta?.description && (
-                              <Typography
-                                sx={{
-                                  fontSize: 12,
-                                  color: palette.text.tertiary,
-                                  mt: "2px",
-                                  lineHeight: 1.4,
-                                }}
-                              >
-                                {meta.description}
-                              </Typography>
-                            )}
-                            {thresholdKeys.length > 0 && (
-                              <Box sx={{ display: "flex", flexDirection: "row", mt: "8px" }}>
-                                {thresholdKeys.map((key, ki) => (
-                                  <Box
-                                    key={key}
-                                    sx={{ width: "110px", ml: ki > 0 ? "8px" : "0px" }}
-                                  >
-                                    <Field
-                                      label={meta?.thresholdLabels[key] || key.replace(/_/g, " ")}
-                                      value={String(
-                                        s.threshold[key] ?? s.default_threshold[key] ?? "",
-                                      )}
-                                      onChange={(e) =>
-                                        handleThresholdChange(s.condition_id, key, e.target.value)
-                                      }
-                                      sx={{ minWidth: "unset", width: "100%" }}
-                                    />
-                                  </Box>
-                                ))}
-                              </Box>
-                            )}
-                          </Box>
-                        </Stack>
-                      );
-                    })}
-                  </Stack>
-                </Stack>
-              </Box>
-
-              {/* Pending suggestions */}
-              {pendingSuggestions.length > 0 ? (
-                <Box>
-                  <Typography sx={{ ...sectionTitleSx, mb: "12px" }}>
-                    Pending suggestions ({pendingSuggestions.length})
-                  </Typography>
-                  <Stack gap="12px">
-                    {pendingSuggestions.map((s) => (
-                      <Box key={s.id} sx={cardSx}>
-                        <Stack gap="8px">
-                          <Stack direction="row" alignItems="center" gap="8px">
-                            <Typography
-                              sx={{
-                                fontSize: 11,
-                                fontWeight: 600,
-                                color: SEVERITY_COLORS[s.severity] || palette.text.tertiary,
-                                backgroundColor: `${SEVERITY_COLORS[s.severity] || palette.text.tertiary}1a`,
-                                px: "8px",
-                                py: "2px",
-                                borderRadius: "4px",
-                                textTransform: "uppercase",
-                              }}
-                            >
-                              {s.severity}
-                            </Typography>
-                            <Typography sx={{ fontSize: 14, fontWeight: 500 }}>
-                              {s.title}
-                            </Typography>
-                          </Stack>
-
-                          <Typography sx={{ fontSize: 13, color: palette.text.secondary }}>
-                            {s.description}
-                          </Typography>
-
-                          {s.suggested_mitigation && (
-                            <Typography sx={{ fontSize: 13, color: palette.text.tertiary }}>
-                              <strong>Suggested:</strong> {s.suggested_mitigation}
-                            </Typography>
-                          )}
-
-                          {s.compliance_tags.length > 0 && (
-                            <Typography sx={{ fontSize: 12, color: palette.text.tertiary }}>
-                              {s.compliance_tags.join(" \u00b7 ")}
-                            </Typography>
-                          )}
-
-                          {s.evidence && Object.keys(s.evidence).length > 0 && (
-                            <Typography sx={{ fontSize: 12, color: palette.text.tertiary }}>
-                              Evidence:{" "}
-                              {Object.entries(s.evidence)
-                                .filter(([k]) => !k.startsWith("threshold"))
-                                .slice(0, 4)
-                                .map(
-                                  ([k, v]) =>
-                                    `${k.replace(/_/g, " ")}: ${Array.isArray(v) ? v.join(", ") : v}`,
-                                )
-                                .join(" \u00b7 ")}
-                            </Typography>
-                          )}
-
-                          <Stack direction="row" justifyContent="flex-end" gap="8px" mt="4px">
-                            <CustomizableButton
-                              text="Dismiss"
-                              variant="outlined"
-                              icon={<X size={14} strokeWidth={1.5} />}
-                              onClick={() => openDismissModal(s)}
-                            />
-                            <CustomizableButton
-                              text="Accept as risk"
-                              icon={<Check size={14} strokeWidth={1.5} />}
-                              onClick={() => openAcceptModal(s)}
-                            />
-                          </Stack>
-                        </Stack>
-                      </Box>
-                    ))}
-                  </Stack>
-                </Box>
-              ) : (
-                <EmptyState
-                  icon={AlertTriangle}
-                  message="No pending risk suggestions. Run detection or wait for the next scheduled check."
-                  showBorder
-                />
-              )}
-
-              {/* History (collapsed) */}
-              {historySuggestions.length > 0 && (
-                <Box>
-                  <Stack
-                    direction="row"
-                    alignItems="center"
-                    gap="4px"
-                    sx={{ cursor: "pointer", mb: "8px" }}
-                    onClick={() => setShowHistory(!showHistory)}
-                  >
-                    {showHistory ? (
-                      <ChevronDown size={16} strokeWidth={1.5} />
-                    ) : (
-                      <ChevronRight size={16} strokeWidth={1.5} />
-                    )}
-                    <Typography
-                      sx={{ fontSize: 13, fontWeight: 500, color: palette.text.secondary }}
+                  {apiKeys.length === 0 ? (
+                    <EmptyState
+                      icon={Key}
+                      message="No API keys configured. Add a provider API key to start creating endpoints."
+                      showBorder
                     >
-                      History ({historySuggestions.length})
-                    </Typography>
-                  </Stack>
-                  <Collapse in={showHistory}>
+                      <EmptyStateTip
+                        icon={Lock}
+                        title="Keys are encrypted at rest"
+                        description="Your provider API keys are encrypted using AES-256-CBC before being stored. They are only decrypted when proxying a request and are never exposed in logs."
+                      />
+                      <EmptyStateTip
+                        icon={Router}
+                        title="Each endpoint references an API key"
+                        description="After adding a key, create endpoints in the Endpoints tab. Each endpoint uses one API key to authenticate with the LLM provider."
+                      />
+                    </EmptyState>
+                  ) : (
                     <Stack gap="8px">
-                      {historySuggestions.map((s) => (
+                      {apiKeys.map((key) => (
                         <Stack
-                          key={s.id}
+                          key={key.id}
                           direction="row"
                           justifyContent="space-between"
                           alignItems="center"
                           sx={{
-                            p: "8px 12px",
-                            border: `1px solid ${palette.border.light}`,
+                            p: "12px 16px",
+                            border: `1px solid ${palette.border.dark}`,
                             borderRadius: "4px",
-                            opacity: 0.7,
                           }}
                         >
+                          <Stack direction="row" alignItems="center" gap="10px">
+                            <ProviderIcon provider={key.provider} size={20} />
+                            <Box>
+                              <Typography sx={{ fontSize: 13, fontWeight: 500 }}>
+                                {key.key_name}
+                              </Typography>
+                              <Typography sx={{ fontSize: 12, color: palette.text.tertiary }}>
+                                {key.provider} &middot; {key.masked_key}
+                              </Typography>
+                            </Box>
+                          </Stack>
                           <Stack direction="row" alignItems="center" gap="8px">
                             <Typography
                               sx={{
-                                fontSize: 11,
-                                fontWeight: 600,
-                                color:
-                                  s.status === "accepted"
-                                    ? palette.status.success.text
-                                    : palette.text.tertiary,
-                                textTransform: "uppercase",
+                                fontSize: 12,
+                                color: key.is_active
+                                  ? palette.status.success.text
+                                  : palette.text.disabled,
+                                fontWeight: 500,
                               }}
                             >
-                              {s.status}
+                              {key.is_active ? "Active" : "Inactive"}
                             </Typography>
-                            <Typography sx={{ fontSize: 13 }}>{s.title}</Typography>
-                          </Stack>
-                          <Stack direction="row" alignItems="center" gap="8px">
-                            {s.reviewed_by_name && (
-                              <Typography sx={{ fontSize: 12, color: palette.text.tertiary }}>
-                                by {s.reviewed_by_name}
-                              </Typography>
-                            )}
-                            {s.reviewed_at && (
-                              <Typography sx={{ fontSize: 12, color: palette.text.tertiary }}>
-                                {new Date(s.reviewed_at).toLocaleDateString()}
-                              </Typography>
-                            )}
+                            <IconButton
+                              size="small"
+                              onClick={() => setKeyDeleteTarget(key)}
+                              sx={{ p: 0.5 }}
+                            >
+                              <Trash2 size={14} strokeWidth={1.5} color={palette.text.tertiary} />
+                            </IconButton>
                           </Stack>
                         </Stack>
                       ))}
                     </Stack>
-                  </Collapse>
+                  )}
+                </Stack>
+              </Box>
+            )}
+
+            {/* ─── Budget tab ───────────────────────────────────────────── */}
+            {activeTab === "budget" && (
+              <Box sx={cardSx}>
+                <Stack gap="12px">
+                  <Stack direction="row" justifyContent="space-between" alignItems="flex-start">
+                    <Box>
+                      <Typography sx={sectionTitleSx}>Budget</Typography>
+                      <Typography sx={{ fontSize: 13, color: palette.text.tertiary, mt: "4px" }}>
+                        Set a monthly spending limit. When hard limit is enabled, requests are
+                        rejected once exceeded.
+                      </Typography>
+                    </Box>
+                    <CustomizableButton
+                      text={budget ? "Edit budget" : "Set budget"}
+                      icon={<Pencil size={14} strokeWidth={1.5} />}
+                      onClick={openBudgetModal}
+                    />
+                  </Stack>
+
+                  {budget ? (
+                    <Stack gap="12px">
+                      <Stack direction="row" justifyContent="space-between">
+                        <Typography sx={{ fontSize: 13, color: palette.text.tertiary }}>
+                          Monthly limit
+                        </Typography>
+                        <Typography sx={{ fontSize: 13, fontWeight: 500 }}>
+                          ${Number(budget.monthly_limit_usd).toFixed(2)}
+                        </Typography>
+                      </Stack>
+                      <Stack direction="row" justifyContent="space-between">
+                        <Typography sx={{ fontSize: 13, color: palette.text.tertiary }}>
+                          Current spend
+                        </Typography>
+                        <Typography sx={{ fontSize: 13, fontWeight: 500 }}>
+                          ${Number(budget.current_spend_usd).toFixed(4)}
+                        </Typography>
+                      </Stack>
+                      {Number(budget.monthly_limit_usd) > 0 && (
+                        <Box
+                          sx={{
+                            height: 6,
+                            borderRadius: 3,
+                            backgroundColor: palette.border.light,
+                            overflow: "hidden",
+                          }}
+                        >
+                          <Box
+                            sx={{
+                              height: "100%",
+                              width: `${Math.min(100, (Number(budget.current_spend_usd) / Number(budget.monthly_limit_usd)) * 100)}%`,
+                              backgroundColor:
+                                (Number(budget.current_spend_usd) /
+                                  Number(budget.monthly_limit_usd)) *
+                                  100 >=
+                                budget.alert_threshold_pct
+                                  ? palette.status.error.text
+                                  : palette.brand.primary,
+                              borderRadius: 3,
+                              transition: "width 0.3s",
+                            }}
+                          />
+                        </Box>
+                      )}
+                      <Stack direction="row" justifyContent="space-between">
+                        <Typography sx={{ fontSize: 13, color: palette.text.tertiary }}>
+                          Alert threshold
+                        </Typography>
+                        <Typography sx={{ fontSize: 13, fontWeight: 500 }}>
+                          {budget.alert_threshold_pct}%
+                        </Typography>
+                      </Stack>
+                      <Stack direction="row" justifyContent="space-between">
+                        <Typography sx={{ fontSize: 13, color: palette.text.tertiary }}>
+                          Hard limit
+                        </Typography>
+                        <Typography sx={{ fontSize: 13, fontWeight: 500 }}>
+                          {budget.is_hard_limit ? "Yes (requests rejected)" : "No (alert only)"}
+                        </Typography>
+                      </Stack>
+                    </Stack>
+                  ) : (
+                    <EmptyState
+                      icon={Wallet}
+                      message="No budget configured. All requests are allowed without cost limits."
+                      showBorder
+                    />
+                  )}
+                </Stack>
+              </Box>
+            )}
+
+            {/* ─── Virtual keys tab ─────────────────────────────────────── */}
+            {activeTab === "virtual-keys" && <VirtualKeysTab embedded />}
+
+            {/* ─── Guardrail settings tab ───────────────────────────────── */}
+            {activeTab === "guardrails" && (
+              <Stack gap="16px">
+                {/* Save button */}
+                <Stack direction="row" justifyContent="flex-end">
+                  <CustomizableButton
+                    text={gsSaving ? "Saving..." : "Save settings"}
+                    onClick={handleSaveGuardrailSettings}
+                    isDisabled={gsSaving}
+                  />
+                </Stack>
+
+                {/* Error behavior card */}
+                <Box sx={cardSx}>
+                  <Stack gap="8px">
+                    <Typography sx={sectionTitleSx}>Error behavior</Typography>
+                    <Typography sx={{ fontSize: 13, color: palette.text.tertiary }}>
+                      What happens when the guardrail scanner itself fails. "Fail-closed" blocks all
+                      requests for safety. "Fail-open" allows requests through.
+                    </Typography>
+                    <Stack direction="row" gap="16px" mt="8px">
+                      <Box flex={1}>
+                        <Select
+                          id="pii-on-error"
+                          label="PII scan on error"
+                          value={gsForm.pii_on_error}
+                          items={[
+                            { _id: "block", name: "Block request (fail-closed)" },
+                            { _id: "allow", name: "Allow request (fail-open)" },
+                          ]}
+                          onChange={(e) =>
+                            setGsForm((p) => ({ ...p, pii_on_error: e.target.value as string }))
+                          }
+                          getOptionValue={(item) => item._id}
+                        />
+                      </Box>
+                      <Box flex={1}>
+                        <Select
+                          id="cf-on-error"
+                          label="Content filter on error"
+                          value={gsForm.content_filter_on_error}
+                          items={[
+                            { _id: "allow", name: "Allow request (fail-open)" },
+                            { _id: "block", name: "Block request (fail-closed)" },
+                          ]}
+                          onChange={(e) =>
+                            setGsForm((p) => ({
+                              ...p,
+                              content_filter_on_error: e.target.value as string,
+                            }))
+                          }
+                          getOptionValue={(item) => item._id}
+                        />
+                      </Box>
+                    </Stack>
+                  </Stack>
                 </Box>
-              )}
-            </Stack>
-          )}
-        </Box>
+
+                {/* Replacement text card */}
+                <Box sx={cardSx}>
+                  <Stack gap="8px">
+                    <Typography sx={sectionTitleSx}>Replacement text</Typography>
+                    <Typography sx={{ fontSize: 13, color: palette.text.tertiary }}>
+                      When a guardrail masks content, this text replaces the detected value. Use
+                      ENTITY_TYPE in the PII format to include the detected type (e.g.,
+                      &lt;EMAIL_ADDRESS&gt;).
+                    </Typography>
+                    <Stack direction="row" gap="16px" mt="8px">
+                      <Box flex={1}>
+                        <Field
+                          label="PII replacement format"
+                          placeholder="<ENTITY_TYPE>"
+                          value={gsForm.pii_replacement_format}
+                          onChange={(e) =>
+                            setGsForm((p) => ({ ...p, pii_replacement_format: e.target.value }))
+                          }
+                        />
+                      </Box>
+                      <Box flex={1}>
+                        <Field
+                          label="Content filter replacement"
+                          placeholder="[REDACTED]"
+                          value={gsForm.content_filter_replacement}
+                          onChange={(e) =>
+                            setGsForm((p) => ({ ...p, content_filter_replacement: e.target.value }))
+                          }
+                        />
+                      </Box>
+                    </Stack>
+                  </Stack>
+                </Box>
+
+                {/* Audit log retention card */}
+                <Box sx={cardSx}>
+                  <Stack gap="8px">
+                    <Typography sx={sectionTitleSx}>Audit log retention</Typography>
+                    <Typography sx={{ fontSize: 13, color: palette.text.tertiary }}>
+                      How long to keep guardrail detection logs. These logs record every blocked or
+                      masked request for compliance auditing (EU AI Act Art. 12).
+                    </Typography>
+                    <Box sx={{ maxWidth: 200, mt: "8px" }}>
+                      <Field
+                        label="Retention period (days)"
+                        placeholder="90"
+                        value={gsForm.log_retention_days}
+                        onChange={(e) =>
+                          setGsForm((p) => ({ ...p, log_retention_days: e.target.value }))
+                        }
+                      />
+                    </Box>
+                    <Box sx={{ mt: "8px" }}>
+                      <CustomizableButton
+                        text="Purge old logs"
+                        variant="outlined"
+                        onClick={async () => {
+                          try {
+                            await apiServices.post("/ai-gateway/guardrails/logs/purge");
+                          } catch {
+                            // Silently handle
+                          }
+                        }}
+                      />
+                    </Box>
+                  </Stack>
+                </Box>
+
+                {/* Request body logging card */}
+                <Box sx={cardSx}>
+                  <Stack gap="8px">
+                    <Typography sx={sectionTitleSx}>Request body logging</Typography>
+                    <Typography sx={{ fontSize: 13, color: palette.text.tertiary }}>
+                      When enabled, full request prompts and LLM responses are stored in the spend
+                      logs. Disabled by default for privacy. Bodies are truncated to 2,048
+                      characters.
+                    </Typography>
+                    <Stack gap="12px" mt="8px">
+                      <Stack direction="row" justifyContent="space-between" alignItems="center">
+                        <Typography sx={{ fontSize: 13 }}>Log request body (prompts)</Typography>
+                        <Toggle
+                          checked={gsForm.log_request_body}
+                          onChange={() =>
+                            setGsForm((p) => ({ ...p, log_request_body: !p.log_request_body }))
+                          }
+                        />
+                      </Stack>
+                      <Stack direction="row" justifyContent="space-between" alignItems="center">
+                        <Typography sx={{ fontSize: 13 }}>
+                          Log response body (LLM output)
+                        </Typography>
+                        <Toggle
+                          checked={gsForm.log_response_body}
+                          onChange={() =>
+                            setGsForm((p) => ({ ...p, log_response_body: !p.log_response_body }))
+                          }
+                        />
+                      </Stack>
+                    </Stack>
+                  </Stack>
+                </Box>
+
+                {/* Spend log cleanup card */}
+                <Box sx={cardSx}>
+                  <Stack gap="8px">
+                    <Typography sx={sectionTitleSx}>Spend log cleanup</Typography>
+                    <Typography sx={{ fontSize: 13, color: palette.text.tertiary }}>
+                      Delete old spend log entries based on the retention period above.
+                    </Typography>
+                    <Box sx={{ mt: "8px" }}>
+                      <CustomizableButton
+                        text={spendPurgeResult || "Purge old spend logs"}
+                        variant="outlined"
+                        onClick={async () => {
+                          setSpendPurgeResult("Purging...");
+                          try {
+                            const res = await apiServices.post<Record<string, any>>(
+                              "/ai-gateway/spend/logs/purge",
+                            );
+                            const count = res?.data?.deleted ?? res?.data?.data?.deleted_count ?? 0;
+                            setSpendPurgeResult(
+                              count > 0 ? `Deleted ${count} logs` : "No old logs to purge",
+                            );
+                            if (count > 0) await loadData();
+                            setTimeout(() => setSpendPurgeResult(""), 3000);
+                          } catch {
+                            setSpendPurgeResult("Failed to purge");
+                            setTimeout(() => setSpendPurgeResult(""), 3000);
+                          }
+                        }}
+                      />
+                    </Box>
+                  </Stack>
+                </Box>
+                {/* Response cache settings card */}
+                <Box sx={cardSx}>
+                  <Stack gap="12px">
+                    <Typography sx={sectionTitleSx}>Response caching</Typography>
+                    <Typography sx={{ fontSize: 13, color: palette.text.tertiary }}>
+                      Cache identical LLM requests to reduce cost and latency. Enable caching
+                      globally here, then toggle it per-endpoint in the Endpoints tab.
+                    </Typography>
+
+                    <Stack direction="row" justifyContent="space-between" alignItems="center">
+                      <Typography sx={{ fontSize: 13 }}>Enable caching globally</Typography>
+                      <Toggle
+                        checked={cacheSettings.cache_global_enabled}
+                        onChange={() =>
+                          setCacheSettings((p) => ({
+                            ...p,
+                            cache_global_enabled: !p.cache_global_enabled,
+                          }))
+                        }
+                      />
+                    </Stack>
+
+                    <Stack direction="row" gap="16px">
+                      <Box sx={{ flex: 1 }}>
+                        <Field
+                          label="Default TTL (seconds)"
+                          placeholder="14400"
+                          value={cacheSettings.cache_default_ttl_seconds}
+                          onChange={(e) =>
+                            setCacheSettings((p) => ({
+                              ...p,
+                              cache_default_ttl_seconds: e.target.value,
+                            }))
+                          }
+                        />
+                      </Box>
+                      <Box sx={{ flex: 1 }}>
+                        <Field
+                          label="Max entries per org"
+                          placeholder="50000"
+                          value={cacheSettings.cache_max_entries_per_org}
+                          onChange={(e) =>
+                            setCacheSettings((p) => ({
+                              ...p,
+                              cache_max_entries_per_org: e.target.value,
+                            }))
+                          }
+                        />
+                      </Box>
+                    </Stack>
+
+                    <Stack direction="row" gap="8px" sx={{ mt: "8px" }}>
+                      <CustomizableButton
+                        text={cacheSaving ? "Saving..." : "Save cache settings"}
+                        variant="contained"
+                        onClick={handleSaveCacheSettings}
+                      />
+                      <CustomizableButton
+                        text={cachePurgeResult || "Purge expired entries"}
+                        variant="outlined"
+                        onClick={async () => {
+                          setCachePurgeResult("Purging...");
+                          try {
+                            const res =
+                              await apiServices.post<Record<string, any>>(
+                                "/ai-gateway/cache/purge",
+                              );
+                            const count = res?.data?.deleted ?? 0;
+                            setCachePurgeResult(
+                              count > 0 ? `Deleted ${count} entries` : "No expired entries",
+                            );
+                            setTimeout(() => setCachePurgeResult(""), 3000);
+                          } catch {
+                            setCachePurgeResult("Failed");
+                            setTimeout(() => setCachePurgeResult(""), 3000);
+                          }
+                        }}
+                      />
+                    </Stack>
+                  </Stack>
+                </Box>
+              </Stack>
+            )}
+
+            {/* ─── Suggested risks tab ──────────────────────────────────── */}
+            {activeTab === "risks" && !riskLoading && !riskError && (
+              <Stack gap="16px">
+                {/* Detection settings card */}
+                <Box sx={cardSx}>
+                  <Stack gap="12px">
+                    <Stack direction="row" justifyContent="space-between" alignItems="flex-start">
+                      <Box>
+                        <Typography sx={sectionTitleSx}>Risk detection settings</Typography>
+                        <Typography sx={{ fontSize: 13, color: palette.text.tertiary, mt: "4px" }}>
+                          Configure which risk conditions to monitor. Detection runs daily at 6 AM
+                          or manually below.
+                        </Typography>
+                      </Box>
+                      <Stack direction="row" gap="8px" alignItems="center">
+                        {detectResult && (
+                          <Typography
+                            sx={{
+                              fontSize: 12,
+                              color: detectResult.includes("found")
+                                ? palette.status.success.text
+                                : palette.text.tertiary,
+                              mr: "4px",
+                            }}
+                          >
+                            {detectResult}
+                          </Typography>
+                        )}
+                        <CustomizableButton
+                          text={detecting ? "Detecting..." : "Run detection now"}
+                          variant="outlined"
+                          icon={<Play size={14} strokeWidth={1.5} />}
+                          onClick={handleRunDetection}
+                          isDisabled={detecting}
+                        />
+                        <CustomizableButton
+                          text={riskSettingsSaving ? "Saving..." : "Save settings"}
+                          onClick={handleSaveRiskSettings}
+                          isDisabled={riskSettingsSaving || !riskSettingsDirty}
+                        />
+                      </Stack>
+                    </Stack>
+
+                    <Stack gap="0px" mt="4px">
+                      {riskSettings.map((s, idx) => {
+                        const meta = CONDITION_META[s.condition_id];
+                        const thresholdKeys = Object.keys(s.default_threshold);
+                        return (
+                          <Stack
+                            key={s.condition_id}
+                            direction="row"
+                            alignItems="flex-start"
+                            gap="12px"
+                            sx={{
+                              p: "12px 0",
+                              borderTop: idx > 0 ? `1px solid ${palette.border.light}` : "none",
+                              opacity: s.is_enabled ? 1 : 0.55,
+                            }}
+                          >
+                            <Box sx={{ pt: "2px" }}>
+                              <Toggle
+                                checked={s.is_enabled}
+                                onChange={() =>
+                                  handleToggleCondition(s.condition_id, !s.is_enabled)
+                                }
+                              />
+                            </Box>
+                            <Box flex={1} minWidth={0}>
+                              <Typography sx={{ fontSize: 13, fontWeight: 500 }}>
+                                {s.label}
+                              </Typography>
+                              {meta?.description && (
+                                <Typography
+                                  sx={{
+                                    fontSize: 12,
+                                    color: palette.text.tertiary,
+                                    mt: "2px",
+                                    lineHeight: 1.4,
+                                  }}
+                                >
+                                  {meta.description}
+                                </Typography>
+                              )}
+                              {thresholdKeys.length > 0 && (
+                                <Box sx={{ display: "flex", flexDirection: "row", mt: "8px" }}>
+                                  {thresholdKeys.map((key, ki) => (
+                                    <Box
+                                      key={key}
+                                      sx={{ width: "110px", ml: ki > 0 ? "8px" : "0px" }}
+                                    >
+                                      <Field
+                                        label={meta?.thresholdLabels[key] || key.replace(/_/g, " ")}
+                                        value={String(
+                                          s.threshold[key] ?? s.default_threshold[key] ?? "",
+                                        )}
+                                        onChange={(e) =>
+                                          handleThresholdChange(s.condition_id, key, e.target.value)
+                                        }
+                                        sx={{ minWidth: "unset", width: "100%" }}
+                                      />
+                                    </Box>
+                                  ))}
+                                </Box>
+                              )}
+                            </Box>
+                          </Stack>
+                        );
+                      })}
+                    </Stack>
+                  </Stack>
+                </Box>
+
+                {/* Pending suggestions */}
+                {pendingSuggestions.length > 0 ? (
+                  <Box>
+                    <Typography sx={{ ...sectionTitleSx, mb: "12px" }}>
+                      Pending suggestions ({pendingSuggestions.length})
+                    </Typography>
+                    <Stack gap="12px">
+                      {pendingSuggestions.map((s) => (
+                        <Box key={s.id} sx={cardSx}>
+                          <Stack gap="8px">
+                            <Stack direction="row" alignItems="center" gap="8px">
+                              <Typography
+                                sx={{
+                                  fontSize: 11,
+                                  fontWeight: 600,
+                                  color: SEVERITY_COLORS[s.severity] || palette.text.tertiary,
+                                  backgroundColor: `${SEVERITY_COLORS[s.severity] || palette.text.tertiary}1a`,
+                                  px: "8px",
+                                  py: "2px",
+                                  borderRadius: "4px",
+                                  textTransform: "uppercase",
+                                }}
+                              >
+                                {s.severity}
+                              </Typography>
+                              <Typography sx={{ fontSize: 14, fontWeight: 500 }}>
+                                {s.title}
+                              </Typography>
+                            </Stack>
+
+                            <Typography sx={{ fontSize: 13, color: palette.text.secondary }}>
+                              {s.description}
+                            </Typography>
+
+                            {s.suggested_mitigation && (
+                              <Typography sx={{ fontSize: 13, color: palette.text.tertiary }}>
+                                <strong>Suggested:</strong> {s.suggested_mitigation}
+                              </Typography>
+                            )}
+
+                            {s.compliance_tags.length > 0 && (
+                              <Typography sx={{ fontSize: 12, color: palette.text.tertiary }}>
+                                {s.compliance_tags.join(" \u00b7 ")}
+                              </Typography>
+                            )}
+
+                            {s.evidence && Object.keys(s.evidence).length > 0 && (
+                              <Typography sx={{ fontSize: 12, color: palette.text.tertiary }}>
+                                Evidence:{" "}
+                                {Object.entries(s.evidence)
+                                  .filter(([k]) => !k.startsWith("threshold"))
+                                  .slice(0, 4)
+                                  .map(
+                                    ([k, v]) =>
+                                      `${k.replace(/_/g, " ")}: ${Array.isArray(v) ? v.join(", ") : v}`,
+                                  )
+                                  .join(" \u00b7 ")}
+                              </Typography>
+                            )}
+
+                            <Stack direction="row" justifyContent="flex-end" gap="8px" mt="4px">
+                              <CustomizableButton
+                                text="Dismiss"
+                                variant="outlined"
+                                icon={<X size={14} strokeWidth={1.5} />}
+                                onClick={() => openDismissModal(s)}
+                              />
+                              <CustomizableButton
+                                text="Accept as risk"
+                                icon={<Check size={14} strokeWidth={1.5} />}
+                                onClick={() => openAcceptModal(s)}
+                              />
+                            </Stack>
+                          </Stack>
+                        </Box>
+                      ))}
+                    </Stack>
+                  </Box>
+                ) : (
+                  <EmptyState
+                    icon={AlertTriangle}
+                    message="No pending risk suggestions. Run detection or wait for the next scheduled check."
+                    showBorder
+                  />
+                )}
+
+                {/* History (collapsed) */}
+                {historySuggestions.length > 0 && (
+                  <Box>
+                    <Stack
+                      direction="row"
+                      alignItems="center"
+                      gap="4px"
+                      sx={{ cursor: "pointer", mb: "8px" }}
+                      onClick={() => setShowHistory(!showHistory)}
+                    >
+                      {showHistory ? (
+                        <ChevronDown size={16} strokeWidth={1.5} />
+                      ) : (
+                        <ChevronRight size={16} strokeWidth={1.5} />
+                      )}
+                      <Typography
+                        sx={{ fontSize: 13, fontWeight: 500, color: palette.text.secondary }}
+                      >
+                        History ({historySuggestions.length})
+                      </Typography>
+                    </Stack>
+                    <Collapse in={showHistory}>
+                      <Stack gap="8px">
+                        {historySuggestions.map((s) => (
+                          <Stack
+                            key={s.id}
+                            direction="row"
+                            justifyContent="space-between"
+                            alignItems="center"
+                            sx={{
+                              p: "8px 12px",
+                              border: `1px solid ${palette.border.light}`,
+                              borderRadius: "4px",
+                              opacity: 0.7,
+                            }}
+                          >
+                            <Stack direction="row" alignItems="center" gap="8px">
+                              <Typography
+                                sx={{
+                                  fontSize: 11,
+                                  fontWeight: 600,
+                                  color:
+                                    s.status === "accepted"
+                                      ? palette.status.success.text
+                                      : palette.text.tertiary,
+                                  textTransform: "uppercase",
+                                }}
+                              >
+                                {s.status}
+                              </Typography>
+                              <Typography sx={{ fontSize: 13 }}>{s.title}</Typography>
+                            </Stack>
+                            <Stack direction="row" alignItems="center" gap="8px">
+                              {s.reviewed_by_name && (
+                                <Typography sx={{ fontSize: 12, color: palette.text.tertiary }}>
+                                  by {s.reviewed_by_name}
+                                </Typography>
+                              )}
+                              {s.reviewed_at && (
+                                <Typography sx={{ fontSize: 12, color: palette.text.tertiary }}>
+                                  {new Date(s.reviewed_at).toLocaleDateString()}
+                                </Typography>
+                              )}
+                            </Stack>
+                          </Stack>
+                        ))}
+                      </Stack>
+                    </Collapse>
+                  </Box>
+                )}
+              </Stack>
+            )}
+            {activeTab === "risks" && riskLoading && (
+              <CustomizableSkeleton variant="rectangular" width="100%" height={400} />
+            )}
+            {activeTab === "risks" && riskError && (
+              <EmptyState icon={AlertTriangle} message={riskError}>
+                <CustomizableButton
+                  variant="outlined"
+                  text="Retry"
+                  icon={<RotateCcw size={16} />}
+                  onClick={loadRiskData}
+                />
+              </EmptyState>
+            )}
+          </Box>
+        )}
+        {loading && <CustomizableSkeleton variant="rectangular" width="100%" height={400} />}
+        {loadError && (
+          <EmptyState icon={AlertTriangle} message={loadError}>
+            <CustomizableButton
+              variant="outlined"
+              text="Retry"
+              icon={<RotateCcw size={16} />}
+              onClick={loadData}
+            />
+          </EmptyState>
+        )}
       </TabContext>
 
       {/* Add API Key Modal */}

--- a/Clients/src/presentation/pages/AIGateway/VirtualKeys/index.tsx
+++ b/Clients/src/presentation/pages/AIGateway/VirtualKeys/index.tsx
@@ -10,6 +10,8 @@ import {
   Check,
   Server,
   TriangleAlert,
+  AlertTriangle,
+  RotateCcw,
 } from "lucide-react";
 import { EmptyState } from "../../../components/EmptyState";
 import EmptyStateTip from "../../../components/EmptyState/EmptyStateTip";
@@ -21,6 +23,7 @@ import StandardModal from "../../../components/Modals/StandardModal";
 import { PageHeaderExtended } from "../../../components/Layout/PageHeaderExtended";
 import { apiServices } from "../../../../infrastructure/api/networkServices";
 import palette from "../../../themes/palette";
+import CustomizableSkeleton from "../../../components/Skeletons";
 import {
   sectionTitleSx,
   useCardSx,
@@ -71,6 +74,7 @@ export default function AIGatewayVirtualKeysPage({ embedded }: { embedded?: bool
   const [keys, setKeys] = useState<VirtualKey[]>([]);
   const [endpointCount, setEndpointCount] = useState<number | null>(null);
   const [loading, setLoading] = useState(true);
+  const [loadError, setLoadError] = useState<string | null>(null);
 
   // Create modal
   const [isCreateOpen, setIsCreateOpen] = useState(false);
@@ -104,6 +108,8 @@ export default function AIGatewayVirtualKeysPage({ embedded }: { embedded?: bool
   }, []);
 
   const loadData = useCallback(async () => {
+    setLoading(true);
+    setLoadError(null);
     try {
       const [keysRes, endpointsRes] = await Promise.all([
         apiServices.get<Record<string, any>>("/ai-gateway/virtual-keys"),
@@ -113,7 +119,7 @@ export default function AIGatewayVirtualKeysPage({ embedded }: { embedded?: bool
       const eps = endpointsRes?.data?.endpoints || [];
       setEndpointCount(eps.filter((e: any) => e.is_active).length);
     } catch {
-      // Silently handle
+      setLoadError("Failed to load virtual keys. Please try again.");
     } finally {
       setLoading(false);
     }
@@ -237,57 +243,70 @@ export default function AIGatewayVirtualKeysPage({ embedded }: { embedded?: bool
 
   const content = (
     <>
-      {!loading && keys.length === 0 && (
-        <EmptyState
-          icon={KeyRound}
-          message="Give your developers a single API key to access any LLM through the gateway — no VerifyWise account needed."
-          showBorder
-        >
-          {endpointCount === 0 && (
-            <Box
-              sx={{
-                display: "flex",
-                alignItems: "flex-start",
-                gap: "8px",
-                p: "12px 16px",
-                borderRadius: "4px",
-                border: "1px solid #FEDF89",
-                bgcolor: "#FFFAEB",
-                mb: "8px",
-              }}
-            >
-              <TriangleAlert
-                size={16}
-                strokeWidth={1.5}
-                color="#B54708"
-                style={{ flexShrink: 0, marginTop: 1 }}
-              />
-              <Box>
-                <Typography fontSize={13} fontWeight={500} color="#B54708">
-                  No endpoints configured
-                </Typography>
-                <Typography fontSize={12} color="#93370D" mt="2px">
-                  Virtual keys route requests through endpoints. You need at least one active
-                  endpoint before creating a virtual key.{" "}
-                  <Link to="/ai-gateway/endpoints" style={{ color: "#B54708", fontWeight: 500 }}>
-                    Go to Endpoints
-                  </Link>{" "}
-                  to set one up.
-                </Typography>
-              </Box>
-            </Box>
-          )}
-          <EmptyStateTip
-            icon={Server}
-            title="Drop-in replacement for any OpenAI SDK"
-            description="Developers point their existing OpenAI SDK at the gateway URL and swap in the virtual key. No code changes beyond the base URL and key — all guardrails, logging, and budget controls apply automatically."
-          />
-          <EmptyStateTip
-            icon={KeyRound}
-            title="Per-key budgets and rate limits"
-            description="Each virtual key can have its own monthly spending cap and request-per-minute limit. When a key hits its budget, only that key is blocked — other keys and the rest of the gateway keep running."
+      {loading ? (
+        <CustomizableSkeleton variant="rectangular" width="100%" height={400} />
+      ) : loadError ? (
+        <EmptyState icon={AlertTriangle} message={loadError}>
+          <CustomizableButton
+            variant="outlined"
+            text="Retry"
+            icon={<RotateCcw size={16} />}
+            onClick={loadData}
           />
         </EmptyState>
+      ) : (
+        keys.length === 0 && (
+          <EmptyState
+            icon={KeyRound}
+            message="Give your developers a single API key to access any LLM through the gateway — no VerifyWise account needed."
+            showBorder
+          >
+            {endpointCount === 0 && (
+              <Box
+                sx={{
+                  display: "flex",
+                  alignItems: "flex-start",
+                  gap: "8px",
+                  p: "12px 16px",
+                  borderRadius: "4px",
+                  border: "1px solid #FEDF89",
+                  bgcolor: "#FFFAEB",
+                  mb: "8px",
+                }}
+              >
+                <TriangleAlert
+                  size={16}
+                  strokeWidth={1.5}
+                  color="#B54708"
+                  style={{ flexShrink: 0, marginTop: 1 }}
+                />
+                <Box>
+                  <Typography fontSize={13} fontWeight={500} color="#B54708">
+                    No endpoints configured
+                  </Typography>
+                  <Typography fontSize={12} color="#93370D" mt="2px">
+                    Virtual keys route requests through endpoints. You need at least one active
+                    endpoint before creating a virtual key.{" "}
+                    <Link to="/ai-gateway/endpoints" style={{ color: "#B54708", fontWeight: 500 }}>
+                      Go to Endpoints
+                    </Link>{" "}
+                    to set one up.
+                  </Typography>
+                </Box>
+              </Box>
+            )}
+            <EmptyStateTip
+              icon={Server}
+              title="Drop-in replacement for any OpenAI SDK"
+              description="Developers point their existing OpenAI SDK at the gateway URL and swap in the virtual key. No code changes beyond the base URL and key — all guardrails, logging, and budget controls apply automatically."
+            />
+            <EmptyStateTip
+              icon={KeyRound}
+              title="Per-key budgets and rate limits"
+              description="Each virtual key can have its own monthly spending cap and request-per-minute limit. When a key hits its budget, only that key is blocked — other keys and the rest of the gateway keep running."
+            />
+          </EmptyState>
+        )
       )}
 
       {!loading && keys.length > 0 && (

--- a/Clients/src/presentation/pages/AIGateway/shared.ts
+++ b/Clients/src/presentation/pages/AIGateway/shared.ts
@@ -110,7 +110,7 @@ export const TOP_PROVIDERS = [
  * Hook: fetch models from the AI Gateway (LiteLLM registry) and provide
  * provider → model cascading data for Select components.
  *
- * Returns { providers, modelsByProvider, getModelsForProvider, loading }
+ * Returns { providers, modelsByProvider, getModelsForProvider, loading, error, reload }
  */
 export function useGatewayModels() {
   const [providers, setProviders] = useState<string[]>([]);
@@ -118,41 +118,44 @@ export function useGatewayModels() {
     Record<string, { id: string; mode: string }[]>
   >({});
   const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const load = useCallback(async (signal?: AbortSignal) => {
+    setLoading(true);
+    setError(null);
+    try {
+      const res = await apiServices.get<Record<string, any>>("/ai-gateway/providers", { signal });
+      const data = res?.data?.data;
+      if (!signal?.aborted && data) {
+        // Filter to chat-capable providers, sort alphabetically
+        const allProviders: string[] = (data.providers || []).sort();
+        const allModels: Record<string, { id: string; provider: string; mode: string }[]> =
+          data.models || {};
+
+        // Only keep providers that have chat models
+        const filtered: Record<string, { id: string; mode: string }[]> = {};
+        for (const p of allProviders) {
+          const models = (allModels[p] || [])
+            .filter((m: any) => m.mode === "chat" || m.mode === "completion")
+            .sort((a: any, b: any) => a.id.localeCompare(b.id));
+          if (models.length > 0) filtered[p] = models;
+        }
+
+        setProviders(Object.keys(filtered).sort());
+        setModelsByProvider(filtered);
+      }
+    } catch {
+      if (!signal?.aborted) setError("Unable to load AI Gateway providers.");
+    } finally {
+      if (!signal?.aborted) setLoading(false);
+    }
+  }, []);
 
   useEffect(() => {
-    let cancelled = false;
-    (async () => {
-      try {
-        const res = await apiServices.get<Record<string, any>>("/ai-gateway/providers");
-        const data = res?.data?.data;
-        if (!cancelled && data) {
-          // Filter to chat-capable providers, sort alphabetically
-          const allProviders: string[] = (data.providers || []).sort();
-          const allModels: Record<string, { id: string; provider: string; mode: string }[]> =
-            data.models || {};
-
-          // Only keep providers that have chat models
-          const filtered: Record<string, { id: string; mode: string }[]> = {};
-          for (const p of allProviders) {
-            const models = (allModels[p] || [])
-              .filter((m: any) => m.mode === "chat" || m.mode === "completion")
-              .sort((a: any, b: any) => a.id.localeCompare(b.id));
-            if (models.length > 0) filtered[p] = models;
-          }
-
-          setProviders(Object.keys(filtered).sort());
-          setModelsByProvider(filtered);
-        }
-      } catch {
-        // Gateway unavailable — providers stay empty
-      } finally {
-        if (!cancelled) setLoading(false);
-      }
-    })();
-    return () => {
-      cancelled = true;
-    };
-  }, []);
+    const ctrl = new AbortController();
+    load(ctrl.signal);
+    return () => ctrl.abort();
+  }, [load]);
 
   /** Get Select-compatible items for a given provider (memoized) */
   const getModelsForProvider = useCallback(
@@ -167,7 +170,15 @@ export function useGatewayModels() {
   /** Get Select-compatible provider items (memoized) */
   const providerItems = useMemo(() => providers.map((p) => ({ _id: p, name: p })), [providers]);
 
-  return { providers, providerItems, modelsByProvider, getModelsForProvider, loading };
+  return {
+    providers,
+    providerItems,
+    modelsByProvider,
+    getModelsForProvider,
+    loading,
+    error,
+    reload: load,
+  };
 }
 
 /** Convert a display name to a URL-safe slug */

--- a/Clients/src/presentation/pages/AITrustCenter/Overview/index.tsx
+++ b/Clients/src/presentation/pages/AITrustCenter/Overview/index.tsx
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
-import React, { Suspense } from "react";
+import React from "react";
 import { Box, Typography, Stack, FormControlLabel, useTheme } from "@mui/material";
 import CustomizableSkeleton from "../../../components/Skeletons";
 import Alert from "../../../components/Alert";
@@ -12,7 +12,7 @@ import {
   useAITrustCentreOverviewMutation,
 } from "../../../../application/hooks/useAITrustCentreOverviewQuery";
 import { handleAlert } from "../../../../application/tools/alertUtils";
-import { Save as SaveIcon } from "lucide-react";
+import { Save as SaveIcon, RotateCcw } from "lucide-react";
 import Field from "../../../components/Inputs/Field";
 
 import { SectionPaper, PrivacyFields, styles, getFormControlLabelStyles } from "./styles";
@@ -68,7 +68,7 @@ const ComplianceBadge: React.FC<{
 );
 
 const AITrustCenterOverview: React.FC = () => {
-  const { data: formData, isLoading: loading, error } = useAITrustCentreOverviewQuery();
+  const { data: formData, isLoading: loading, error, refetch } = useAITrustCentreOverviewQuery();
   const updateOverviewMutation = useAITrustCentreOverviewMutation();
 
   // Local state for form data and notifications
@@ -200,16 +200,23 @@ const AITrustCenterOverview: React.FC = () => {
   return (
     <Box>
       {error && (
-        <Suspense fallback={<div>Loading...</div>}>
-          <Alert
-            variant="error"
-            body={error.message || "An error occurred"}
-            isToast={true}
-            onClick={() => {}}
-          />
-        </Suspense>
+        <Alert
+          variant="error"
+          body={error.message || "An error occurred loading the AI Trust Center overview."}
+          isToast={true}
+          onClick={() => {}}
+        />
       )}
-
+      {error && (
+        <Box sx={{ display: "flex", justifyContent: "flex-end", mb: 2 }}>
+          <CustomizableButton
+            variant="outlined"
+            text="Retry"
+            icon={<RotateCcw size={16} />}
+            onClick={() => refetch()}
+          />
+        </Box>
+      )}
       {/* Introduction Section */}
       <SectionPaper sx={{ opacity: localFormData.info?.intro_visible ? 1 : 0.5 }}>
         <SectionHeader
@@ -570,15 +577,13 @@ const AITrustCenterOverview: React.FC = () => {
       </Stack>
 
       {alert && (
-        <Suspense fallback={<div>Loading...</div>}>
-          <Alert
-            variant={alert.variant}
-            title={alert.title}
-            body={alert.body}
-            isToast={true}
-            onClick={() => setAlert(null)}
-          />
-        </Suspense>
+        <Alert
+          variant={alert.variant}
+          title={alert.title}
+          body={alert.body}
+          isToast={true}
+          onClick={() => setAlert(null)}
+        />
       )}
     </Box>
   );

--- a/Clients/src/presentation/pages/AITrustCenter/Resources/index.tsx
+++ b/Clients/src/presentation/pages/AITrustCenter/Resources/index.tsx
@@ -867,7 +867,7 @@ const TrustCenterResources: React.FC = () => {
       </Box>
 
       {alert && (
-        <Suspense fallback={<div>Loading...</div>}>
+        <Suspense fallback={<></>}>
           <Alert
             variant={alert.variant}
             title={alert.title}
@@ -880,7 +880,7 @@ const TrustCenterResources: React.FC = () => {
 
       {/* Error notification for add resource */}
       {addResourceError && (
-        <Suspense fallback={<div>Loading...</div>}>
+        <Suspense fallback={<></>}>
           <Alert
             variant="error"
             body={addResourceError}
@@ -892,7 +892,7 @@ const TrustCenterResources: React.FC = () => {
 
       {/* Error notification for delete resource */}
       {deleteResourceError && (
-        <Suspense fallback={<div>Loading...</div>}>
+        <Suspense fallback={<></>}>
           <Alert
             variant="error"
             body={deleteResourceError}
@@ -904,7 +904,7 @@ const TrustCenterResources: React.FC = () => {
 
       {/* Error notification for edit resource */}
       {editResourceError && (
-        <Suspense fallback={<div>Loading...</div>}>
+        <Suspense fallback={<></>}>
           <Alert
             variant="error"
             body={editResourceError}

--- a/Clients/src/presentation/pages/AITrustCenter/Resources/index.tsx
+++ b/Clients/src/presentation/pages/AITrustCenter/Resources/index.tsx
@@ -1,10 +1,15 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import React, { useState, Suspense, useCallback, useEffect, useRef, useMemo } from "react";
 import { useSearchParams } from "react-router-dom";
-import { Box, Typography, TableCell, Stack, Tooltip } from "@mui/material";
+import { Box, Typography, TableCell, Stack, Tooltip, Alert as MuiAlert } from "@mui/material";
 import Alert from "../../../components/Alert";
-import { Eye as VisibilityIcon, EyeOff as VisibilityOffIcon } from "lucide-react";
-import { CirclePlus as AddCircleOutlineIcon } from "lucide-react";
+import {
+  Eye as VisibilityIcon,
+  EyeOff as VisibilityOffIcon,
+  CirclePlus as AddCircleOutlineIcon,
+  RotateCcw,
+  FileText,
+} from "lucide-react";
 import Toggle from "../../../components/Inputs/Toggle";
 import { useStyles } from "./styles";
 import { CustomizableButton } from "../../../components/button/customizable-button";
@@ -177,12 +182,14 @@ const TrustCenterResources: React.FC = () => {
     data: overviewData,
     isLoading: overviewLoading,
     error: overviewError,
+    refetch: refetchOverview,
   } = useAITrustCentreOverviewQuery();
   const updateOverviewMutation = useAITrustCentreOverviewMutation();
   const {
     data: resources,
     isLoading: resourcesLoading,
     error: resourcesError,
+    refetch: refetchResources,
   } = useAITrustCentreResourcesQuery();
   const createResourceMutation = useCreateAITrustCentreResourceMutation();
   const updateResourceMutation = useUpdateAITrustCentreResourceMutation();
@@ -631,9 +638,20 @@ const TrustCenterResources: React.FC = () => {
           {isTableLoading ? (
             <CustomizableSkeleton variant="rectangular" width="100%" height={400} />
           ) : tableError ? (
-            <Box display="flex" justifyContent="center" alignItems="center" minHeight="200px">
-              <Typography color="error">{tableError?.message || "An error occurred"}</Typography>
-            </Box>
+            <Stack alignItems="center" spacing={2} sx={{ py: 4 }}>
+              <MuiAlert severity="error" sx={{ width: "100%", maxWidth: 600 }}>
+                {tableError?.message || "An error occurred loading resources."}
+              </MuiAlert>
+              <CustomizableButton
+                variant="outlined"
+                text="Retry"
+                icon={<RotateCcw size={16} />}
+                onClick={() => {
+                  refetchOverview();
+                  refetchResources();
+                }}
+              />
+            </Stack>
           ) : (
             <GroupedTableView
               groupedData={groupedResources}
@@ -646,6 +664,7 @@ const TrustCenterResources: React.FC = () => {
                   paginated={true}
                   disabled={!formData?.info?.resources_visible}
                   emptyStateText="No resources found. Add your first resource to get started."
+                  emptyStateIcon={FileText}
                   renderRow={(resource, sortConfig) => (
                     <ResourceTableRow
                       key={resource.id}

--- a/Clients/src/presentation/pages/AITrustCenter/Settings/index.tsx
+++ b/Clients/src/presentation/pages/AITrustCenter/Settings/index.tsx
@@ -9,7 +9,8 @@ import { useStyles } from "./styles";
 import Field from "../../../components/Inputs/Field";
 import { ButtonToggle } from "../../../components/button-toggle";
 import { CustomizableButton } from "../../../components/button/customizable-button";
-import { Save as SaveIcon } from "lucide-react";
+import { Save as SaveIcon, AlertTriangle, RotateCcw } from "lucide-react";
+import { EmptyState } from "../../../components/EmptyState";
 import ConfirmationModal from "../../../components/Dialogs/ConfirmationModal";
 import {
   useAITrustCentreOverviewQuery,
@@ -27,7 +28,12 @@ import { brand, text, background } from "../../../themes/palette";
 const AITrustCenterSettings: React.FC = () => {
   const styles = useStyles();
   const { fetchLogoAsBlobUrl } = useLogoFetch();
-  const { data: overviewData, isLoading: loading, error } = useAITrustCentreOverviewQuery();
+  const {
+    data: overviewData,
+    isLoading: loading,
+    error,
+    refetch,
+  } = useAITrustCentreOverviewQuery();
   const updateOverviewMutation = useAITrustCentreOverviewMutation();
   const [alert, setAlert] = React.useState<AlertProps | null>(null);
   const [hasUnsavedChanges, setHasUnsavedChanges] = React.useState(false);
@@ -351,10 +357,20 @@ const AITrustCenterSettings: React.FC = () => {
           display: "flex",
           justifyContent: "center",
           alignItems: "center",
-          height: "200px",
+          py: 8,
         }}
       >
-        <Typography color="error">Error loading AI Trust Center settings</Typography>
+        <EmptyState
+          icon={AlertTriangle}
+          message="Error loading AI Trust Center settings. Please try again."
+        >
+          <CustomizableButton
+            variant="contained"
+            text="Retry"
+            icon={<RotateCcw size={16} />}
+            onClick={() => refetch()}
+          />
+        </EmptyState>
       </Box>
     );
   }

--- a/Clients/src/presentation/pages/AITrustCenter/Subprocessors/index.tsx
+++ b/Clients/src/presentation/pages/AITrustCenter/Subprocessors/index.tsx
@@ -701,7 +701,7 @@ const AITrustCenterSubprocessors: React.FC = () => {
       </Box>
 
       {alert && (
-        <Suspense fallback={<div>Loading...</div>}>
+        <Suspense fallback={<></>}>
           <Alert
             variant={alert.variant}
             title={alert.title}
@@ -714,7 +714,7 @@ const AITrustCenterSubprocessors: React.FC = () => {
 
       {/* Error notification for add subprocessor */}
       {addSubprocessorError && (
-        <Suspense fallback={<div>Loading...</div>}>
+        <Suspense fallback={<></>}>
           <Alert
             variant="error"
             body={addSubprocessorError}
@@ -726,7 +726,7 @@ const AITrustCenterSubprocessors: React.FC = () => {
 
       {/* Error notification for delete subprocessor */}
       {deleteSubprocessorError && (
-        <Suspense fallback={<div>Loading...</div>}>
+        <Suspense fallback={<></>}>
           <Alert
             variant="error"
             body={deleteSubprocessorError}
@@ -738,7 +738,7 @@ const AITrustCenterSubprocessors: React.FC = () => {
 
       {/* Error notification for edit subprocessor */}
       {editSubprocessorError && (
-        <Suspense fallback={<div>Loading...</div>}>
+        <Suspense fallback={<></>}>
           <Alert
             variant="error"
             body={editSubprocessorError}

--- a/Clients/src/presentation/pages/AITrustCenter/Subprocessors/index.tsx
+++ b/Clients/src/presentation/pages/AITrustCenter/Subprocessors/index.tsx
@@ -1,14 +1,14 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import React, { useState, Suspense, useCallback, useEffect, useRef, useMemo } from "react";
 import { useSearchParams } from "react-router-dom";
-import { Box, Typography, TableCell, Stack } from "@mui/material";
+import { Box, Typography, TableCell, Stack, Alert as MuiAlert } from "@mui/material";
 import Toggle from "../../../components/Inputs/Toggle";
 import IconButtonComponent from "../../../components/IconButton";
 import { useStyles } from "./styles";
 import Field from "../../../components/Inputs/Field";
 import { CustomizableButton } from "../../../components/button/customizable-button";
 import StandardModal from "../../../components/Modals/StandardModal";
-import { CirclePlus as AddCircleOutlineIcon } from "lucide-react";
+import { CirclePlus as AddCircleOutlineIcon, RotateCcw, Users } from "lucide-react";
 import { useTheme } from "@mui/material/styles";
 import AITrustCenterTable from "../../../components/Table/AITrustCenterTable";
 import CustomizableSkeleton from "../../../components/Skeletons";
@@ -186,12 +186,14 @@ const AITrustCenterSubprocessors: React.FC = () => {
     data: overviewData,
     isLoading: overviewLoading,
     error: overviewError,
+    refetch: refetchOverview,
   } = useAITrustCentreOverviewQuery();
   const updateOverviewMutation = useAITrustCentreOverviewMutation();
   const {
     data: subprocessors,
     isLoading: subprocessorsLoading,
     error: subprocessorsError,
+    refetch: refetchSubprocessors,
   } = useAITrustCentreSubprocessorsQuery();
   const createSubprocessorMutation = useCreateAITrustCentreSubprocessorMutation();
   const updateSubprocessorMutation = useUpdateAITrustCentreSubprocessorMutation();
@@ -564,9 +566,20 @@ const AITrustCenterSubprocessors: React.FC = () => {
           {isTableLoading ? (
             <CustomizableSkeleton variant="rectangular" width="100%" height={400} />
           ) : tableError ? (
-            <Box display="flex" justifyContent="center" alignItems="center" minHeight="200px">
-              <Typography color="error">{tableError?.message || "An error occurred"}</Typography>
-            </Box>
+            <Stack alignItems="center" spacing={2} sx={{ py: 4 }}>
+              <MuiAlert severity="error" sx={{ width: "100%", maxWidth: 600 }}>
+                {tableError?.message || "An error occurred loading subprocessors."}
+              </MuiAlert>
+              <CustomizableButton
+                variant="outlined"
+                text="Retry"
+                icon={<RotateCcw size={16} />}
+                onClick={() => {
+                  refetchOverview();
+                  refetchSubprocessors();
+                }}
+              />
+            </Stack>
           ) : (
             <GroupedTableView
               groupedData={groupedSubprocessors}
@@ -579,6 +592,7 @@ const AITrustCenterSubprocessors: React.FC = () => {
                   paginated={true}
                   disabled={!formData?.info?.subprocessor_visible}
                   emptyStateText="No subprocessors found. Add your first subprocessor to get started."
+                  emptyStateIcon={Users}
                   renderRow={(subprocessor, sortConfig) => (
                     <SubprocessorTableRow
                       key={subprocessor.id}

--- a/Clients/src/presentation/types/interfaces/i.table.ts
+++ b/Clients/src/presentation/types/interfaces/i.table.ts
@@ -1,4 +1,5 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
+import type { LucideIcon } from "lucide-react";
 import { VendorModel } from "../../../domain/models/Common/vendor/vendor.model";
 import { RiskModel } from "../../../domain/models/Common/risks/risk.model";
 import { FileModel } from "../../../domain/models/Common/file/file.model";
@@ -23,6 +24,7 @@ export interface IAITrustCenterTableProps<T> {
   isLoading?: boolean;
   paginated?: boolean;
   emptyStateText?: string;
+  emptyStateIcon?: LucideIcon;
   renderRow: (
     item: T,
     sortConfig?: { key: string; direction: "asc" | "desc" | null },


### PR DESCRIPTION
## Describe your changes

Replace blank loaders and silent/plain-text errors with CustomizableSkeleton, EmptyState, and retryable Alert/CustomizableButton components across AITrustCenter and AIGateway pages.
Update shared hooks (useGatewayModels) to expose load errors and reload handlers.
Format-check, typecheck, and targeted vitest suites all pass; lint remains blocked by a local eslint resolution issue.

Fixes No. 6 of #4018 

## Please ensure all items are checked off before requesting a review:

- [x] I deployed the code locally.
- [x] I have performed a self-review of my code.
- [x] I have included the issue # in the PR.
- [x] I have labelled the PR correctly.
- [x] The issue I am working on is assigned to me.
- [x] I have avoided using hardcoded values to ensure scalability and maintain consistency across the application.
- [x] I have ensured that font sizes, color choices, and other UI elements are referenced from the theme.
- [x] My pull request is focused and addresses a single, specific feature.
- [x] If there are UI changes, I have attached a screenshot or video to this PR.
- [ ] If I added or modified an API endpoint, the change is reflected in the generated OpenAPI spec (`npm run generate:swagger`).
- [ ] If the endpoint requires authentication, it uses `authenticateJWT` and the generated spec declares `bearerAuth` security.
- [ ] I ran `npm run check:api-drift` and committed the regenerated `swagger.yaml` and `endpoints.ts`.
