### PR TITLE
feat(settings): add help text to admin tabs and hide AI Approval Rules

### DIFF
--- a/Clients/src/i18n/translations.ts
+++ b/Clients/src/i18n/translations.ts
@@ -25,6 +25,13 @@ export type Lang = "en" | "de" | "fr" | "es";
 
 export const translations: Record<string, Record<string, string>> = {
   de: {
+    // Settings — help text
+    "Enabled — risks include monetary estimates based on the FAIR model: annual loss expectancy, residual risk after controls, and return on mitigation investment.":
+      "Aktiviert — Risiken enthalten monetäre Schätzungen auf Basis des FAIR-Modells: erwarteter Jahresverlust, Restrisiko nach Maßnahmen und Rendite der Risikominderung.",
+    "Disabled — risks use qualitative scoring only, based on severity and likelihood.":
+      "Deaktiviert — Risiken verwenden nur eine qualitative Bewertung auf Basis von Schweregrad und Eintrittswahrscheinlichkeit.",
+    "Invite people and set each member's role. Admins manage the whole workspace and its settings. Editors can create and edit governance records. Reviewers can review and approve or reject. Auditors have read-only access.":
+      "Laden Sie Personen ein und legen Sie die Rolle jedes Mitglieds fest. Admins verwalten den gesamten Arbeitsbereich und seine Einstellungen. Editoren können Governance-Datensätze erstellen und bearbeiten. Reviewer können prüfen und genehmigen oder ablehnen. Auditoren haben nur Lesezugriff.",
     // AI Trust Index
     "App details": "App-Details",
     "Changes are saved automatically.": "Änderungen werden automatisch gespeichert.",
@@ -8706,6 +8713,13 @@ export const translations: Record<string, Record<string, string>> = {
   },
 
   fr: {
+    // Settings — help text
+    "Enabled — risks include monetary estimates based on the FAIR model: annual loss expectancy, residual risk after controls, and return on mitigation investment.":
+      "Activé — les risques incluent des estimations monétaires basées sur le modèle FAIR : perte annuelle attendue, risque résiduel après contrôles et retour sur l'investissement de mitigation.",
+    "Disabled — risks use qualitative scoring only, based on severity and likelihood.":
+      "Désactivé — les risques utilisent uniquement une notation qualitative, basée sur la gravité et la probabilité.",
+    "Invite people and set each member's role. Admins manage the whole workspace and its settings. Editors can create and edit governance records. Reviewers can review and approve or reject. Auditors have read-only access.":
+      "Invitez des personnes et définissez le rôle de chaque membre. Les administrateurs gèrent l'ensemble de l'espace de travail et ses paramètres. Les éditeurs peuvent créer et modifier les enregistrements de gouvernance. Les relecteurs peuvent examiner et approuver ou rejeter. Les auditeurs disposent d'un accès en lecture seule.",
     // AI Trust Index
     "App details": "Détails de l'application",
     "Changes are saved automatically.": "Les modifications sont enregistrées automatiquement.",
@@ -17340,6 +17354,13 @@ export const translations: Record<string, Record<string, string>> = {
       "Les applications suivies sont incluses dans le récapitulatif hebdomadaire des modifications, afin que les destinataires configurés soient informés des changements de score, de note ou de politique.",
   },
   es: {
+    // Settings — help text
+    "Enabled — risks include monetary estimates based on the FAIR model: annual loss expectancy, residual risk after controls, and return on mitigation investment.":
+      "Activado — los riesgos incluyen estimaciones monetarias basadas en el modelo FAIR: pérdida anual esperada, riesgo residual tras los controles y retorno de la inversión en mitigación.",
+    "Disabled — risks use qualitative scoring only, based on severity and likelihood.":
+      "Desactivado — los riesgos usan solo una puntuación cualitativa, basada en la gravedad y la probabilidad.",
+    "Invite people and set each member's role. Admins manage the whole workspace and its settings. Editors can create and edit governance records. Reviewers can review and approve or reject. Auditors have read-only access.":
+      "Invita a personas y asigna el rol de cada miembro. Los administradores gestionan todo el espacio de trabajo y su configuración. Los editores pueden crear y editar registros de gobernanza. Los revisores pueden revisar y aprobar o rechazar. Los auditores tienen acceso de solo lectura.",
     // AI Trust Index
     "App details": "Detalles de la aplicación",
     "Changes are saved automatically.": "Los cambios se guardan automáticamente.",

--- a/Clients/src/presentation/pages/SettingsPage/AIApprovalRules/index.tsx
+++ b/Clients/src/presentation/pages/SettingsPage/AIApprovalRules/index.tsx
@@ -338,7 +338,12 @@ export default function AIApprovalRules() {
               multiline
               rows={6}
               InputProps={{ sx: { fontFamily: "monospace", fontSize: 13 } }}
-              helperText='Use {"all": [...]} or {"any": [...]}. Facts: operation_type, risk_level, tool_category, user_role, entity_count, is_bulk'
+              helperText={
+                'Wrap conditions in {"all": [...]} (every condition must match) or {"any": [...]} (one match is enough). ' +
+                'Each condition is {"fact": ..., "operator": ..., "value": ...}. ' +
+                'Example: {"all": [{"fact": "risk_level", "operator": "equal", "value": "high"}]}. ' +
+                "Available facts: operation_type, risk_level, tool_category, user_role, entity_count, is_bulk."
+              }
             />
           </Stack>
         </DialogContent>

--- a/Clients/src/presentation/pages/SettingsPage/Features/index.tsx
+++ b/Clients/src/presentation/pages/SettingsPage/Features/index.tsx
@@ -59,8 +59,8 @@ const Features: React.FC = () => {
               </Typography>
               <Typography sx={{ fontSize: 13, color: theme.palette.text.secondary }}>
                 {isQuantitative
-                  ? "Enabled — risks include FAIR-based monetary estimates (ALE, residual risk, ROI)."
-                  : "Disabled — risks use qualitative scoring only (severity, likelihood)."}
+                  ? "Enabled — risks include monetary estimates based on the FAIR model: annual loss expectancy, residual risk after controls, and return on mitigation investment."
+                  : "Disabled — risks use qualitative scoring only, based on severity and likelihood."}
               </Typography>
               {!isAdmin && (
                 <Typography

--- a/Clients/src/presentation/pages/SettingsPage/Team/index.tsx
+++ b/Clients/src/presentation/pages/SettingsPage/Team/index.tsx
@@ -444,6 +444,11 @@ const TeamManagement: React.FC = (): JSX.Element => {
         >
           Team members
         </Typography>
+        <Typography sx={{ fontSize: 13, color: "#666666", mb: 2 }}>
+          Invite people and set each member's role. Admins manage the whole workspace and its
+          settings. Editors can create and edit governance records. Reviewers can review and approve
+          or reject. Auditors have read-only access.
+        </Typography>
         <Stack sx={{ maxWidth: theme.spacing(480) }}>
           <Stack
             sx={{

--- a/Clients/src/presentation/pages/SettingsPage/index.tsx
+++ b/Clients/src/presentation/pages/SettingsPage/index.tsx
@@ -23,6 +23,13 @@ import { PluginSlot } from "../../components/PluginSlot";
 import { PLUGIN_SLOTS } from "../../../domain/constants/pluginSlots";
 
 // Built-in tabs (defined outside component to avoid recreation on each render)
+// Feature flag: the AI Approval Rules tab governs the in-platform AI agent /
+// advisor write-operation approval engine. It is hidden from end users for now,
+// alongside the AI Agent dashboard tabs (see SHOW_AI_AGENT_DASHBOARD_TABS in
+// IntegratedDashboard). The tab, its component, and the backend stay in the
+// codebase so the work is not lost; flip this to true to surface it again.
+const SHOW_AI_APPROVAL_RULES = false;
+
 const BUILT_IN_TABS = [
   "profile",
   "password",
@@ -34,7 +41,7 @@ const BUILT_IN_TABS = [
   "audit-ledger",
   "sso",
   "custom-fields",
-  "ai-approval-rules",
+  ...(SHOW_AI_APPROVAL_RULES ? ["ai-approval-rules"] : []),
 ];
 
 export default function ProfilePage() {
@@ -224,7 +231,7 @@ export default function ProfilePage() {
                   },
                 ]
               : []),
-            ...(!isAuditLedgerDisabled
+            ...(SHOW_AI_APPROVAL_RULES && !isAuditLedgerDisabled
               ? [
                   {
                     label: "AI Approval Rules",
@@ -295,7 +302,7 @@ export default function ProfilePage() {
             <CustomFieldsTab />
           </TabPanel>
         )}
-        {!isAuditLedgerDisabled && (
+        {SHOW_AI_APPROVAL_RULES && !isAuditLedgerDisabled && (
           <TabPanel sx={{ p: 0 }} value="ai-approval-rules">
             <AIApprovalRules />
           </TabPanel>


### PR DESCRIPTION
## Summary

Two related improvements to the Settings page: clearer in-context help on the admin tabs that are hard to understand from labels alone, and hiding the AI Approval Rules tab (which belongs to a feature whose other surfaces are already hidden).

## Help text (the confusing admin-only tabs)

The simple user tabs (Profile, Password, Preferences, Organization) were left unchanged to avoid clutter. The three admin tabs where the controls are non-obvious got targeted help, reusing the existing in-house patterns:

- **Features** — the Quantitative Risk Assessment toggle now spells out the FAIR acronyms in plain English (annual loss expectancy, residual risk after controls, return on mitigation investment) instead of "ALE, residual risk, ROI".
- **AI Approval Rules** — the Conditions (JSON) helper now shows a concrete valid example and explains the all/any structure, instead of only listing fact names.
- **Team** — a new subtitle under "Team members" explains what each role (Admin, Editor, Reviewer, Auditor) can do, grounded in the actual RBAC.
- i18n: de/fr/es added for the two new plain-prose strings (the Features toggle states and the Team role subtitle).

CustomFields was left as-is: it already has an info tooltip, helper text, and a `department_owner` placeholder that meet the bar.

## Hide AI Approval Rules tab

The AI Approval Rules tab configures the in-platform AI agent / advisor write-operation approval engine (from PR #3757). Its dashboard counterparts were already hidden in #4169 via `SHOW_AI_AGENT_DASHBOARD_TABS`; this gates the matching Settings tab the same way so the AI Agent feature is hidden consistently from end users.

A `SHOW_AI_APPROVAL_RULES` flag (default false) gates the tab in `BUILT_IN_TABS`, the tab list, and the TabPanel. The component, its help text, and the backend stay in the codebase; flip the flag to true to surface it again. A direct visit to `/settings/ai-approval-rules` falls through to the default tab since the value is no longer a valid built-in tab.
