### PR TITLE
feat(frontend): standardize empty states on policy, incident, and approval pages

### DIFF
--- a/Clients/src/presentation/components/EmptyState/index.tsx
+++ b/Clients/src/presentation/components/EmptyState/index.tsx
@@ -32,6 +32,11 @@ interface EmptyStateProps {
    * Optional content below the message (typically EmptyStateTip components)
    */
   children?: ReactNode;
+  /**
+   * Fill the parent container and center content vertically and horizontally.
+   * Use in modals or panels with a fixed height.
+   */
+  fillContainer?: boolean;
 }
 
 /**
@@ -45,20 +50,28 @@ export const EmptyState: FC<EmptyStateProps> = ({
   showBorder = true,
   icon = Inbox,
   children,
+  fillContainer = false,
 }) => {
   const theme = useTheme();
 
   return (
     <Stack
       alignItems="center"
+      justifyContent={fillContainer ? "center" : undefined}
       sx={{
+        width: "100%",
+        ...(fillContainer && { height: "100%" }),
         ...(showBorder && {
           border: `1px dashed ${theme.palette.border.dark}`,
           borderRadius: "4px",
           backgroundColor: theme.palette.background.main,
         }),
-        pt: "48px",
-        pb: children ? 0 : 12,
+        ...(fillContainer
+          ? { py: children ? 0 : 12 }
+          : {
+              pt: "48px",
+              pb: children ? 0 : 12,
+            }),
       }}
       role="status"
       aria-label={imageAlt}

--- a/Clients/src/presentation/components/Modals/RequestorApprovalModal/index.tsx
+++ b/Clients/src/presentation/components/Modals/RequestorApprovalModal/index.tsx
@@ -542,15 +542,12 @@ const RequestorApprovalModal: FC<IRequestorApprovalProps> = ({ isOpen, onClose, 
           }}
         >
           {hasNoData ? (
-            <Box
-              sx={{
-                display: "flex",
-                alignItems: "center",
-                justifyContent: "center",
-                height: "100%",
-              }}
-            >
-              <EmptyState message="No approval requests found." icon={ClipboardCheck} />
+            <Box sx={{ width: "100%", height: "100%" }}>
+              <EmptyState
+                message="No approval requests found."
+                icon={ClipboardCheck}
+                fillContainer
+              />
             </Box>
           ) : (
             <Stack direction="row" spacing={12} sx={{ height: "100%", flex: 1 }}>

--- a/Clients/src/presentation/pages/ApprovalWorkflows/ApprovalWorkflowsTable.tsx
+++ b/Clients/src/presentation/pages/ApprovalWorkflows/ApprovalWorkflowsTable.tsx
@@ -25,6 +25,7 @@ import { ApprovalWorkflowTableProps } from "src/presentation/types/interfaces/i.
 import { useStandardTable } from "../../../application/hooks/useStandardTable";
 import StandardTableHead from "../../components/Table/StandardTableHead";
 import StandardTablePagination from "../../components/Table/StandardTablePagination";
+import { TableEmptyStateLayout } from "../../components/Table/TableEmptyStateLayout";
 import CustomizableSkeleton from "../../components/Skeletons";
 
 const cellStyle = singleTheme.tableStyles.primary.body.cell;
@@ -105,26 +106,36 @@ const ApprovalWorkflowsTable: React.FC<ApprovalWorkflowTableProps> = ({
 
   if (!sortedRows || sortedRows.length === 0) {
     return (
-      <EmptyState
-        icon={ClipboardCheck}
-        message="No approval workflows yet. Define review and sign-off chains for your governance process."
+      <TableEmptyStateLayout
+        header={
+          <StandardTableHead
+            columns={visibleTableColumns}
+            sortConfig={sortConfig}
+            onSort={handleSort}
+          />
+        }
       >
-        <EmptyStateTip
-          icon={Send}
-          title="Create approval workflows"
-          description="Define multi-step review chains that run automatically when controls, evidence, or policies need sign-off."
-        />
-        <EmptyStateTip
-          icon={UserCheck}
-          title="Assign reviewers"
-          description="Add team members as reviewers at each step. They'll be notified when items reach their review stage."
-        />
-        <EmptyStateTip
-          icon={MessageSquare}
-          title="Track feedback and comments"
-          description="Reviewers can approve, reject, or request changes with detailed comments. The full audit trail is preserved."
-        />
-      </EmptyState>
+        <EmptyState
+          icon={ClipboardCheck}
+          message="No approval workflows yet. Define review and sign-off chains for your governance process."
+        >
+          <EmptyStateTip
+            icon={Send}
+            title="Create approval workflows"
+            description="Define multi-step review chains that run automatically when controls, evidence, or policies need sign-off."
+          />
+          <EmptyStateTip
+            icon={UserCheck}
+            title="Assign reviewers"
+            description="Add team members as reviewers at each step. They'll be notified when items reach their review stage."
+          />
+          <EmptyStateTip
+            icon={MessageSquare}
+            title="Track feedback and comments"
+            description="Reviewers can approve, reject, or request changes with detailed comments. The full audit trail is preserved."
+          />
+        </EmptyState>
+      </TableEmptyStateLayout>
     );
   }
 

--- a/Clients/src/presentation/pages/IncidentManagement/IncidentTable.tsx
+++ b/Clients/src/presentation/pages/IncidentManagement/IncidentTable.tsx
@@ -25,6 +25,7 @@ import { useStandardTable } from "../../../application/hooks/useStandardTable";
 import type { StandardColumn } from "../../../domain/types/standardTable";
 import StandardTableHead from "../../components/Table/StandardTableHead";
 import StandardTablePagination from "../../components/Table/StandardTablePagination";
+import { TableEmptyStateLayout } from "../../components/Table/TableEmptyStateLayout";
 
 dayjs.extend(utc);
 
@@ -148,134 +149,125 @@ const IncidentTable: React.FC<IncidentTableProps> = ({
   const tableBody = useMemo(
     () => (
       <TableBody>
-        {sortedRows?.length > 0 ? (
-          sortedRows
-            .slice(
-              hidePagination ? 0 : validPage * rowsPerPage,
-              hidePagination
-                ? Math.min(sortedRows.length, 100)
-                : validPage * rowsPerPage + rowsPerPage,
-            )
-            .map((incident) => (
-              <TableRow
-                key={incident.id}
-                sx={{
-                  ...singleTheme.tableStyles.primary.body.row,
-                  ...incidentRowHover,
-                  ...(archivedId === incident.id?.toString() && incidentTableRowDeletingStyle),
-                }}
-                onClick={() => onEdit?.(incident.id?.toString(), "edit")}
-              >
-                {isVisible("incident_id") && (
-                  <TableCell
-                    sx={{
-                      ...cellStyle,
-                      width: "110px",
-                      maxWidth: "110px",
-                      backgroundColor: sortConfig.key === "incident_id" ? "#e8e8e8" : "#fafafa",
-                    }}
-                  >
-                    {incident.incident_id}{" "}
-                  </TableCell>
-                )}
-                {isVisible("ai_project") && (
-                  <TableCell
-                    sx={{
-                      ...cellStyle,
-                      backgroundColor:
-                        sortConfig.key === "ai_project" ? "background.surface" : "inherit",
-                    }}
-                  >
-                    <TooltipCell value={incident.ai_project} />
-                  </TableCell>
-                )}
-                {isVisible("type") && (
-                  <TableCell
-                    sx={{
-                      ...cellStyle,
-                      backgroundColor: sortConfig.key === "type" ? "background.surface" : "inherit",
-                    }}
-                  >
-                    <TooltipCell value={incident.type} />
-                  </TableCell>
-                )}
-                {isVisible("severity") && (
-                  <TableCell
-                    sx={{
-                      ...cellStyle,
-                      backgroundColor:
-                        sortConfig.key === "severity" ? "background.surface" : "inherit",
-                    }}
-                  >
-                    <Chip label={incident.severity} />
-                  </TableCell>
-                )}
-                {isVisible("status") && (
-                  <TableCell
-                    sx={{
-                      ...cellStyle,
-                      backgroundColor:
-                        sortConfig.key === "status" ? "background.surface" : "inherit",
-                    }}
-                  >
-                    <Chip label={incident.status} />
-                  </TableCell>
-                )}
-                {isVisible("occurred_date") && (
-                  <TableCell
-                    sx={{
-                      ...cellStyle,
-                      backgroundColor:
-                        sortConfig.key === "occurred_date" ? "background.surface" : "inherit",
-                    }}
-                  >
-                    {incident.occurred_date ? displayFormattedDate(incident.occurred_date) : "-"}
-                  </TableCell>
-                )}
-                {isVisible("approved_by") && (
-                  <TableCell
-                    sx={{
-                      ...cellStyle,
-                      backgroundColor:
-                        sortConfig.key === "approved_by" ? "background.surface" : "inherit",
-                    }}
-                  >
-                    <TooltipCell value={incident.approved_by} />
-                  </TableCell>
-                )}
-                {isVisible("actions") && (
-                  <TableCell
-                    sx={{
-                      ...cellStyle,
-                    }}
-                  >
-                    <Stack direction="row" spacing={1}>
-                      <CustomIconButton
-                        id={incident.id}
-                        type="Incident"
-                        onEdit={() => onEdit?.(incident.id?.toString(), "edit")}
-                        onDelete={() => onArchive?.(incident.id?.toString(), "archive")}
-                        onView={() => onView?.(incident.id?.toString(), "view")}
-                        onMouseEvent={() => {}}
-                        warningTitle="Are you sure?"
-                        warningMessage="You are about to archive this incident. This action cannot be undone. You can also choose to edit or view the incident instead."
-                      />
-                    </Stack>
-                  </TableCell>
-                )}
-              </TableRow>
-            ))
-        ) : (
-          <TableRow>
-            <TableCell
-              colSpan={visibleTableColumns.length}
-              align="center"
-              sx={{ border: "none", p: 0 }}
-            >
-              <EmptyState icon={AlertTriangle} message="No incidents found." />
-            </TableCell>
-          </TableRow>
-        )}
+        {sortedRows?.length > 0
+          ? sortedRows
+              .slice(
+                hidePagination ? 0 : validPage * rowsPerPage,
+                hidePagination
+                  ? Math.min(sortedRows.length, 100)
+                  : validPage * rowsPerPage + rowsPerPage,
+              )
+              .map((incident) => (
+                <TableRow
+                  key={incident.id}
+                  sx={{
+                    ...singleTheme.tableStyles.primary.body.row,
+                    ...incidentRowHover,
+                    ...(archivedId === incident.id?.toString() && incidentTableRowDeletingStyle),
+                  }}
+                  onClick={() => onEdit?.(incident.id?.toString(), "edit")}
+                >
+                  {isVisible("incident_id") && (
+                    <TableCell
+                      sx={{
+                        ...cellStyle,
+                        width: "110px",
+                        maxWidth: "110px",
+                        backgroundColor: sortConfig.key === "incident_id" ? "#e8e8e8" : "#fafafa",
+                      }}
+                    >
+                      {incident.incident_id}{" "}
+                    </TableCell>
+                  )}
+                  {isVisible("ai_project") && (
+                    <TableCell
+                      sx={{
+                        ...cellStyle,
+                        backgroundColor:
+                          sortConfig.key === "ai_project" ? "background.surface" : "inherit",
+                      }}
+                    >
+                      <TooltipCell value={incident.ai_project} />
+                    </TableCell>
+                  )}
+                  {isVisible("type") && (
+                    <TableCell
+                      sx={{
+                        ...cellStyle,
+                        backgroundColor:
+                          sortConfig.key === "type" ? "background.surface" : "inherit",
+                      }}
+                    >
+                      <TooltipCell value={incident.type} />
+                    </TableCell>
+                  )}
+                  {isVisible("severity") && (
+                    <TableCell
+                      sx={{
+                        ...cellStyle,
+                        backgroundColor:
+                          sortConfig.key === "severity" ? "background.surface" : "inherit",
+                      }}
+                    >
+                      <Chip label={incident.severity} />
+                    </TableCell>
+                  )}
+                  {isVisible("status") && (
+                    <TableCell
+                      sx={{
+                        ...cellStyle,
+                        backgroundColor:
+                          sortConfig.key === "status" ? "background.surface" : "inherit",
+                      }}
+                    >
+                      <Chip label={incident.status} />
+                    </TableCell>
+                  )}
+                  {isVisible("occurred_date") && (
+                    <TableCell
+                      sx={{
+                        ...cellStyle,
+                        backgroundColor:
+                          sortConfig.key === "occurred_date" ? "background.surface" : "inherit",
+                      }}
+                    >
+                      {incident.occurred_date ? displayFormattedDate(incident.occurred_date) : "-"}
+                    </TableCell>
+                  )}
+                  {isVisible("approved_by") && (
+                    <TableCell
+                      sx={{
+                        ...cellStyle,
+                        backgroundColor:
+                          sortConfig.key === "approved_by" ? "background.surface" : "inherit",
+                      }}
+                    >
+                      <TooltipCell value={incident.approved_by} />
+                    </TableCell>
+                  )}
+                  {isVisible("actions") && (
+                    <TableCell
+                      sx={{
+                        ...cellStyle,
+                      }}
+                    >
+                      <Stack direction="row" spacing={1}>
+                        <CustomIconButton
+                          id={incident.id}
+                          type="Incident"
+                          onEdit={() => onEdit?.(incident.id?.toString(), "edit")}
+                          onDelete={() => onArchive?.(incident.id?.toString(), "archive")}
+                          onView={() => onView?.(incident.id?.toString(), "view")}
+                          onMouseEvent={() => {}}
+                          warningTitle="Are you sure?"
+                          warningMessage="You are about to archive this incident. This action cannot be undone. You can also choose to edit or view the incident instead."
+                        />
+                      </Stack>
+                    </TableCell>
+                  )}
+                </TableRow>
+              ))
+          : null}
       </TableBody>
     ),
     [
@@ -303,26 +295,36 @@ const IncidentTable: React.FC<IncidentTableProps> = ({
 
   if (!sortedRows || sortedRows.length === 0) {
     return (
-      <EmptyState
-        icon={AlertTriangle}
-        message="No incidents reported yet. Track and manage AI-related incidents to maintain compliance."
+      <TableEmptyStateLayout
+        header={
+          <StandardTableHead
+            columns={visibleTableColumns}
+            sortConfig={sortConfig}
+            onSort={handleSort}
+          />
+        }
       >
-        <EmptyStateTip
-          icon={FileWarning}
-          title="What counts as an incident?"
-          description="Any unintended AI behavior, data breach, biased output, system outage, or safety concern. Log them early, even if minor."
-        />
-        <EmptyStateTip
-          icon={ClipboardList}
-          title="Document root cause and response"
-          description="Record what happened, why it happened, the impact, and what corrective actions were taken. This builds your incident response history."
-        />
-        <EmptyStateTip
-          icon={Bell}
-          title="Assign owners and track resolution"
-          description="Assign each incident to a responsible person and track it through to resolution. A clear ownership chain speeds up response times."
-        />
-      </EmptyState>
+        <EmptyState
+          icon={AlertTriangle}
+          message="No incidents reported yet. Track and manage AI-related incidents to maintain compliance."
+        >
+          <EmptyStateTip
+            icon={FileWarning}
+            title="What counts as an incident?"
+            description="Any unintended AI behavior, data breach, biased output, system outage, or safety concern. Log them early, even if minor."
+          />
+          <EmptyStateTip
+            icon={ClipboardList}
+            title="Document root cause and response"
+            description="Record what happened, why it happened, the impact, and what corrective actions were taken. This builds your incident response history."
+          />
+          <EmptyStateTip
+            icon={Bell}
+            title="Assign owners and track resolution"
+            description="Assign each incident to a responsible person and track it through to resolution. A clear ownership chain speeds up response times."
+          />
+        </EmptyState>
+      </TableEmptyStateLayout>
     );
   }
 

--- a/Clients/src/presentation/pages/PolicyDashboard/PolicyManager.tsx
+++ b/Clients/src/presentation/pages/PolicyDashboard/PolicyManager.tsx
@@ -15,6 +15,10 @@ import { CustomizableButton } from "../../components/button/customizable-button"
 import { deletePolicy } from "../../../application/repository/policy.repository";
 import { EmptyState } from "../../components/EmptyState";
 import EmptyStateTip from "../../components/EmptyState/EmptyStateTip";
+import StandardTableHead from "../../components/Table/StandardTableHead";
+import { TableEmptyStateLayout } from "../../components/Table/TableEmptyStateLayout";
+import { useStandardTable } from "../../../application/hooks/useStandardTable";
+import type { StandardColumn } from "../../../domain/types/standardTable";
 import { SearchBox } from "../../components/Search";
 import { handleAlert } from "../../../application/tools/alertUtils";
 import Alert from "../../components/Alert";
@@ -450,6 +454,58 @@ const PolicyManager: React.FC<PolicyManagerProps> = ({ tags: _tags }) => {
     getGroupKey: getPolicyGroupKey,
   });
 
+  const standardTableColumns = useMemo(
+    (): StandardColumn[] =>
+      POLICY_TABLE_COLUMNS.filter((col) => col.alwaysVisible || visibleColumns.has(col.key)).map(
+        (col) => ({
+          id: col.key,
+          label: col.key === "actions" ? "" : col.label.toUpperCase(),
+          sortable: col.key !== "actions",
+        }),
+      ),
+    [visibleColumns],
+  );
+
+  const policySortComparator = useCallback(
+    (a: PolicyManagerModel, b: PolicyManagerModel, key: string): number => {
+      switch (key) {
+        case "title":
+          return (a.title?.toLowerCase() || "").localeCompare(b.title?.toLowerCase() || "");
+        case "status":
+          return (a.status?.toLowerCase() || "").localeCompare(b.status?.toLowerCase() || "");
+        case "next_review": {
+          const aVal = a.next_review_date ? new Date(a.next_review_date).getTime() : 0;
+          const bVal = b.next_review_date ? new Date(b.next_review_date).getTime() : 0;
+          return aVal - bVal;
+        }
+        case "author":
+          return (a.author_id?.toString() || "").localeCompare(b.author_id?.toString() || "");
+        case "last_updated": {
+          const aVal = a.last_updated_at ? new Date(a.last_updated_at).getTime() : 0;
+          const bVal = b.last_updated_at ? new Date(b.last_updated_at).getTime() : 0;
+          return aVal - bVal;
+        }
+        case "updated_by":
+          return (a.last_updated_by?.toString() || "").localeCompare(
+            b.last_updated_by?.toString() || "",
+          );
+        default:
+          return 0;
+      }
+    },
+    [],
+  );
+
+  const { sortConfig, handleSort } = useStandardTable<PolicyManagerModel>({
+    rows: filteredPolicies,
+    storageKey: "policy_manager_table",
+    defaultSortColumn: "",
+    defaultSortDirection: null,
+    sortComparator: policySortComparator,
+  });
+
+  const hasActiveFilters = !!searchTerm.trim() || !!selectedStatus || folderPolicyIds !== null;
+
   // Define export columns for policy table
   const exportColumns = useMemo(() => {
     return [
@@ -633,35 +689,45 @@ const PolicyManager: React.FC<PolicyManagerProps> = ({ tags: _tags }) => {
             {isLoading ? (
               <CustomizableSkeleton variant="rectangular" width="100%" height={400} />
             ) : filteredPolicies.length === 0 ? (
-              <EmptyState
-                icon={FileText}
-                message={
-                  searchTerm
-                    ? "No matching policies found."
-                    : "No policies yet. Policies define the rules your organization follows for AI governance."
+              <TableEmptyStateLayout
+                header={
+                  <StandardTableHead
+                    columns={standardTableColumns}
+                    sortConfig={sortConfig}
+                    onSort={handleSort}
+                  />
                 }
-                imageAlt="No policies available"
               >
-                {!searchTerm && (
-                  <>
-                    <EmptyStateTip
-                      icon={Sparkles}
-                      title="Create from templates"
-                      description="Start with a blank policy or use one of the built-in templates. Fill in the details for your organization and publish when ready."
-                    />
-                    <EmptyStateTip
-                      icon={Shield}
-                      title="Link policies to controls"
-                      description="Each policy can be mapped to specific compliance controls, creating an audit trail showing which policies address which requirements."
-                    />
-                    <EmptyStateTip
-                      icon={Link2}
-                      title="Common policies to start with"
-                      description="AI Ethics Policy, Data Governance Policy, AI Risk Management Policy, Incident Response Policy, and Third-Party AI Vendor Policy."
-                    />
-                  </>
-                )}
-              </EmptyState>
+                <EmptyState
+                  icon={FileText}
+                  message={
+                    hasActiveFilters
+                      ? "No matching policies found."
+                      : "No policies yet. Policies define the rules your organization follows for AI governance."
+                  }
+                  imageAlt="No policies available"
+                >
+                  {!hasActiveFilters && (
+                    <>
+                      <EmptyStateTip
+                        icon={Sparkles}
+                        title="Create from templates"
+                        description="Start with a blank policy or use one of the built-in templates. Fill in the details for your organization and publish when ready."
+                      />
+                      <EmptyStateTip
+                        icon={Shield}
+                        title="Link policies to controls"
+                        description="Each policy can be mapped to specific compliance controls, creating an audit trail showing which policies address which requirements."
+                      />
+                      <EmptyStateTip
+                        icon={Link2}
+                        title="Common policies to start with"
+                        description="AI Ethics Policy, Data Governance Policy, AI Risk Management Policy, Incident Response Policy, and Third-Party AI Vendor Policy."
+                      />
+                    </>
+                  )}
+                </EmptyState>
+              </TableEmptyStateLayout>
             ) : (
               <GroupedTableView
                 groupedData={groupedPolicies}


### PR DESCRIPTION
## Describe your changes

Apply TableEmptyStateLayout with column headers on policy manager, incident management, and approval workflows, and improve approval requests modal empty state with full-width centered layout.

## Write your issue number after "Fixes "

Fixes #4195 

## Please ensure all items are checked off before requesting a review:

- [x] I deployed the code locally.
- [x] I have performed a self-review of my code.
- [x] I have included the issue # in the PR.
- [x] I have labelled the PR correctly.
- [x] The issue I am working on is assigned to me.
- [x] I have avoided using hardcoded values to ensure scalability and maintain consistency across the application.
- [x] I have ensured that font sizes, color choices, and other UI elements are referenced from the theme.
- [x] My pull request is focused and addresses a single, specific feature.
- [x] If there are UI changes, I have attached a screenshot or video to this PR.
- [ ] If I added or modified an API endpoint, the change is reflected in the generated OpenAPI spec (`npm run generate:swagger`).
- [ ] If the endpoint requires authentication, it uses `authenticateJWT` and the generated spec declares `bearerAuth` security.
- [ ] I ran `npm run check:api-drift` and committed the regenerated `swagger.yaml` and `endpoints.ts`.
- [ ] If this PR adds or modifies an organization-scoped table, the [tenant isolation registry](Servers/tests/integration/tenant-isolation/tenantIsolation.registry.ts) and [test matrix](Servers/tests/integration/tenant-isolation) are updated. See the [tenant isolation runbook](docs/technical/security/tenant-isolation.md) for details.

<img width="2478" height="973" alt="Screenshot 2026-06-26 at 5 55 09 PM" src="https://github.com/user-attachments/assets/9e7c8cc9-983d-4d67-8b7c-89fecff4b051" />
<img width="1072" height="749" alt="Screenshot 2026-06-26 at 5 55 00 PM" src="https://github.com/user-attachments/assets/91e75467-0581-473f-b319-db1263006184" />
<img width="2469" height="1131" alt="Screenshot 2026-06-26 at 5 49 15 PM" src="https://github.com/user-attachments/assets/8a779abf-c6ef-4a93-a758-03048cb93558" />
<img width="2484" height="1105" alt="Screenshot 2026-06-26 at 5 49 09 PM" src="https://github.com/user-attachments/assets/8561e43e-dc97-4b0a-8e17-2b1724ac06bb" />



