### PR TITLE
Fix tableName mismatch on VendorsProjects and ProjectFrameworks models

### DIFF
--- a/Servers/domain.layer/models/projectFrameworks/projectFrameworks.model.ts
+++ b/Servers/domain.layer/models/projectFrameworks/projectFrameworks.model.ts
@@ -5,7 +5,7 @@ import { IProjectFrameworks } from "../../interfaces/i.projectFramework";
 import { ValidationException, NotFoundException } from "../../exceptions/custom.exception";
 
 @Table({
-  tableName: "project_frameworks",
+  tableName: "projects_frameworks",
   timestamps: true,
   underscored: true,
 })

--- a/Servers/domain.layer/models/vendorsProjects/vendorsProjects.model.ts
+++ b/Servers/domain.layer/models/vendorsProjects/vendorsProjects.model.ts
@@ -4,7 +4,7 @@ import { VendorModel } from "../vendor/vendor.model";
 import { IVendorsProjects } from "../../interfaces/i.vendorProjects";
 
 @Table({
-  tableName: "vendor_projects",
+  tableName: "vendors_projects",
   timestamps: true,
   underscored: true,
 })


### PR DESCRIPTION
## Summary

Corrects the Sequelize `tableName` on two models so they match the actual database tables.

- `VendorsProjectsModel` declared `tableName: "vendor_projects"` — the real table is `vendors_projects`.
- `ProjectFrameworksModel` declared `tableName: "project_frameworks"` — the real table is `projects_frameworks`.

Both tables are created in the plural form in the tenant-tables migration.

## Why

The mismatch is a latent bug. Every working query against these tables is raw SQL that already uses the correct plural names, and these models are otherwise used only via `mapToModel` row-mapping, which does not generate SQL from `tableName`. As a result there is no behavioural change to any current code path.

The risk is future: the models' own static ORM helpers (for example `findByProjectId`) call `findOne`/`findAll`, which would resolve the wrong table name and fail with `relation does not exist` if ever wired up. Aligning `tableName` with the database removes that footgun.

## Scope

Two one-line changes, no migration, no behavioural change to existing queries.
