### PR TITLE
Feat: Global api error toast

### DIFF
--- a/Clients/src/application/repository/entity.repository.ts
+++ b/Clients/src/application/repository/entity.repository.ts
@@ -23,13 +23,8 @@ export async function createNewUser({ routeUrl, body }: RequestParams): Promise<
  * @throws Will throw an error if the login fails.
  */
 export async function loginUser({ routeUrl, body }: RequestParams): Promise<any> {
-  try {
-    const response = await apiServices.post(routeUrl, body);
-    return response;
-  } catch (error) {
-    console.error("Error logging in user:", error);
-    throw error;
-  }
+  const response = await apiServices.post(routeUrl, body);
+  return response;
 }
 
 /**
@@ -44,19 +39,11 @@ export async function getEntityById({
   signal,
   responseType = "json",
 }: GetRequestParams): Promise<any> {
-  try {
-    const response = await apiServices.get(routeUrl, {
-      signal,
-      responseType,
-    });
-    return response.data;
-  } catch (error: any) {
-    // Don't log 404 errors as they're often expected (e.g., empty lists)
-    if (error?.status !== 404) {
-      console.error("Error getting entity by ID:", error);
-    }
-    throw error;
-  }
+  const response = await apiServices.get(routeUrl, {
+    signal,
+    responseType,
+  });
+  return response.data;
 }
 
 /**
@@ -67,14 +54,10 @@ export async function getEntityById({
  * @throws Will throw an error if the update operation fails.
  */
 export async function updateEntityById({ routeUrl, body, headers }: RequestParams): Promise<any> {
-  try {
-    const response = await apiServices.patch(routeUrl, body, {
-      headers: { ...headers },
-    });
-    return response;
-  } catch (error) {
-    console.error("", error);
-  }
+  const response = await apiServices.patch(routeUrl, body, {
+    headers: { ...headers },
+  });
+  return response;
 }
 
 /**
@@ -85,13 +68,8 @@ export async function updateEntityById({ routeUrl, body, headers }: RequestParam
  * @throws Will throw an error if the delete operation fails.
  */
 export async function deleteEntityById({ routeUrl }: RequestParams): Promise<any> {
-  try {
-    const response = await apiServices.delete(routeUrl);
-    return response;
-  } catch (error) {
-    console.error("Error deleting user by ID:", error);
-    throw error;
-  }
+  const response = await apiServices.delete(routeUrl);
+  return response;
 }
 
 /**
@@ -105,15 +83,10 @@ export async function getAllEntities({
   routeUrl,
   params,
 }: RequestParams & { params?: Record<string, any> }): Promise<any> {
-  try {
-    // Deduped: list fetches (e.g. /projects) are requested by several dashboard
-    // consumers at mount. Concurrent identical GETs share one in-flight request.
-    const response = await getDeduped(routeUrl, { params });
-    return response.data;
-  } catch (error) {
-    console.error("Error getting all users:", error);
-    throw error;
-  }
+  // Deduped: list fetches (e.g. /projects) are requested by several dashboard
+  // consumers at mount. Concurrent identical GETs share one in-flight request.
+  const response = await getDeduped(routeUrl, { params });
+  return response.data;
 }
 
 /**
@@ -124,13 +97,8 @@ export async function getAllEntities({
  * @throws Will throw an error if the request fails.
  */
 export async function checkUserExists({ routeUrl }: RequestParams): Promise<any> {
-  try {
-    const response = await apiServices.get(routeUrl);
-    return response.data;
-  } catch (error) {
-    console.error("Error checking if user exists:", error);
-    throw error;
-  }
+  const response = await apiServices.get(routeUrl);
+  return response.data;
 }
 
 /**
@@ -140,14 +108,8 @@ export async function checkUserExists({ routeUrl }: RequestParams): Promise<any>
  * @throws Will throw an error if the request fails.
  */
 export async function postAutoDrivers(): Promise<any> {
-  try {
-    const response = await apiServices.post("/autoDrivers");
-
-    return response;
-  } catch (error) {
-    console.error("Error creating demo data:", error);
-    throw error;
-  }
+  const response = await apiServices.post("/autoDrivers");
+  return response;
 }
 
 /**
@@ -170,8 +132,7 @@ export async function checkDemoDataExists(): Promise<boolean> {
     );
 
     return hasDemoProjects;
-  } catch (error) {
-    console.error("Error checking demo data:", error);
+  } catch {
     return false;
   }
 }
@@ -183,14 +144,8 @@ export async function checkDemoDataExists(): Promise<boolean> {
  * @throws Will throw an error if the request fails.
  */
 export async function deleteAutoDrivers(): Promise<any> {
-  try {
-    const response = await apiServices.delete("/autoDrivers");
-
-    return response;
-  } catch (error) {
-    console.error("Error deleting demo data:", error);
-    throw error;
-  }
+  const response = await apiServices.delete("/autoDrivers");
+  return response;
 }
 
 export async function resetPassword({ routeUrl, body }: RequestParams): Promise<any> {
@@ -206,13 +161,8 @@ export async function resetPassword({ routeUrl, body }: RequestParams): Promise<
  * @throws Will throw an error if the request fails.
  */
 export async function getAllUsers(): Promise<any> {
-  try {
-    const response = await apiServices.get("/users");
-    return response.data;
-  } catch (error) {
-    console.error("Error getting all users:", error);
-    throw error;
-  }
+  const response = await apiServices.get("/users");
+  return response.data;
 }
 
 /**
@@ -223,26 +173,17 @@ export async function getAllUsers(): Promise<any> {
  * @throws Will throw an error if the request fails.
  */
 export async function generateReport({ routeUrl, body, signal }: RequestParams): Promise<any> {
-  try {
-    const response = await apiServices.post(routeUrl, body, {
-      signal,
-      responseType: "blob",
-    });
+  const response = await apiServices.post(routeUrl, body, {
+    signal,
+    responseType: "blob",
+  });
 
-    return response;
-  } catch (error) {
-    console.error("", error);
-  }
+  return response;
 }
 
 export async function getAllFrameworks(): Promise<any> {
-  try {
-    const response = await apiServices.get("/frameworks");
-    return response.data;
-  } catch (error) {
-    console.error("Error getting all frameworks:", error);
-    throw error;
-  }
+  const response = await apiServices.get("/frameworks");
+  return response.data;
 }
 
 export const assignFrameworkToProject = async ({
@@ -252,20 +193,15 @@ export const assignFrameworkToProject = async ({
   frameworkId: number;
   projectId: string;
 }) => {
-  try {
-    const response = await apiServices.post(
-      `/frameworks/toProject?frameworkId=${frameworkId}&projectId=${projectId}`,
-      {},
-    );
+  const response = await apiServices.post(
+    `/frameworks/toProject?frameworkId=${frameworkId}&projectId=${projectId}`,
+    {},
+  );
 
-    return {
-      status: response.status,
-      data: response.data,
-    };
-  } catch (error) {
-    console.error("Error assigning framework to project:", error);
-    throw error;
-  }
+  return {
+    status: response.status,
+    data: response.data,
+  };
 };
 
 /**
@@ -280,14 +216,9 @@ export async function archiveIncidentById({
   body,
   headers,
 }: RequestParams): Promise<any> {
-  try {
-    // PATCH /incidents/:id/archive
-    const response = await apiServices.patch(`${routeUrl}/archive`, body, {
-      headers: { ...headers },
-    });
-    return response;
-  } catch (error) {
-    console.error("Error archiving incident:", error);
-    throw error;
-  }
+  // PATCH /incidents/:id/archive
+  const response = await apiServices.patch(`${routeUrl}/archive`, body, {
+    headers: { ...headers },
+  });
+  return response;
 }

--- a/Clients/src/application/repository/file.repository.ts
+++ b/Clients/src/application/repository/file.repository.ts
@@ -739,11 +739,6 @@ export interface BulkUpdateFileTagsPayload {
 }
 
 export async function bulkUpdateFileTags(payload: BulkUpdateFileTagsPayload): Promise<any> {
-  try {
-    const response = await apiServices.patch("/files/bulk-tags", payload);
-    return response.data;
-  } catch (error) {
-    console.error("Error performing bulk file tag update:", error);
-    throw error;
-  }
+  const response = await apiServices.patch("/files/bulk-tags", payload);
+  return response.data;
 }

--- a/Clients/src/application/repository/tests/entity.repository.test.ts
+++ b/Clients/src/application/repository/tests/entity.repository.test.ts
@@ -76,16 +76,12 @@ describe("Test Entity Repository", () => {
       expect(response).toEqual(mockResponse);
     });
 
-    it("should log and rethrow when post fails", async () => {
+    it("should rethrow when post fails", async () => {
       const error = new Error("Unauthorized");
-      const consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(() => undefined);
 
       vi.mocked(apiServices.post).mockRejectedValue(error);
 
       await expect(loginUser({ routeUrl: "/auth/login", body: {} })).rejects.toThrow(error);
-      expect(consoleErrorSpy).toHaveBeenCalledWith("Error logging in user:", error);
-
-      consoleErrorSpy.mockRestore();
     });
   });
 
@@ -135,9 +131,8 @@ describe("Test Entity Repository", () => {
       expect(response).toEqual("blob");
     });
 
-    it("should NOT log and still rethrow on 404 errors", async () => {
+    it("should rethrow on 404 errors", async () => {
       const error = { status: 404, message: "Not found" };
-      const consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(() => undefined);
 
       vi.mocked(apiServices.get).mockRejectedValue(error);
 
@@ -147,14 +142,10 @@ describe("Test Entity Repository", () => {
           signal: new AbortController().signal,
         }),
       ).rejects.toEqual(error);
-      expect(consoleErrorSpy).not.toHaveBeenCalled();
-
-      consoleErrorSpy.mockRestore();
     });
 
-    it("should log and rethrow on non-404 errors", async () => {
+    it("should rethrow on non-404 errors", async () => {
       const error = { status: 500, message: "Server error" };
-      const consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(() => undefined);
 
       vi.mocked(apiServices.get).mockRejectedValue(error);
 
@@ -164,9 +155,6 @@ describe("Test Entity Repository", () => {
           signal: new AbortController().signal,
         }),
       ).rejects.toEqual(error);
-      expect(consoleErrorSpy).toHaveBeenCalledWith("Error getting entity by ID:", error);
-
-      consoleErrorSpy.mockRestore();
     });
   });
 
@@ -189,21 +177,17 @@ describe("Test Entity Repository", () => {
       expect(response).toEqual(mockResponse);
     });
 
-    it("should swallow the error and return undefined when patch fails", async () => {
+    it("should rethrow when patch fails", async () => {
       const error = new Error("Patch failed");
-      const consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(() => undefined);
 
       vi.mocked(apiServices.patch).mockRejectedValue(error);
 
-      const response = await updateEntityById({
-        routeUrl: "/projects/1",
-        body: {},
-      });
-
-      expect(response).toBeUndefined();
-      expect(consoleErrorSpy).toHaveBeenCalled();
-
-      consoleErrorSpy.mockRestore();
+      await expect(
+        updateEntityById({
+          routeUrl: "/projects/1",
+          body: {},
+        }),
+      ).rejects.toThrow(error);
     });
   });
 
@@ -226,16 +210,12 @@ describe("Test Entity Repository", () => {
       expect(response).toEqual(mockResponse);
     });
 
-    it("should log and rethrow when delete fails", async () => {
+    it("should rethrow when delete fails", async () => {
       const error = new Error("Delete failed");
-      const consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(() => undefined);
 
       vi.mocked(apiServices.delete).mockRejectedValue(error);
 
       await expect(deleteEntityById({ routeUrl: "/projects/5" })).rejects.toThrow(error);
-      expect(consoleErrorSpy).toHaveBeenCalledWith("Error deleting user by ID:", error);
-
-      consoleErrorSpy.mockRestore();
     });
   });
 
@@ -273,16 +253,12 @@ describe("Test Entity Repository", () => {
       });
     });
 
-    it("should log and rethrow when get fails", async () => {
+    it("should rethrow when get fails", async () => {
       const error = new Error("Network error");
-      const consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(() => undefined);
 
       vi.mocked(apiServices.get).mockRejectedValue(error);
 
       await expect(getAllEntities({ routeUrl: "/projects" })).rejects.toThrow(error);
-      expect(consoleErrorSpy).toHaveBeenCalledWith("Error getting all users:", error);
-
-      consoleErrorSpy.mockRestore();
     });
   });
 
@@ -305,16 +281,12 @@ describe("Test Entity Repository", () => {
       expect(response).toEqual(mockData);
     });
 
-    it("should log and rethrow when get fails", async () => {
+    it("should rethrow when get fails", async () => {
       const error = new Error("Server error");
-      const consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(() => undefined);
 
       vi.mocked(apiServices.get).mockRejectedValue(error);
 
       await expect(checkUserExists({ routeUrl: "/users/exists" })).rejects.toThrow(error);
-      expect(consoleErrorSpy).toHaveBeenCalledWith("Error checking if user exists:", error);
-
-      consoleErrorSpy.mockRestore();
     });
   });
 
@@ -336,16 +308,12 @@ describe("Test Entity Repository", () => {
       expect(response).toEqual(mockResponse);
     });
 
-    it("should log and rethrow when post fails", async () => {
+    it("should rethrow when post fails", async () => {
       const error = new Error("Creation error");
-      const consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(() => undefined);
 
       vi.mocked(apiServices.post).mockRejectedValue(error);
 
       await expect(postAutoDrivers()).rejects.toThrow(error);
-      expect(consoleErrorSpy).toHaveBeenCalledWith("Error creating demo data:", error);
-
-      consoleErrorSpy.mockRestore();
     });
   });
 
@@ -390,16 +358,11 @@ describe("Test Entity Repository", () => {
     });
 
     it("should return false on error (does not rethrow)", async () => {
-      const consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(() => undefined);
-
       vi.mocked(apiServices.get).mockRejectedValue(new Error("Network error"));
 
       const result = await checkDemoDataExists();
 
       expect(result).toBe(false);
-      expect(consoleErrorSpy).toHaveBeenCalledWith("Error checking demo data:", expect.any(Error));
-
-      consoleErrorSpy.mockRestore();
     });
   });
 
@@ -421,16 +384,12 @@ describe("Test Entity Repository", () => {
       expect(response).toEqual(mockResponse);
     });
 
-    it("should log and rethrow when delete fails", async () => {
+    it("should rethrow when delete fails", async () => {
       const error = new Error("Delete error");
-      const consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(() => undefined);
 
       vi.mocked(apiServices.delete).mockRejectedValue(error);
 
       await expect(deleteAutoDrivers()).rejects.toThrow(error);
-      expect(consoleErrorSpy).toHaveBeenCalledWith("Error deleting demo data:", error);
-
-      consoleErrorSpy.mockRestore();
     });
   });
 
@@ -473,16 +432,12 @@ describe("Test Entity Repository", () => {
       expect(response).toEqual(mockData);
     });
 
-    it("should log and rethrow when get fails", async () => {
+    it("should rethrow when get fails", async () => {
       const error = new Error("Server error");
-      const consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(() => undefined);
 
       vi.mocked(apiServices.get).mockRejectedValue(error);
 
       await expect(getAllUsers()).rejects.toThrow(error);
-      expect(consoleErrorSpy).toHaveBeenCalledWith("Error getting all users:", error);
-
-      consoleErrorSpy.mockRestore();
     });
   });
 
@@ -506,21 +461,17 @@ describe("Test Entity Repository", () => {
       expect(response).toEqual(mockResponse);
     });
 
-    it("should swallow the error and return undefined when post fails", async () => {
+    it("should rethrow when post fails", async () => {
       const error = new Error("Report generation failed");
-      const consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(() => undefined);
 
       vi.mocked(apiServices.post).mockRejectedValue(error);
 
-      const response = await generateReport({
-        routeUrl: "/reports/generate",
-        body: {},
-      });
-
-      expect(response).toBeUndefined();
-      expect(consoleErrorSpy).toHaveBeenCalled();
-
-      consoleErrorSpy.mockRestore();
+      await expect(
+        generateReport({
+          routeUrl: "/reports/generate",
+          body: {},
+        }),
+      ).rejects.toThrow(error);
     });
   });
 
@@ -542,16 +493,12 @@ describe("Test Entity Repository", () => {
       expect(response).toEqual(mockData);
     });
 
-    it("should log and rethrow when get fails", async () => {
+    it("should rethrow when get fails", async () => {
       const error = new Error("Framework fetch error");
-      const consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(() => undefined);
 
       vi.mocked(apiServices.get).mockRejectedValue(error);
 
       await expect(getAllFrameworks()).rejects.toThrow(error);
-      expect(consoleErrorSpy).toHaveBeenCalledWith("Error getting all frameworks:", error);
-
-      consoleErrorSpy.mockRestore();
     });
   });
 
@@ -581,18 +528,14 @@ describe("Test Entity Repository", () => {
       expect(response).toEqual({ status: 201, data: { assigned: true } });
     });
 
-    it("should log and rethrow when post fails", async () => {
+    it("should rethrow when post fails", async () => {
       const error = new Error("Assignment error");
-      const consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(() => undefined);
 
       vi.mocked(apiServices.post).mockRejectedValue(error);
 
       await expect(assignFrameworkToProject({ frameworkId: 1, projectId: "p1" })).rejects.toThrow(
         error,
       );
-      expect(consoleErrorSpy).toHaveBeenCalledWith("Error assigning framework to project:", error);
-
-      consoleErrorSpy.mockRestore();
     });
   });
 
@@ -619,18 +562,14 @@ describe("Test Entity Repository", () => {
       expect(response).toEqual(mockResponse);
     });
 
-    it("should log and rethrow when patch fails", async () => {
+    it("should rethrow when patch fails", async () => {
       const error = new Error("Archive error");
-      const consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(() => undefined);
 
       vi.mocked(apiServices.patch).mockRejectedValue(error);
 
       await expect(archiveIncidentById({ routeUrl: "/incidents/7", body: {} })).rejects.toThrow(
         error,
       );
-      expect(consoleErrorSpy).toHaveBeenCalledWith("Error archiving incident:", error);
-
-      consoleErrorSpy.mockRestore();
     });
   });
 });

--- a/Clients/src/application/repository/trainingregistar.repository.ts
+++ b/Clients/src/application/repository/trainingregistar.repository.ts
@@ -8,11 +8,6 @@ import { apiServices } from "../../infrastructure/api/networkServices";
  * @returns {Promise<any>} The response from the API.
  */
 export async function createTraining(routeUrl: string, data: any): Promise<any> {
-  try {
-    const response = await apiServices.post(routeUrl, data);
-    return response.data;
-  } catch (error) {
-    console.error("Error creating training:", error);
-    throw error;
-  }
+  const response = await apiServices.post(routeUrl, data);
+  return response.data;
 }

--- a/Clients/src/infrastructure/api/__tests__/customAxios.test.ts
+++ b/Clients/src/infrastructure/api/__tests__/customAxios.test.ts
@@ -23,7 +23,7 @@ vi.mock("../../../i18n/domTranslator", () => ({
 vi.mock("../../../i18n/translations", () => ({
   translations: {
     de: {
-      Error: "Fehler",
+      "Error": "Fehler",
       "An error occurred. Please try again later":
         "Ein Fehler ist aufgetreten. Bitte versuchen Sie es später erneut",
     },

--- a/Clients/src/infrastructure/api/__tests__/customAxios.test.ts
+++ b/Clients/src/infrastructure/api/__tests__/customAxios.test.ts
@@ -16,14 +16,30 @@ vi.mock("../../../application/redux/auth/authSlice", () => ({
   setAuthToken: vi.fn((token: string) => ({ type: "auth/setAuthToken", payload: token })),
 }));
 
+vi.mock("../../../i18n/domTranslator", () => ({
+  getLanguage: vi.fn(() => "en"),
+}));
+
+vi.mock("../../../i18n/translations", () => ({
+  translations: {
+    de: {
+      Error: "Fehler",
+      "An error occurred. Please try again later":
+        "Ein Fehler ist aufgetreten. Bitte versuchen Sie es später erneut",
+    },
+  },
+}));
+
 import CustomAxios, { showAlert, setShowAlertCallback } from "../customAxios";
 import { store } from "../../../application/redux/store";
+import { getLanguage } from "../../../i18n/domTranslator";
 
 const mockStore = vi.mocked(store);
 
 describe("customAxios", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    setShowAlertCallback(null as any);
     mockStore.getState.mockReturnValue({
       auth: { authToken: "test-token", activeOrganizationId: null },
     } as any);
@@ -86,6 +102,80 @@ describe("customAxios", () => {
       setShowAlertCallback(callback);
       showAlert({ variant: "success", body: "Done" });
       expect(callback).toHaveBeenCalledWith({ variant: "success", body: "Done" });
+    });
+  });
+
+  describe("response interceptor global error toast", () => {
+    const rejected = (CustomAxios.interceptors.response as any).handlers[0].rejected;
+
+    it("shows a translated error toast for HTTP 5xx responses", async () => {
+      const callback = vi.fn();
+      setShowAlertCallback(callback);
+
+      const error = {
+        config: { url: "/test" },
+        response: { status: 500, data: { message: "Server error" } },
+        message: "Internal Server Error",
+      };
+
+      await expect(rejected(error)).rejects.toEqual(error);
+      expect(callback).toHaveBeenCalledWith({
+        variant: "error",
+        title: "Error",
+        body: "An error occurred. Please try again later",
+      });
+    });
+
+    it("shows a translated error toast for network errors", async () => {
+      const callback = vi.fn();
+      setShowAlertCallback(callback);
+
+      const error = {
+        config: { url: "/test" },
+        response: undefined,
+        request: {},
+        message: "Network Error",
+      };
+
+      await expect(rejected(error)).rejects.toEqual(error);
+      expect(callback).toHaveBeenCalledWith({
+        variant: "error",
+        title: "Error",
+        body: "An error occurred. Please try again later",
+      });
+    });
+
+    it("translates the toast body when the active language is not English", async () => {
+      vi.mocked(getLanguage).mockReturnValue("de");
+      const callback = vi.fn();
+      setShowAlertCallback(callback);
+
+      const error = {
+        config: { url: "/test" },
+        response: { status: 503, data: {} },
+        message: "Service Unavailable",
+      };
+
+      await expect(rejected(error)).rejects.toEqual(error);
+      expect(callback).toHaveBeenCalledWith({
+        variant: "error",
+        title: "Fehler",
+        body: "Ein Fehler ist aufgetreten. Bitte versuchen Sie es später erneut",
+      });
+    });
+
+    it("does not show a toast for 4xx client errors", async () => {
+      const callback = vi.fn();
+      setShowAlertCallback(callback);
+
+      const error = {
+        config: { url: "/test" },
+        response: { status: 400, data: { message: "Bad request" } },
+        message: "Bad Request",
+      };
+
+      await expect(rejected(error)).rejects.toEqual(error);
+      expect(callback).not.toHaveBeenCalled();
     });
   });
 });

--- a/Clients/src/infrastructure/api/customAxios.ts
+++ b/Clients/src/infrastructure/api/customAxios.ts
@@ -25,6 +25,8 @@ import { store } from "../../application/redux/store";
 import { ENV_VARs } from "../../../env.vars";
 import { clearAuthState, setAuthToken } from "../../application/redux/auth/authSlice";
 import { AlertProps } from "../../presentation/types/alert.types";
+import { translations, type Lang } from "../../i18n/translations";
+import { getLanguage } from "../../i18n/domTranslator";
 import type {
   ApiErrorEnvelope,
   ApiSuccessEnvelope,
@@ -50,6 +52,31 @@ export const setShowAlertCallback = (callback: (alert: AlertProps) => void) => {
 export const showAlert = (alert: AlertProps) => {
   if (showAlertCallback) {
     showAlertCallback(alert);
+  }
+};
+
+// Lightweight translation helper for non-React infrastructure code.
+// Looks up the current language from the DOM translator and falls back to the
+// English source key when no translation is available.
+const translate = (key: string): string => {
+  const lang: Lang = getLanguage();
+  if (lang === "en") return key;
+  return translations[lang]?.[key] || key;
+};
+
+// Show a translated error toast for server or network failures.
+// 4xx errors are intentionally left for callers/UI layers to handle.
+const showGlobalErrorAlert = (error: AxiosError) => {
+  const status = error.response?.status;
+  const isServerError = status != null && status >= 500;
+  const isNetworkError = error.response == null;
+
+  if (isServerError || isNetworkError) {
+    showAlert({
+      variant: "error",
+      title: translate("Error"),
+      body: translate("An error occurred. Please try again later"),
+    });
   }
 };
 
@@ -231,6 +258,10 @@ CustomAxios.interceptors.response.use(
         isRefreshing = false;
       }
     }
+
+    // Surface generic translated error toasts for server and network failures.
+    // Auth-specific errors (403/429/406) are handled above and return early.
+    showGlobalErrorAlert(error);
 
     return Promise.reject(error);
   },


### PR DESCRIPTION
## Describe your changes

Centralizes translated error toasts for HTTP 5xx and network failures in customAxios, and removes ad-hoc console.error handling from entity.repository.ts, trainingregistar.repository.ts, and file.repository.ts so errors propagate to the global alert system. Includes updated unit tests and passes Prettier format and TypeScript type checks.

Fixes #4018 

## Please ensure all items are checked off before requesting a review:

- [x] I deployed the code locally.
- [x] I have performed a self-review of my code.
- [x] I have included the issue # in the PR.
- [x] I have labelled the PR correctly.
- [x] The issue I am working on is assigned to me.
- [x] I have avoided using hardcoded values to ensure scalability and maintain consistency across the application.
- [x] I have ensured that font sizes, color choices, and other UI elements are referenced from the theme.
- [x] My pull request is focused and addresses a single, specific feature.
- [ ] If there are UI changes, I have attached a screenshot or video to this PR.
- [ ] If I added or modified an API endpoint, the change is reflected in the generated OpenAPI spec (`npm run generate:swagger`).
- [ ] If the endpoint requires authentication, it uses `authenticateJWT` and the generated spec declares `bearerAuth` security.
- [ ] I ran `npm run check:api-drift` and committed the regenerated `swagger.yaml` and `endpoints.ts`.
- [ ] If this PR adds or modifies an organization-scoped table, the [tenant isolation registry](Servers/tests/integration/tenant-isolation/tenantIsolation.registry.ts) and [test matrix](Servers/tests/integration/tenant-isolation) are updated. See the [tenant isolation runbook](docs/technical/security/tenant-isolation.md) for details.
