### PR TITLE
fix(a11y): improve modal focus handling and drawer ARIA labels

### DIFF
--- a/Clients/src/presentation/components/Dialogs/ConfirmationModal/__tests__/ConfirmationModal.test.tsx
+++ b/Clients/src/presentation/components/Dialogs/ConfirmationModal/__tests__/ConfirmationModal.test.tsx
@@ -66,6 +66,14 @@ describe("ConfirmationModal", () => {
     expect(baseProps.onCancel).toHaveBeenCalledTimes(1);
   });
 
+  it("calls onCancel when Escape is pressed", async () => {
+    const user = userEvent.setup();
+    renderWithProviders(<ConfirmationModal {...baseProps} isOpen />);
+
+    await user.keyboard("{Escape}");
+    expect(baseProps.onCancel).toHaveBeenCalledTimes(1);
+  });
+
   it("renders the dialog with correct ARIA attributes", () => {
     renderWithProviders(<ConfirmationModal {...baseProps} isOpen />);
 

--- a/Clients/src/presentation/components/Dialogs/ConfirmationModal/index.tsx
+++ b/Clients/src/presentation/components/Dialogs/ConfirmationModal/index.tsx
@@ -1,7 +1,5 @@
-import { createPortal } from "react-dom";
 import { CustomizableButton } from "../../button/customizable-button";
-import { Stack, SxProps, Theme, Typography } from "@mui/material";
-import { useModalKeyHandling } from "../../../../application/hooks/useModalKeyHandling";
+import { Modal, Stack, SxProps, Theme, Typography } from "@mui/material";
 
 interface ConfirmationModalProps {
   title: string;
@@ -32,45 +30,30 @@ const ConfirmationModal: React.FC<ConfirmationModalProps> = ({
   isOpen = true,
   isLoading = false,
 }) => {
-  useModalKeyHandling({
-    isOpen,
-    onClose: onCancel,
-  });
-
-  if (!isOpen) return null;
-
-  const stopPropagation = (e: React.MouseEvent) => {
-    e.stopPropagation();
-  };
-
-  return createPortal(
-    <>
-      <Stack
-        className="confirmation-backdrop"
-        onClick={onCancel}
-        sx={{
-          position: "fixed",
-          top: 0,
-          left: 0,
-          right: 0,
-          bottom: 0,
-          backgroundColor: "rgba(0, 0, 0, 0.5)",
-          zIndex: 1299,
-          cursor: "default",
-        }}
-      />
+  return (
+    <Modal
+      open={isOpen}
+      onClose={onCancel}
+      aria-labelledby="confirmation-modal-title"
+      aria-describedby="confirmation-modal-body"
+      slotProps={{
+        backdrop: {
+          className: "confirmation-backdrop",
+        },
+      }}
+      sx={{
+        display: "flex",
+        alignItems: "center",
+        justifyContent: "center",
+        padding: 2,
+      }}
+    >
       <Stack
         role="dialog"
         aria-modal="true"
         aria-labelledby="confirmation-modal-title"
         aria-describedby="confirmation-modal-body"
-        onClick={stopPropagation}
         sx={{
-          position: "fixed",
-          top: "50%",
-          left: "50%",
-          transform: "translate(-50%, -50%)",
-          zIndex: 1300,
           bgcolor: "background.main",
           cursor: "default",
           width: 485,
@@ -81,6 +64,7 @@ const ConfirmationModal: React.FC<ConfirmationModalProps> = ({
             "0px 8px 8px -4px rgba(16, 24, 40, 0.03), 0px 20px 24px -4px rgba(16, 24, 40, 0.08)",
           gap: 8,
           boxSizing: "border-box",
+          outline: "none",
         }}
       >
         <Stack sx={{ gap: 8 }}>
@@ -119,8 +103,7 @@ const ConfirmationModal: React.FC<ConfirmationModalProps> = ({
           />
         </Stack>
       </Stack>
-    </>,
-    document.body,
+    </Modal>
   );
 };
 

--- a/Clients/src/presentation/components/Drawer/AnnexDrawerDialog/index.tsx
+++ b/Clients/src/presentation/components/Drawer/AnnexDrawerDialog/index.tsx
@@ -31,6 +31,7 @@ import DatePicker from "../../Inputs/Datepicker";
 import Select from "../../Inputs/Select";
 import TabBar from "../../TabBar";
 import StandardModal from "../../Modals/StandardModal";
+import { drawerAccessibilityProps, DRAWER_TITLE_ID } from "../drawerAccessibility";
 import { useState, useEffect, useMemo, useRef } from "react";
 import { Dayjs } from "dayjs";
 import dayjs from "dayjs";
@@ -603,6 +604,7 @@ const VWISO42001AnnexDrawerDialog = ({
       <Drawer
         open={open}
         onClose={onClose}
+        {...drawerAccessibilityProps}
         sx={{
           "width": 850,
           "margin": 0,
@@ -635,6 +637,7 @@ const VWISO42001AnnexDrawerDialog = ({
       className="vw-iso-42001-annex-drawer-dialog"
       open={open}
       onClose={onClose}
+      {...drawerAccessibilityProps}
       sx={{
         "width": 850,
         "margin": 0,
@@ -661,7 +664,7 @@ const VWISO42001AnnexDrawerDialog = ({
             alignItems: "center",
           }}
         >
-          <Typography fontSize={15} fontWeight={700}>
+          <Typography id={DRAWER_TITLE_ID} fontSize={15} fontWeight={700}>
             {title}
           </Typography>
           <CustomizableButton

--- a/Clients/src/presentation/components/Drawer/ClauseDrawerDialog/index.tsx
+++ b/Clients/src/presentation/components/Drawer/ClauseDrawerDialog/index.tsx
@@ -47,6 +47,7 @@ import { CustomizableButton } from "../../button/customizable-button";
 import Alert from "../../Alert";
 import StandardModal from "../../Modals/StandardModal";
 import { text } from "../../../themes/palette";
+import { drawerAccessibilityProps, DRAWER_TITLE_ID } from "../drawerAccessibility";
 
 import { LinkedRisksPopup } from "../../LinkedRisks";
 import NotesTab from "../../Notes/NotesTab";
@@ -674,7 +675,7 @@ const ISO42001ClauseDrawerDialog: React.FC<ISO42001ClauseDrawerProps> = ({
 
   if (isLoading && !subclause) {
     return (
-      <Drawer open={open} onClose={onClose} anchor="right">
+      <Drawer open={open} onClose={onClose} anchor="right" {...drawerAccessibilityProps}>
         <Stack
           sx={{
             width: 850,
@@ -701,6 +702,7 @@ const ISO42001ClauseDrawerDialog: React.FC<ISO42001ClauseDrawerProps> = ({
         className="iso42001-clause-drawer-dialog"
         open={open}
         onClose={onClose}
+        {...drawerAccessibilityProps}
         sx={{
           "width": 850,
           "margin": 0,
@@ -722,7 +724,7 @@ const ISO42001ClauseDrawerDialog: React.FC<ISO42001ClauseDrawerProps> = ({
             alignItems="center"
             padding="15px 20px"
           >
-            <Typography fontSize={15} fontWeight={700}>
+            <Typography id={DRAWER_TITLE_ID} fontSize={15} fontWeight={700}>
               {subclause?.subclause_id ??
                 (clause?.clause_no
                   ? `${clause.clause_no}.${subclause?.order_no || 1}`

--- a/Clients/src/presentation/components/Drawer/EUAIActQuestionDrawerDialog/index.tsx
+++ b/Clients/src/presentation/components/Drawer/EUAIActQuestionDrawerDialog/index.tsx
@@ -42,6 +42,7 @@ import TabBar from "../../TabBar";
 import { CustomizableButton } from "../../button/customizable-button";
 import Alert from "../../Alert";
 import StandardModal from "../../Modals/StandardModal";
+import { drawerAccessibilityProps, DRAWER_TITLE_ID } from "../drawerAccessibility";
 import { text } from "../../../themes/palette";
 
 import { LinkedRisksPopup } from "../../LinkedRisks";
@@ -833,6 +834,7 @@ const EUAIActQuestionDrawerDialog: React.FC<EUAIActQuestionDrawerProps> = ({
       <Drawer
         open={open}
         onClose={onClose}
+        {...drawerAccessibilityProps}
         sx={{
           "width": 850,
           "margin": 0,
@@ -869,6 +871,7 @@ const EUAIActQuestionDrawerDialog: React.FC<EUAIActQuestionDrawerProps> = ({
         className="eu-ai-act-question-drawer-dialog"
         open={open}
         onClose={onClose}
+        {...drawerAccessibilityProps}
         sx={{
           "width": 850,
           "margin": 0,
@@ -892,7 +895,7 @@ const EUAIActQuestionDrawerDialog: React.FC<EUAIActQuestionDrawerProps> = ({
             alignItems="center"
             padding="15px 20px"
           >
-            <Typography fontSize={15} fontWeight={700}>
+            <Typography id={DRAWER_TITLE_ID} fontSize={15} fontWeight={700}>
               {subtopic?.title}
             </Typography>
             <Button

--- a/Clients/src/presentation/components/Drawer/ISO27001AnnexDrawerDialog/index.tsx
+++ b/Clients/src/presentation/components/Drawer/ISO27001AnnexDrawerDialog/index.tsx
@@ -29,6 +29,7 @@ import Select from "../../Inputs/Select";
 import { useState, useEffect, useMemo, useRef } from "react";
 import TabBar from "../../TabBar";
 import StandardModal from "../../Modals/StandardModal";
+import { drawerAccessibilityProps, DRAWER_TITLE_ID } from "../drawerAccessibility";
 import {
   getFileById,
   attachFilesToEntity,
@@ -665,6 +666,7 @@ const VWISO27001AnnexDrawerDialog = ({
       <Drawer
         open={open}
         onClose={onClose}
+        {...drawerAccessibilityProps}
         sx={{
           "width": 850,
           "margin": 0,
@@ -697,6 +699,7 @@ const VWISO27001AnnexDrawerDialog = ({
       className="vw-iso-27001-annex-drawer-dialog"
       open={open}
       onClose={onClose}
+      {...drawerAccessibilityProps}
       sx={{
         "width": 850,
         "margin": 0,
@@ -718,7 +721,7 @@ const VWISO27001AnnexDrawerDialog = ({
             alignItems: "center",
           }}
         >
-          <Typography fontSize={15} fontWeight={700}>
+          <Typography id={DRAWER_TITLE_ID} fontSize={15} fontWeight={700}>
             {title}
           </Typography>
           <CustomizableButton

--- a/Clients/src/presentation/components/Drawer/ISO27001ClauseDrawerDialog/index.tsx
+++ b/Clients/src/presentation/components/Drawer/ISO27001ClauseDrawerDialog/index.tsx
@@ -48,6 +48,7 @@ import {
   getEntityFiles,
 } from "../../../../application/repository/file.repository";
 import StandardModal from "../../Modals/StandardModal";
+import { drawerAccessibilityProps, DRAWER_TITLE_ID } from "../drawerAccessibility";
 import allowedRoles from "../../../../application/constants/permissions";
 import { FilePickerModal } from "../../FilePickerModal";
 import AuditRiskPopup from "../../RiskPopup/AuditRiskPopup";
@@ -762,6 +763,7 @@ const VWISO27001ClauseDrawerDialog = ({
       <Drawer
         open={open}
         onClose={onClose}
+        {...drawerAccessibilityProps}
         sx={{
           "width": 850,
           "margin": 0,
@@ -794,6 +796,7 @@ const VWISO27001ClauseDrawerDialog = ({
         className="vw-iso-27001-clause-drawer-dialog"
         open={open}
         onClose={onClose}
+        {...drawerAccessibilityProps}
         sx={{
           "width": 850,
           "margin": 0,
@@ -822,7 +825,7 @@ const VWISO27001ClauseDrawerDialog = ({
               alignItems: "center",
             }}
           >
-            <Typography fontSize={15} fontWeight={700}>
+            <Typography id={DRAWER_TITLE_ID} fontSize={15} fontWeight={700}>
               {clause?.order_no + "." + (index + 1)} {displayData?.title}
             </Typography>
             <CustomizableButton

--- a/Clients/src/presentation/components/Drawer/NISTAIRMFDashboardDrawerDialog/index.tsx
+++ b/Clients/src/presentation/components/Drawer/NISTAIRMFDashboardDrawerDialog/index.tsx
@@ -25,6 +25,7 @@ import Alert from "../../Alert";
 import TabBar from "../../TabBar";
 import { LinkedRisksPopup } from "../../LinkedRisks";
 import StandardModal from "../../Modals/StandardModal";
+import { drawerAccessibilityProps, DRAWER_TITLE_ID } from "../drawerAccessibility";
 import { text } from "../../../themes/palette";
 
 import AddNewRiskForm from "../../AddNewRiskForm";
@@ -610,6 +611,7 @@ const NISTAIRMFDrawerDialog: React.FC<NISTAIRMFDrawerProps> = ({
             onClose();
           }
         }}
+        {...drawerAccessibilityProps}
         sx={{
           "width": 850,
           "margin": 0,
@@ -654,7 +656,7 @@ const NISTAIRMFDrawerDialog: React.FC<NISTAIRMFDrawerProps> = ({
                 alignItems="center"
                 padding="15px 20px"
               >
-                <Typography fontSize={15} fontWeight={700}>
+                <Typography id={DRAWER_TITLE_ID} fontSize={15} fontWeight={700}>
                   {functionType} {category?.index}.{subcategory?.index}
                 </Typography>
                 <Button

--- a/Clients/src/presentation/components/Drawer/drawerAccessibility.ts
+++ b/Clients/src/presentation/components/Drawer/drawerAccessibility.ts
@@ -1,0 +1,9 @@
+export const DRAWER_TITLE_ID = "framework-drawer-title";
+
+export const drawerAccessibilityProps = {
+  slotProps: {
+    root: {
+      "aria-labelledby": DRAWER_TITLE_ID,
+    },
+  },
+} as const;

--- a/Clients/src/presentation/components/Modals/StandardModal/__tests__/StandardModal.test.tsx
+++ b/Clients/src/presentation/components/Modals/StandardModal/__tests__/StandardModal.test.tsx
@@ -5,6 +5,7 @@ vi.mock("../../../button/customizable-button", () => ({
 }));
 
 import { screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import { renderWithProviders } from "../../../../../test/renderWithProviders";
 import StandardModal from "../index";
 
@@ -36,5 +37,24 @@ describe("StandardModal", () => {
       </StandardModal>,
     );
     expect(screen.queryByText("Modal content")).not.toBeInTheDocument();
+  });
+
+  it("calls onClose when Escape is pressed", async () => {
+    const onClose = vi.fn();
+    const user = userEvent.setup();
+
+    renderWithProviders(
+      <StandardModal
+        isOpen={true}
+        onClose={onClose}
+        title="Test Modal"
+        description="Test description"
+      >
+        <div>Modal content</div>
+      </StandardModal>,
+    );
+
+    await user.keyboard("{Escape}");
+    expect(onClose).toHaveBeenCalledTimes(1);
   });
 });

--- a/Clients/src/presentation/components/Modals/StandardModal/index.tsx
+++ b/Clients/src/presentation/components/Modals/StandardModal/index.tsx
@@ -167,6 +167,9 @@ const StandardModal: React.FC<StandardModalProps> = ({
           onClose();
         }
       }}
+      disableRestoreFocus={false}
+      disableAutoFocus={false}
+      disableEnforceFocus={false}
       aria-labelledby={titleId}
       aria-describedby={descriptionId}
       sx={{

--- a/Clients/src/presentation/components/Table/WithPlaceholder/index.tsx
+++ b/Clients/src/presentation/components/Table/WithPlaceholder/index.tsx
@@ -378,15 +378,6 @@ const TableWithPlaceholder: React.FC<ITableWithPlaceholderProps> = ({
                   "outline": "none",
                 }}
                 onClick={() => onEdit(row.id)}
-                onKeyDown={(e) => {
-                  if (e.key === "Enter" || e.key === " ") {
-                    e.preventDefault();
-                    onEdit(row.id);
-                  }
-                }}
-                tabIndex={0}
-                role="button"
-                aria-label={`Edit vendor ${row.vendor_name}`}
               >
                 <TableCell
                   sx={{


### PR DESCRIPTION

## Describe your changes

Migrate ConfirmationModal to MUI Modal for built-in focus trap and Escape handling, clarify StandardModal focus props, and add shared drawer aria-labelledby wiring. 

## Write your issue number after "Fixes "

Fixes #4216 

## Please ensure all items are checked off before requesting a review:

- [ ] I deployed the code locally.
- [ ] I have performed a self-review of my code.
- [ ] I have included the issue # in the PR.
- [ ] I have labelled the PR correctly.
- [ ] The issue I am working on is assigned to me.
- [ ] I have avoided using hardcoded values to ensure scalability and maintain consistency across the application.
- [ ] I have ensured that font sizes, color choices, and other UI elements are referenced from the theme.
- [ ] My pull request is focused and addresses a single, specific feature.
- [ ] If there are UI changes, I have attached a screenshot or video to this PR.
- [ ] If I added or modified an API endpoint, the change is reflected in the generated OpenAPI spec (`npm run generate:swagger`).
- [ ] If the endpoint requires authentication, it uses `authenticateJWT` and the generated spec declares `bearerAuth` security.
- [ ] I ran `npm run check:api-drift` and committed the regenerated `swagger.yaml` and `endpoints.ts`.
- [ ] If this PR adds or modifies an organization-scoped table, the [tenant isolation registry](Servers/tests/integration/tenant-isolation/tenantIsolation.registry.ts) and [test matrix](Servers/tests/integration/tenant-isolation) are updated. See the [tenant isolation runbook](docs/technical/security/tenant-isolation.md) for details.

<img width="1203" height="691" alt="Screenshot 2026-06-30 at 9 32 43 PM" src="https://github.com/user-attachments/assets/b32ede7b-63e3-4361-a8d4-e71c6d1b9dd7" />
<img width="1468" height="656" alt="Screenshot 2026-06-30 at 9 32 09 PM" src="https://github.com/user-attachments/assets/ac62cad6-5ce3-4c2b-ace0-1f0bded62ce0" />
<img width="839" height="695" alt="Screenshot 2026-06-30 at 9 22 46 PM" src="https://github.com/user-attachments/assets/64068391-de76-4b6c-9107-20b85b013afe" />
<img width="1093" height="707" alt="Screenshot 2026-06-30 at 7 45 10 PM" src="https://github.com/user-attachments/assets/8457a742-a774-4046-9b61-b209367f192f" />
<img width="775" height="727" alt="Screenshot 2026-06-30 at 7 40 55 PM" src="https://github.com/user-attachments/assets/5f82f6f4-4c90-401a-9540-8ed505f26703" />
<img width="751" height="150" alt="Screenshot 2026-06-30 at 7 39 28 PM" src="https://github.com/user-attachments/assets/6d9e58e4-cfb2-41c3-981d-e54cbcab9e55" />
<img width="888" height="686" alt="Screenshot 2026-06-30 at 7 36 36 PM" src="https://github.com/user-attachments/assets/b91c449b-0739-43a7-96bd-dfe2dea0d66d" />

