### PR TITLE
Feat: Server HTML Sanitization Rich Text

### DIFF
--- a/Clients/src/application/utils/__tests__/richTextSanitizer.test.ts
+++ b/Clients/src/application/utils/__tests__/richTextSanitizer.test.ts
@@ -1,0 +1,141 @@
+import { describe, expect, it } from "vitest";
+import { renderHook } from "@testing-library/react";
+import {
+  sanitizeRichText,
+  useRichTextSanitizer,
+  RICH_TEXT_ALLOWED_TAGS,
+  RICH_TEXT_ALLOWED_ATTR,
+} from "../richTextSanitizer";
+
+describe("richTextSanitizer", () => {
+  describe("sanitizeRichText", () => {
+    it("returns empty string for empty input", () => {
+      expect(sanitizeRichText("")).toBe("");
+    });
+
+    it("strips script tags and their contents", () => {
+      const dirty = `<p>Hello</p><script>alert('xss')</script>`;
+      expect(sanitizeRichText(dirty)).toBe("<p>Hello</p>");
+    });
+
+    it("strips inline event handlers", () => {
+      const dirty = `<img src="x" onerror="alert(1)" alt="bad">`;
+      const result = sanitizeRichText(dirty);
+      expect(result).not.toContain("onerror");
+      expect(result).not.toContain("alert");
+    });
+
+    it("blocks javascript: URIs", () => {
+      const dirty = `<a href="javascript:alert(1)">click</a>`;
+      const result = sanitizeRichText(dirty);
+      expect(result).not.toContain("javascript:");
+    });
+
+    it("blocks data: URIs", () => {
+      const dirty = `<img src="data:image/svg+xml,<svg onload='alert(1)'/>" alt="x">`;
+      const result = sanitizeRichText(dirty);
+      expect(result).not.toContain("data:");
+      expect(result).not.toContain("alert");
+    });
+
+    it("strips forbidden tags (iframe, object, embed, form, input, button)", () => {
+      const dirty =
+        `<iframe src="https://evil.example/"></iframe>` +
+        `<object data="evil.swf"></object>` +
+        `<embed src="evil.swf">` +
+        `<form><input type="text"><button>go</button></form>`;
+      const result = sanitizeRichText(dirty);
+      expect(result).not.toContain("<iframe");
+      expect(result).not.toContain("<object");
+      expect(result).not.toContain("<embed");
+      expect(result).not.toContain("<form");
+      expect(result).not.toContain("<input");
+      expect(result).not.toContain("<button");
+    });
+
+    it("strips style tags", () => {
+      const dirty = `<style>body{background:url(javascript:alert(1))}</style><p>ok</p>`;
+      const result = sanitizeRichText(dirty);
+      expect(result).not.toContain("<style");
+      expect(result).toContain("<p>ok</p>");
+    });
+
+    it("strips SVG tags", () => {
+      const dirty = `<svg onload="alert(1)"><rect width="100" height="100"/></svg>`;
+      const result = sanitizeRichText(dirty);
+      expect(result).not.toContain("<svg");
+      expect(result).not.toContain("onload");
+    });
+
+    it("strips arbitrary style properties", () => {
+      const dirty = `<p style="position:absolute; color:#ff0000;">x</p>`;
+      const result = sanitizeRichText(dirty);
+      expect(result).not.toContain("position");
+      expect(result).toMatch(/style="[^"]*color:/);
+    });
+
+    it("preserves safe formatting tags", () => {
+      const clean = `<p><strong>bold</strong> <em>italic</em> <u>under</u> <s>strike</s></p>`;
+      expect(sanitizeRichText(clean)).toBe(clean);
+    });
+
+    it("preserves headings and links", () => {
+      const clean = `<h1>A</h1><h2>B</h2><a href="https://example.com" target="_blank" rel="noopener">link</a>`;
+      expect(sanitizeRichText(clean)).toBe(clean);
+    });
+
+    it("preserves allowlisted inline styles", () => {
+      const clean = `<p style="text-align:center; color:#ff0000; background-color:#00ff00;">x</p>`;
+      const result = sanitizeRichText(clean);
+      expect(result).toContain("text-align:center");
+      expect(result).toMatch(/color:\s*(?:#ff0000|rgb\(255,\s*0,\s*0\))/);
+      expect(result).toMatch(/background-color:\s*(?:#00ff00|rgb\(0,\s*255,\s*0\))/);
+    });
+
+    it("preserves tables with colspan and rowspan", () => {
+      const clean =
+        `<table><thead><tr><th colspan="2">Header</th></tr></thead>` +
+        `<tbody><tr><td rowspan="2">A</td><td>B</td></tr></tbody></table>`;
+      expect(sanitizeRichText(clean)).toBe(clean);
+    });
+
+    it("preserves TipTap task-list markup", () => {
+      const clean = `<ul data-type="taskList"><li data-checked="true">Done task</li></ul>`;
+      expect(sanitizeRichText(clean)).toBe(clean);
+    });
+  });
+
+  describe("allowlist constants", () => {
+    it("includes expected tags", () => {
+      expect(RICH_TEXT_ALLOWED_TAGS).toContain("p");
+      expect(RICH_TEXT_ALLOWED_TAGS).toContain("a");
+      expect(RICH_TEXT_ALLOWED_TAGS).toContain("img");
+      expect(RICH_TEXT_ALLOWED_TAGS).toContain("table");
+      expect(RICH_TEXT_ALLOWED_TAGS).not.toContain("script");
+      expect(RICH_TEXT_ALLOWED_TAGS).not.toContain("iframe");
+    });
+
+    it("includes expected attributes", () => {
+      expect(RICH_TEXT_ALLOWED_ATTR).toContain("href");
+      expect(RICH_TEXT_ALLOWED_ATTR).toContain("src");
+      expect(RICH_TEXT_ALLOWED_ATTR).toContain("data-checked");
+      expect(RICH_TEXT_ALLOWED_ATTR).not.toContain("onerror");
+    });
+  });
+
+  describe("useRichTextSanitizer", () => {
+    it("reports wasStripped=true when dangerous content is removed", () => {
+      const dirty = `<p>safe</p><script>alert(1)</script>`;
+      const { result } = renderHook(() => useRichTextSanitizer(dirty));
+      expect(result.current.sanitizedHtml).toBe("<p>safe</p>");
+      expect(result.current.wasStripped).toBe(true);
+    });
+
+    it("reports wasStripped=false for clean content", () => {
+      const clean = `<p><strong>bold</strong> <a href="https://example.com">link</a></p>`;
+      const { result } = renderHook(() => useRichTextSanitizer(clean));
+      expect(result.current.sanitizedHtml).toBe(clean);
+      expect(result.current.wasStripped).toBe(false);
+    });
+  });
+});

--- a/Clients/src/application/utils/richTextSanitizer.ts
+++ b/Clients/src/application/utils/richTextSanitizer.ts
@@ -88,7 +88,7 @@ export const RICH_TEXT_ALLOWED_STYLES: ReadonlySet<string> = new Set([
  * DOMPurify configuration that applies the same allowlist philosophy as the
  * backend sanitizer.
  */
-export const DOMPURIFY_CONFIG: DOMPurify.Config = {
+export const DOMPURIFY_CONFIG: NonNullable<Parameters<typeof DOMPurify.sanitize>[1]> = {
   ALLOWED_TAGS: RICH_TEXT_ALLOWED_TAGS,
   ALLOWED_ATTR: RICH_TEXT_ALLOWED_ATTR,
   FORBID_TAGS: [
@@ -208,7 +208,7 @@ function restrictInlineStyles(html: string): string {
  */
 export function sanitizeRichText(html: string): string {
   if (!html) return html;
-  const firstPass = DOMPurify.sanitize(html, DOMPURIFY_CONFIG);
+  const firstPass = DOMPurify.sanitize(html, DOMPURIFY_CONFIG) as string;
   const noDataImages = blockDataUrisOnImages(firstPass);
   return restrictInlineStyles(noDataImages);
 }

--- a/Clients/src/application/utils/richTextSanitizer.ts
+++ b/Clients/src/application/utils/richTextSanitizer.ts
@@ -119,8 +119,7 @@ export const DOMPURIFY_CONFIG: DOMPurify.Config = {
   ],
   ALLOW_DATA_ATTR: false,
   // Restrict URI schemes to safe values (http, https, blob, mailto, tel).
-  ALLOWED_URI_REGEXP:
-    /^(?:(?:(?:f|ht)tps?|blob|mailto|tel):|[^a-z]|[a-z.+\-]+(?:[^a-z.+\-:]|$))/i,
+  ALLOWED_URI_REGEXP: /^(?:(?:(?:f|ht)tps?|blob|mailto|tel):|[^a-z]|[a-z.+\-]+(?:[^a-z.+\-:]|$))/i,
 };
 
 /**
@@ -164,14 +163,12 @@ function blockDataUrisOnImages(html: string): string {
   const wrapper = document.createElement("div");
   wrapper.innerHTML = html;
 
-  wrapper
-    .querySelectorAll("img")
-    .forEach((img) => {
-      const src = img.getAttribute("src") || "";
-      if (src.trim().toLowerCase().startsWith("data:")) {
-        img.removeAttribute("src");
-      }
-    });
+  wrapper.querySelectorAll("img").forEach((img) => {
+    const src = img.getAttribute("src") || "";
+    if (src.trim().toLowerCase().startsWith("data:")) {
+      img.removeAttribute("src");
+    }
+  });
 
   return wrapper.innerHTML;
 }

--- a/Clients/src/application/utils/richTextSanitizer.ts
+++ b/Clients/src/application/utils/richTextSanitizer.ts
@@ -1,0 +1,250 @@
+import { useMemo } from "react";
+import DOMPurify from "dompurify";
+
+/**
+ * Allowlisted HTML tags for rich-text rendering.
+ *
+ * Mirrors the backend allowlist in Servers/utils/sanitization.utils.ts.
+ */
+export const RICH_TEXT_ALLOWED_TAGS: string[] = [
+  // Text structure
+  "p",
+  "br",
+  "div",
+  "span",
+  "hr",
+  // Headings
+  "h1",
+  "h2",
+  "h3",
+  "h4",
+  "h5",
+  "h6",
+  // Inline formatting
+  "strong",
+  "b",
+  "em",
+  "i",
+  "u",
+  "s",
+  "del",
+  "mark",
+  "sup",
+  "sub",
+  // Code
+  "code",
+  "pre",
+  // Lists
+  "ul",
+  "ol",
+  "li",
+  // Links / media
+  "a",
+  "img",
+  // Tables
+  "table",
+  "thead",
+  "tbody",
+  "tr",
+  "th",
+  "td",
+  // Block elements
+  "blockquote",
+];
+
+/**
+ * Allowlisted HTML attributes for rich-text rendering.
+ */
+export const RICH_TEXT_ALLOWED_ATTR: string[] = [
+  "class",
+  "style",
+  "href",
+  "target",
+  "rel",
+  "title",
+  "src",
+  "alt",
+  "width",
+  "height",
+  "colspan",
+  "rowspan",
+  // TipTap task-list specific attributes
+  "data-type",
+  "data-checked",
+];
+
+/**
+ * Allowlisted inline CSS properties.
+ *
+ * Only text alignment and color properties used by the editor are permitted.
+ */
+export const RICH_TEXT_ALLOWED_STYLES: ReadonlySet<string> = new Set([
+  "text-align",
+  "color",
+  "background-color",
+]);
+
+/**
+ * DOMPurify configuration that applies the same allowlist philosophy as the
+ * backend sanitizer.
+ */
+export const DOMPURIFY_CONFIG: DOMPurify.Config = {
+  ALLOWED_TAGS: RICH_TEXT_ALLOWED_TAGS,
+  ALLOWED_ATTR: RICH_TEXT_ALLOWED_ATTR,
+  FORBID_TAGS: [
+    "script",
+    "style",
+    "iframe",
+    "object",
+    "embed",
+    "form",
+    "input",
+    "button",
+    "base",
+    "meta",
+    "svg",
+  ],
+  FORBID_ATTR: [
+    "onerror",
+    "onload",
+    "onclick",
+    "onmouseover",
+    "onfocus",
+    "onblur",
+    "onmouseenter",
+    "onmouseleave",
+    "onkeydown",
+    "onkeyup",
+    "onsubmit",
+  ],
+  ALLOW_DATA_ATTR: false,
+  // Restrict URI schemes to safe values (http, https, blob, mailto, tel).
+  ALLOWED_URI_REGEXP:
+    /^(?:(?:(?:f|ht)tps?|blob|mailto|tel):|[^a-z]|[a-z.+\-]+(?:[^a-z.+\-:]|$))/i,
+};
+
+/**
+ * Filters a style attribute value down to the allowlisted CSS properties.
+ *
+ * Uses a temporary DOM element so the browser parses the CSS safely; any
+ * property outside the allowlist is dropped.
+ */
+function sanitizeStyleAttribute(styleValue: string): string {
+  if (typeof document === "undefined") {
+    // SSR / test fallback: strip the entire style attribute if no DOM is available.
+    return "";
+  }
+
+  const temp = document.createElement("div");
+  temp.style.cssText = styleValue;
+
+  const allowed: string[] = [];
+  for (let i = 0; i < temp.style.length; i++) {
+    const property = temp.style.item(i);
+    if (RICH_TEXT_ALLOWED_STYLES.has(property)) {
+      const value = temp.style.getPropertyValue(property);
+      allowed.push(`${property}:${value}`);
+    }
+  }
+
+  return allowed.join(";");
+}
+
+/**
+ * Post-processes sanitized HTML to block data: URIs on images.
+ *
+ * DOMPurify's ALLOWED_URI_REGEXP does not apply to <img src> attributes, so we
+ * remove any remaining data: image URIs to match the backend allowlist.
+ */
+function blockDataUrisOnImages(html: string): string {
+  if (typeof document === "undefined" || !html.includes("data:")) {
+    return html;
+  }
+
+  const wrapper = document.createElement("div");
+  wrapper.innerHTML = html;
+
+  wrapper
+    .querySelectorAll("img")
+    .forEach((img) => {
+      const src = img.getAttribute("src") || "";
+      if (src.trim().toLowerCase().startsWith("data:")) {
+        img.removeAttribute("src");
+      }
+    });
+
+  return wrapper.innerHTML;
+}
+
+/**
+ * Post-processes sanitized HTML to restrict inline style properties.
+ *
+ * DOMPurify does not provide fine-grained CSS property filtering, so we walk
+ * the result and drop any style properties outside our allowlist.
+ */
+function restrictInlineStyles(html: string): string {
+  if (typeof document === "undefined" || !html.includes("style=")) {
+    return html;
+  }
+
+  const wrapper = document.createElement("div");
+  wrapper.innerHTML = html;
+
+  const elements = wrapper.querySelectorAll("[style]");
+  elements.forEach((el) => {
+    const sanitized = sanitizeStyleAttribute(el.getAttribute("style") || "");
+    if (sanitized) {
+      el.setAttribute("style", sanitized);
+    } else {
+      el.removeAttribute("style");
+    }
+  });
+
+  return wrapper.innerHTML;
+}
+
+/**
+ * Sanitizes user-generated HTML for safe rendering in the UI.
+ *
+ * @param html - Raw HTML string.
+ * @returns Sanitized HTML string.
+ */
+export function sanitizeRichText(html: string): string {
+  if (!html) return html;
+  const firstPass = DOMPurify.sanitize(html, DOMPURIFY_CONFIG);
+  const noDataImages = blockDataUrisOnImages(firstPass);
+  return restrictInlineStyles(noDataImages);
+}
+
+/**
+ * Normalizes an HTML string for stable comparison.
+ *
+ * DOMPurify may reformat whitespace, attribute order, or self-closing tags;
+ * this helper removes those differences so we can reliably detect whether
+ * meaningful content was stripped.
+ */
+function normalizeHtml(html: string): string {
+  return html
+    .replace(/\s+/g, " ")
+    .replace(/\s*>\s*/g, ">")
+    .replace(/\s*</g, "<")
+    .replace(/\s*\/\s*>/g, "/>")
+    .trim();
+}
+
+/**
+ * React hook that sanitizes rich text and reports whether content was stripped.
+ *
+ * @param html - Raw HTML string.
+ * @returns `{ sanitizedHtml, wasStripped }`
+ */
+export function useRichTextSanitizer(html: string): {
+  sanitizedHtml: string;
+  wasStripped: boolean;
+} {
+  return useMemo(() => {
+    const sanitizedHtml = sanitizeRichText(html);
+    const wasStripped = normalizeHtml(sanitizedHtml) !== normalizeHtml(html);
+    return { sanitizedHtml, wasStripped };
+  }, [html]);
+}

--- a/Clients/src/i18n/translations.ts
+++ b/Clients/src/i18n/translations.ts
@@ -25,6 +25,8 @@ export type Lang = "en" | "de" | "fr" | "es";
 
 export const translations: Record<string, Record<string, string>> = {
   de: {
+    // Rich text renderer
+    "Rich text content": "Rich-Text-Inhalt",
     // Settings — help text
     "Enabled — risks include monetary estimates based on the FAIR model: annual loss expectancy, residual risk after controls, and return on mitigation investment.":
       "Aktiviert — Risiken enthalten monetäre Schätzungen auf Basis des FAIR-Modells: erwarteter Jahresverlust, Restrisiko nach Maßnahmen und Rendite der Risikominderung.",
@@ -8732,6 +8734,8 @@ export const translations: Record<string, Record<string, string>> = {
   },
 
   fr: {
+    // Rich text renderer
+    "Rich text content": "Contenu de texte enrichi",
     // Settings — help text
     "Enabled — risks include monetary estimates based on the FAIR model: annual loss expectancy, residual risk after controls, and return on mitigation investment.":
       "Activé — les risques incluent des estimations monétaires basées sur le modèle FAIR : perte annuelle attendue, risque résiduel après contrôles et retour sur l'investissement de mitigation.",
@@ -17393,6 +17397,8 @@ export const translations: Record<string, Record<string, string>> = {
     "Select a log to view details.": "Sélectionnez un journal pour voir les détails.",
   },
   es: {
+    // Rich text renderer
+    "Rich text content": "Contenido de texto enriquecido",
     // Settings — help text
     "Enabled — risks include monetary estimates based on the FAIR model: annual loss expectancy, residual risk after controls, and return on mitigation investment.":
       "Activado — los riesgos incluyen estimaciones monetarias basadas en el modelo FAIR: pérdida anual esperada, riesgo residual tras los controles y retorno de la inversión en mitigación.",

--- a/Clients/src/presentation/components/RichTextRenderer/__tests__/RichTextRenderer.test.tsx
+++ b/Clients/src/presentation/components/RichTextRenderer/__tests__/RichTextRenderer.test.tsx
@@ -37,10 +37,7 @@ describe("RichTextRenderer", () => {
   it("calls onStripped when dangerous content is removed", () => {
     const onStripped = vi.fn();
     render(
-      <RichTextRenderer
-        html="<p>safe</p><script>alert(1)</script>"
-        onStripped={onStripped}
-      />,
+      <RichTextRenderer html="<p>safe</p><script>alert(1)</script>" onStripped={onStripped} />,
     );
     expect(onStripped).toHaveBeenCalledTimes(1);
   });

--- a/Clients/src/presentation/components/RichTextRenderer/__tests__/RichTextRenderer.test.tsx
+++ b/Clients/src/presentation/components/RichTextRenderer/__tests__/RichTextRenderer.test.tsx
@@ -1,0 +1,58 @@
+import { describe, expect, it, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import RichTextRenderer from "../index";
+
+describe("RichTextRenderer", () => {
+  it("renders sanitized HTML in a div by default", () => {
+    render(<RichTextRenderer html="<p><strong>safe</strong></p>" />);
+    const container = screen.getByText("safe").closest("div");
+    expect(container).toBeInTheDocument();
+    expect(container?.innerHTML).toContain("<strong>safe</strong>");
+  });
+
+  it("strips scripts from rendered HTML", () => {
+    render(<RichTextRenderer html="<p>safe</p><script>alert(1)</script>" />);
+    expect(screen.getByText("safe")).toBeInTheDocument();
+    expect(screen.queryByText("alert(1)")).not.toBeInTheDocument();
+  });
+
+  it("renders a sandboxed iframe when sandbox=true", () => {
+    render(<RichTextRenderer html="<p>safe</p>" sandbox />);
+    const iframe = screen.getByTitle("Rich text content");
+    expect(iframe.tagName).toBe("IFRAME");
+    expect(iframe).toHaveAttribute("sandbox", "allow-same-origin");
+    expect(iframe).toHaveAttribute("srcDoc", "<p>safe</p>");
+  });
+
+  it("applies the provided className", () => {
+    render(<RichTextRenderer html="<p>safe</p>" className="my-rich-text" />);
+    expect(screen.getByText("safe").closest("div")).toHaveClass("my-rich-text");
+  });
+
+  it("applies className to the iframe when sandboxed", () => {
+    render(<RichTextRenderer html="<p>safe</p>" sandbox className="my-rich-text" />);
+    expect(screen.getByTitle("Rich text content")).toHaveClass("my-rich-text");
+  });
+
+  it("calls onStripped when dangerous content is removed", () => {
+    const onStripped = vi.fn();
+    render(
+      <RichTextRenderer
+        html="<p>safe</p><script>alert(1)</script>"
+        onStripped={onStripped}
+      />,
+    );
+    expect(onStripped).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not call onStripped when content is already clean", () => {
+    const onStripped = vi.fn();
+    render(<RichTextRenderer html="<p>safe</p>" onStripped={onStripped} />);
+    expect(onStripped).not.toHaveBeenCalled();
+  });
+
+  it("returns null when there is no sanitized content", () => {
+    const { container } = render(<RichTextRenderer html="" />);
+    expect(container.firstChild).toBeNull();
+  });
+});

--- a/Clients/src/presentation/components/RichTextRenderer/index.tsx
+++ b/Clients/src/presentation/components/RichTextRenderer/index.tsx
@@ -1,5 +1,6 @@
 import React, { useEffect } from "react";
 import { useRichTextSanitizer } from "../../../application/utils/richTextSanitizer";
+import { useTranslation } from "../../../application/hooks/useTranslation";
 
 export interface RichTextRendererProps {
   /** Raw HTML content to sanitize and render. */
@@ -42,6 +43,7 @@ export const RichTextRenderer: React.FC<RichTextRendererProps> = ({
   onStripped,
 }) => {
   const { sanitizedHtml, wasStripped } = useRichTextSanitizer(html);
+  const { t } = useTranslation();
 
   useEffect(() => {
     if (wasStripped && onStripped) {
@@ -64,17 +66,12 @@ export const RichTextRenderer: React.FC<RichTextRendererProps> = ({
           width: "100%",
           minHeight: "80px",
         }}
-        title="Rich text content"
+        title={t("Rich text content")}
       />
     );
   }
 
-  return (
-    <div
-      className={className}
-      dangerouslySetInnerHTML={{ __html: sanitizedHtml }}
-    />
-  );
+  return <div className={className} dangerouslySetInnerHTML={{ __html: sanitizedHtml }} />;
 };
 
 export default RichTextRenderer;

--- a/Clients/src/presentation/components/RichTextRenderer/index.tsx
+++ b/Clients/src/presentation/components/RichTextRenderer/index.tsx
@@ -1,0 +1,80 @@
+import React, { useEffect } from "react";
+import { useRichTextSanitizer } from "../../../application/utils/richTextSanitizer";
+
+export interface RichTextRendererProps {
+  /** Raw HTML content to sanitize and render. */
+  html: string;
+  /**
+   * Optional CSS class for the wrapping element.
+   *
+   * When `sandbox` is true, the class is applied to the iframe.
+   * Otherwise it is applied to the div that hosts the sanitized HTML.
+   */
+  className?: string;
+  /**
+   * Render inside a sandboxed iframe for extra isolation.
+   *
+   * The iframe uses `sandbox="allow-same-origin"` so that same-origin
+   * styles/resources still work, but scripts cannot execute.
+   *
+   * @default false
+   */
+  sandbox?: boolean;
+  /**
+   * Called when the sanitizer strips content from the provided HTML.
+   *
+   * Use this to show a warning banner/toast in the UI (e.g. Inna's UI).
+   */
+  onStripped?: () => void;
+}
+
+/**
+ * Shared rich-text renderer for user-generated HTML.
+ *
+ * Sanitizes the provided HTML using the same allowlist as the backend and
+ * renders the result. Optionally renders inside a sandboxed iframe for
+ * defense-in-depth isolation.
+ */
+export const RichTextRenderer: React.FC<RichTextRendererProps> = ({
+  html,
+  className,
+  sandbox = false,
+  onStripped,
+}) => {
+  const { sanitizedHtml, wasStripped } = useRichTextSanitizer(html);
+
+  useEffect(() => {
+    if (wasStripped && onStripped) {
+      onStripped();
+    }
+  }, [wasStripped, onStripped]);
+
+  if (!sanitizedHtml) {
+    return null;
+  }
+
+  if (sandbox) {
+    return (
+      <iframe
+        className={className}
+        srcDoc={sanitizedHtml}
+        sandbox="allow-same-origin"
+        style={{
+          border: "none",
+          width: "100%",
+          minHeight: "80px",
+        }}
+        title="Rich text content"
+      />
+    );
+  }
+
+  return (
+    <div
+      className={className}
+      dangerouslySetInnerHTML={{ __html: sanitizedHtml }}
+    />
+  );
+};
+
+export default RichTextRenderer;

--- a/Clients/src/presentation/pages/PolicyDashboard/PolicyEditorPage.tsx
+++ b/Clients/src/presentation/pages/PolicyDashboard/PolicyEditorPage.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useState, useCallback, useRef, useMemo } from "react";
 import { useParams, useSearchParams, useNavigate } from "react-router-dom";
-import DOMPurify from "dompurify";
+import { sanitizeRichText } from "../../../application/utils/richTextSanitizer";
 import {
   useEditor,
   EditorContent,
@@ -345,69 +345,7 @@ function normalizeSlateHtml(html: string): string {
   return n;
 }
 
-const sanitizeOptions: Parameters<typeof DOMPurify.sanitize>[1] = {
-  ALLOWED_TAGS: [
-    "p",
-    "br",
-    "strong",
-    "b",
-    "em",
-    "i",
-    "u",
-    "h1",
-    "h2",
-    "h3",
-    "h4",
-    "h5",
-    "h6",
-    "blockquote",
-    "code",
-    "pre",
-    "ul",
-    "ol",
-    "li",
-    "label",
-    "input",
-    "a",
-    "img",
-    "span",
-    "div",
-    "mark",
-    "s",
-    "hr",
-    "table",
-    "thead",
-    "tbody",
-    "tr",
-    "th",
-    "td",
-    "sup",
-    "sub",
-  ],
-  ALLOWED_ATTR: [
-    "href",
-    "title",
-    "alt",
-    "src",
-    "width",
-    "class",
-    "id",
-    "style",
-    "target",
-    "rel",
-    "colspan",
-    "rowspan",
-    "data-type",
-    "data-checked",
-    "type",
-    "checked",
-  ],
-  ALLOWED_URI_REGEXP:
-    /^(?:(?:(?:f|ht)tps?|mailto|tel|callto|cid|xmpp|data):|[^a-z]|[a-z.+\-]+(?:[^a-z.+\-:]|$))/i,
-  ADD_ATTR: ["target"],
-  FORBID_TAGS: ["script", "object", "embed", "iframe", "form", "input", "button"],
-  FORBID_ATTR: ["onerror", "onload", "onclick", "onmouseover", "onfocus", "onblur"],
-};
+
 
 // ── Search highlight extension ─────────────────────────────────────────
 const searchHighlightKey = new PluginKey("searchHighlight");
@@ -759,7 +697,7 @@ export default function PolicyEditorPage() {
   const initialContent = (() => {
     const raw = policy?.content_html || template?.content || "";
     if (!raw) return "";
-    return DOMPurify.sanitize(normalizeSlateHtml(raw), sanitizeOptions);
+    return sanitizeRichText(normalizeSlateHtml(raw));
   })();
 
   // ── TipTap editor ─────────────────────────────────────────────────
@@ -1502,7 +1440,7 @@ export default function PolicyEditorPage() {
     setImportError(null);
     try {
       const { html } = await importDocxToHtml(file);
-      const sanitized = DOMPurify.sanitize(html, sanitizeOptions);
+      const sanitized = sanitizeRichText(html);
       if (editor) {
         editor.commands.setContent(sanitized);
       }

--- a/Clients/src/presentation/pages/PolicyDashboard/PolicyEditorPage.tsx
+++ b/Clients/src/presentation/pages/PolicyDashboard/PolicyEditorPage.tsx
@@ -345,8 +345,6 @@ function normalizeSlateHtml(html: string): string {
   return n;
 }
 
-
-
 // ── Search highlight extension ─────────────────────────────────────────
 const searchHighlightKey = new PluginKey("searchHighlight");
 

--- a/Servers/controllers/evidenceHub.ctrl.ts
+++ b/Servers/controllers/evidenceHub.ctrl.ts
@@ -10,7 +10,7 @@ import {
 } from "../utils/evidenceHub.utils";
 import { STATUS_CODE } from "../utils/statusCode.utils";
 import logger, { logStructured } from "../utils/logger/fileLogger";
-import { sanitizeUserHtml } from "../utils/sanitizeUserHtml";
+import { sanitizeUserHtml } from "../utils/sanitization.utils";
 import { translateError } from "../utils/i18n.utils";
 import {
   recordEvidenceAddedToModel,

--- a/Servers/controllers/intakeForm.ctrl.ts
+++ b/Servers/controllers/intakeForm.ctrl.ts
@@ -36,7 +36,7 @@ import { AiRiskClassification } from "../domain.layer/enums/ai-risk-classificati
 import { ModelInventoryModel } from "../domain.layer/models/modelInventory/modelInventory.model";
 import { IIntakeFormSchema } from "../domain.layer/interfaces/i.intakeForm";
 import { STATUS_CODE } from "../utils/statusCode.utils";
-import { sanitizeUserHtml } from "../utils/sanitizeUserHtml";
+import { sanitizeUserHtml } from "../utils/sanitization.utils";
 import logger from "../utils/logger/fileLogger";
 import { logProcessing, logSuccess, logFailure } from "../utils/logger/logHelper";
 import {

--- a/Servers/controllers/policy.ctrl.ts
+++ b/Servers/controllers/policy.ctrl.ts
@@ -44,7 +44,7 @@ import { NotificationEntityType } from "../domain.layer/interfaces/i.notificatio
 import logger from "../utils/logger/fileLogger";
 import { translateError } from "../utils/i18n.utils";
 import { logProcessing, logSuccess, logFailure } from "../utils/logger/logHelper";
-import { sanitizeUserHtml } from "../utils/sanitizeUserHtml";
+import { sanitizeUserHtml } from "../utils/sanitization.utils";
 
 export class PolicyController {
   // Get all policies

--- a/Servers/services/notesService.ts
+++ b/Servers/services/notesService.ts
@@ -28,7 +28,7 @@ import {
   BusinessLogicException,
 } from "../domain.layer/exceptions/custom.exception";
 import { logFailure, logProcessing, logSuccess } from "../utils/logger/logHelper";
-import { sanitizeUserHtml } from "../utils/sanitizeUserHtml";
+import { sanitizeUserHtml } from "../utils/sanitization.utils";
 
 export class NotesService {
   /**

--- a/Servers/services/policies/policyImporter.ts
+++ b/Servers/services/policies/policyImporter.ts
@@ -8,7 +8,7 @@
  */
 
 import mammoth from "mammoth";
-import { sanitizeUserHtml } from "../../utils/sanitizeUserHtml";
+import { sanitizeUserHtml } from "../../utils/sanitization.utils";
 
 /** Maximum permitted upload size (must match multer limit in policy.route.ts). */
 export const DOCX_MAX_FILE_SIZE_BYTES = 10 * 1024 * 1024; // 10 MB

--- a/Servers/services/policies/tests/policyImporter.spec.ts
+++ b/Servers/services/policies/tests/policyImporter.spec.ts
@@ -12,12 +12,12 @@ jest.mock("mammoth", () => ({
 
 // Mock the shared sanitizer module to assert it's called with the converted
 // HTML. Real sanitize-html behavior is covered by utils/__tests__/sanitizeUserHtml.test.ts.
-jest.mock("../../../utils/sanitizeUserHtml", () => ({
+jest.mock("../../../utils/sanitization.utils", () => ({
   sanitizeUserHtml: jest.fn((html: unknown) => html),
 }));
 
 import mammoth from "mammoth";
-import { sanitizeUserHtml } from "../../../utils/sanitizeUserHtml";
+import { sanitizeUserHtml } from "../../../utils/sanitization.utils";
 import { convertDocxToHtml, DOCX_MAX_FILE_SIZE_BYTES, DOCX_ALLOWED_MIMES } from "../policyImporter";
 
 const mockConvertToHtml = mammoth.convertToHtml as jest.MockedFunction<

--- a/Servers/utils/__tests__/sanitizeUserHtml.test.ts
+++ b/Servers/utils/__tests__/sanitizeUserHtml.test.ts
@@ -185,11 +185,9 @@ describe("sanitizeUserHtml", () => {
 
     it("preserves color and background-color styles", () => {
       const clean =
-        `<p style="color:#ff0000;">red</p>` +
-        `<p style="background-color:rgb(0,128,0);">green</p>`;
+        `<p style="color:#ff0000;">red</p>` + `<p style="background-color:rgb(0,128,0);">green</p>`;
       const expected =
-        `<p style="color:#ff0000">red</p>` +
-        `<p style="background-color:rgb(0,128,0)">green</p>`;
+        `<p style="color:#ff0000">red</p>` + `<p style="background-color:rgb(0,128,0)">green</p>`;
       expect(sanitizeUserHtml(clean)).toBe(expected);
     });
 

--- a/Servers/utils/__tests__/sanitizeUserHtml.test.ts
+++ b/Servers/utils/__tests__/sanitizeUserHtml.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "@jest/globals";
-import { sanitizeUserHtml } from "../sanitizeUserHtml";
+import { sanitizeUserHtml } from "../sanitization.utils";
 
 describe("sanitizeUserHtml", () => {
   describe("null / undefined / non-string handling", () => {
@@ -40,10 +40,23 @@ describe("sanitizeUserHtml", () => {
       expect(result).toContain(`href="https://example.com"`);
     });
 
+    it("strips onmouseover handlers", () => {
+      const dirty = `<p onmouseover="alert(1)">hover me</p>`;
+      const result = sanitizeUserHtml(dirty)!;
+      expect(result).not.toContain("onmouseover");
+      expect(result).toContain("hover me");
+    });
+
     it("blocks javascript: URIs on anchors", () => {
       const dirty = `<a href="javascript:alert('x')">click</a>`;
       const result = sanitizeUserHtml(dirty)!;
       expect(result).not.toContain("javascript:");
+    });
+
+    it("blocks vbscript: URIs on anchors", () => {
+      const dirty = `<a href="vbscript:msgbox(1)">click</a>`;
+      const result = sanitizeUserHtml(dirty)!;
+      expect(result).not.toContain("vbscript:");
     });
 
     it("blocks data: URIs on images (which can carry executable SVG payloads)", () => {
@@ -61,6 +74,14 @@ describe("sanitizeUserHtml", () => {
       expect(result).toContain("<p>after</p>");
     });
 
+    it("strips iframe srcdoc payloads", () => {
+      const dirty = `<iframe srcdoc="<script>alert(1)</script>"></iframe>`;
+      const result = sanitizeUserHtml(dirty)!;
+      expect(result).not.toContain("<iframe");
+      expect(result).not.toContain("srcdoc");
+      expect(result).not.toContain("alert");
+    });
+
     it("strips <object> and <embed> tags", () => {
       const dirty = `<object data="evil.swf"></object><embed src="evil.swf">`;
       const result = sanitizeUserHtml(dirty)!;
@@ -74,6 +95,39 @@ describe("sanitizeUserHtml", () => {
       expect(result).not.toContain("<style");
       expect(result).not.toContain("javascript:");
     });
+
+    it("strips SVG tags with onload handlers", () => {
+      const dirty = `<svg onload="alert(1)"><rect width="100" height="100"/></svg>`;
+      const result = sanitizeUserHtml(dirty)!;
+      expect(result).not.toContain("<svg");
+      expect(result).not.toContain("onload");
+      expect(result).not.toContain("alert");
+    });
+
+    it("strips form and input elements", () => {
+      const dirty = `<form action="/evil"><input type="text" name="x"><button>go</button></form>`;
+      const result = sanitizeUserHtml(dirty)!;
+      expect(result).not.toContain("<form");
+      expect(result).not.toContain("<input");
+      expect(result).not.toContain("<button");
+    });
+
+    it("strips <base> and <meta> tags", () => {
+      const dirty = `<base href="https://evil.example/"><meta http-equiv="refresh" content="0;url=javascript:alert(1)"><p>ok</p>`;
+      const result = sanitizeUserHtml(dirty)!;
+      expect(result).not.toContain("<base");
+      expect(result).not.toContain("<meta");
+      expect(result).not.toContain("javascript:");
+      expect(result).toContain("<p>ok</p>");
+    });
+
+    it("strips arbitrary style properties that could be used for XSS", () => {
+      const dirty = `<p style="behavior:url(javascript:alert(1)); position:absolute;">x</p>`;
+      const result = sanitizeUserHtml(dirty)!;
+      expect(result).not.toContain("behavior");
+      expect(result).not.toContain("javascript:");
+      expect(result).toBe("<p>x</p>");
+    });
   });
 
   describe("safe content preservation", () => {
@@ -82,13 +136,18 @@ describe("sanitizeUserHtml", () => {
       expect(sanitizeUserHtml(clean)).toBe(clean);
     });
 
-    it("preserves headings h1-h3 (per the allowlist)", () => {
-      const clean = `<h1>A</h1><h2>B</h2><h3>C</h3>`;
+    it("preserves headings h1-h6", () => {
+      const clean = `<h1>A</h1><h2>B</h2><h3>C</h3><h4>D</h4><h5>E</h5><h6>F</h6>`;
       expect(sanitizeUserHtml(clean)).toBe(clean);
     });
 
     it("preserves anchors with safe http(s) URLs", () => {
       const clean = `<a href="https://verifywise.ai">link</a>`;
+      expect(sanitizeUserHtml(clean)).toBe(clean);
+    });
+
+    it("preserves anchors with mailto and tel URLs", () => {
+      const clean = `<a href="mailto:test@example.com">email</a><a href="tel:+1234567890">call</a>`;
       expect(sanitizeUserHtml(clean)).toBe(clean);
     });
 
@@ -107,6 +166,38 @@ describe("sanitizeUserHtml", () => {
       expect(result).toContain("blob:");
     });
 
+    it("preserves tables with colspan and rowspan", () => {
+      const clean =
+        `<table><thead><tr><th colspan="2">Header</th></tr></thead>` +
+        `<tbody><tr><td rowspan="2">A</td><td>B</td></tr></tbody></table>`;
+      expect(sanitizeUserHtml(clean)).toBe(clean);
+    });
+
+    it("preserves TipTap task-list markup", () => {
+      const clean = `<ul data-type="taskList"><li data-checked="true">Done task</li></ul>`;
+      expect(sanitizeUserHtml(clean)).toBe(clean);
+    });
+
+    it("preserves text-align style", () => {
+      const clean = `<p style="text-align:center;">centered</p>`;
+      expect(sanitizeUserHtml(clean)).toBe(`<p style="text-align:center">centered</p>`);
+    });
+
+    it("preserves color and background-color styles", () => {
+      const clean =
+        `<p style="color:#ff0000;">red</p>` +
+        `<p style="background-color:rgb(0,128,0);">green</p>`;
+      const expected =
+        `<p style="color:#ff0000">red</p>` +
+        `<p style="background-color:rgb(0,128,0)">green</p>`;
+      expect(sanitizeUserHtml(clean)).toBe(expected);
+    });
+
+    it("preserves code blocks and blockquotes", () => {
+      const clean = `<pre><code>const x = 1;</code></pre><blockquote><p>quote</p></blockquote>`;
+      expect(sanitizeUserHtml(clean)).toBe(clean);
+    });
+
     it("preserves plain text without tags untouched", () => {
       expect(sanitizeUserHtml("just a sentence")).toBe("just a sentence");
     });
@@ -118,6 +209,20 @@ describe("sanitizeUserHtml", () => {
       const once = sanitizeUserHtml(dirty);
       const twice = sanitizeUserHtml(once);
       expect(twice).toBe(once);
+    });
+  });
+
+  describe("stripping detection", () => {
+    it("returns different output when dangerous content is stripped", () => {
+      const dirty = `<p>safe</p><script>alert(1)</script>`;
+      const sanitized = sanitizeUserHtml(dirty);
+      expect(sanitized).not.toBe(dirty);
+      expect(sanitized).toBe("<p>safe</p>");
+    });
+
+    it("returns identical output for already-clean content", () => {
+      const clean = `<p><strong>bold</strong> <a href="https://example.com">link</a></p>`;
+      expect(sanitizeUserHtml(clean)).toBe(clean);
     });
   });
 });

--- a/Servers/utils/sanitization.utils.ts
+++ b/Servers/utils/sanitization.utils.ts
@@ -98,14 +98,8 @@ export const USER_HTML_ALLOWED_ATTRIBUTES: sanitizeHtml.IOptions["allowedAttribu
 export const USER_HTML_ALLOWED_STYLES: sanitizeHtml.IOptions["allowedStyles"] = {
   "*": {
     "text-align": [/^left$|^right$|^center$|^justify$/i],
-    color: [
-      /^#(?:[0-9a-f]{3,4}|[0-9a-f]{6,8})$/i,
-      /^(?:rgb|hsl)a?\([^)]*\)$/i,
-    ],
-    "background-color": [
-      /^#(?:[0-9a-f]{3,4}|[0-9a-f]{6,8})$/i,
-      /^(?:rgb|hsl)a?\([^)]*\)$/i,
-    ],
+    color: [/^#(?:[0-9a-f]{3,4}|[0-9a-f]{6,8})$/i, /^(?:rgb|hsl)a?\([^)]*\)$/i],
+    "background-color": [/^#(?:[0-9a-f]{3,4}|[0-9a-f]{6,8})$/i, /^(?:rgb|hsl)a?\([^)]*\)$/i],
   },
 };
 

--- a/Servers/utils/sanitization.utils.ts
+++ b/Servers/utils/sanitization.utils.ts
@@ -1,0 +1,142 @@
+/**
+ * @file sanitization.utils.ts
+ * @description Shared HTML sanitizer for user-generated rich-text content.
+ *
+ * Call this on every rich-text field before persisting (notes, evidence
+ * descriptions, intake form descriptions, policy bodies, etc.) to mitigate
+ * stored XSS. The allowlist is explicit and strict: only formatting,
+ * structural, link, image, and table tags are permitted; scripts, event
+ * handlers, dangerous URI schemes, and arbitrary styles are stripped.
+ *
+ * Behavior:
+ *   - null / undefined inputs are returned unchanged (handy for optional fields)
+ *   - non-string inputs are coerced to string before sanitizing
+ *   - <script>, <style>, <iframe>, <object>, <embed>, <form>, on* event
+ *     handlers, javascript:/data: URIs, and non-allowlisted attributes are
+ *     all stripped silently
+ *   - style attributes are restricted to a safe subset of properties only
+ */
+
+import sanitizeHtml from "sanitize-html";
+
+/**
+ * Allowlisted HTML tags.
+ *
+ * Mirrors the markup produced by the TipTap-based RichTextEditor:
+ * headings, paragraphs, lists, links, images, tables, code blocks,
+ * blockquotes, and basic inline formatting.
+ */
+export const USER_HTML_ALLOWED_TAGS: string[] = [
+  // Text structure
+  "p",
+  "br",
+  "div",
+  "span",
+  "hr",
+  // Headings
+  "h1",
+  "h2",
+  "h3",
+  "h4",
+  "h5",
+  "h6",
+  // Inline formatting
+  "strong",
+  "b",
+  "em",
+  "i",
+  "u",
+  "s",
+  "del",
+  "mark",
+  "sup",
+  "sub",
+  // Code
+  "code",
+  "pre",
+  // Lists
+  "ul",
+  "ol",
+  "li",
+  // Links / media
+  "a",
+  "img",
+  // Tables
+  "table",
+  "thead",
+  "tbody",
+  "tr",
+  "th",
+  "td",
+  // Block elements
+  "blockquote",
+];
+
+/**
+ * Allowlisted HTML attributes per tag.
+ *
+ * Global attribute `class` is allowed for styling hooks.
+ * Link and image attributes are restricted to safe, non-executable values.
+ */
+export const USER_HTML_ALLOWED_ATTRIBUTES: sanitizeHtml.IOptions["allowedAttributes"] = {
+  "*": ["class"],
+  a: ["href", "target", "rel", "title"],
+  img: ["src", "alt", "width", "height", "title"],
+  th: ["colspan", "rowspan"],
+  td: ["colspan", "rowspan"],
+  // TipTap task-list specific attributes
+  ul: ["data-type"],
+  li: ["data-checked"],
+};
+
+/**
+ * Allowlisted inline CSS properties.
+ *
+ * Only text alignment and color properties used by the editor are permitted.
+ * All other styles (positioning, behavior URLs, expressions, etc.) are removed.
+ */
+export const USER_HTML_ALLOWED_STYLES: sanitizeHtml.IOptions["allowedStyles"] = {
+  "*": {
+    "text-align": [/^left$|^right$|^center$|^justify$/i],
+    color: [
+      /^#(?:[0-9a-f]{3,4}|[0-9a-f]{6,8})$/i,
+      /^(?:rgb|hsl)a?\([^)]*\)$/i,
+    ],
+    "background-color": [
+      /^#(?:[0-9a-f]{3,4}|[0-9a-f]{6,8})$/i,
+      /^(?:rgb|hsl)a?\([^)]*\)$/i,
+    ],
+  },
+};
+
+/**
+ * Allowlisted URI schemes.
+ *
+ * `data:` is intentionally excluded — it can carry executable payloads via
+ * <img src="data:image/svg+xml,..."> or <iframe src="data:text/html,...">.
+ * `javascript:` and `vbscript:` are blocked by sanitize-html by default.
+ */
+export const USER_HTML_ALLOWED_SCHEMES: string[] = ["http", "https", "blob", "mailto", "tel"];
+
+const SANITIZE_OPTIONS: sanitizeHtml.IOptions = {
+  allowedTags: USER_HTML_ALLOWED_TAGS,
+  allowedAttributes: USER_HTML_ALLOWED_ATTRIBUTES,
+  allowedStyles: USER_HTML_ALLOWED_STYLES,
+  allowedSchemes: USER_HTML_ALLOWED_SCHEMES,
+  // Ensure disallowed tags/attributes are removed (not escaped)
+  disallowedTagsMode: "discard",
+};
+
+/**
+ * Sanitizes user-provided HTML for safe persistence and rendering.
+ *
+ * @param input - Raw HTML string, or null/undefined for optional fields.
+ * @returns The sanitized HTML string, or null/undefined if the input was.
+ */
+export function sanitizeUserHtml<T extends string | null | undefined>(input: T): T;
+export function sanitizeUserHtml(input: unknown): string | null | undefined;
+export function sanitizeUserHtml(input: unknown): string | null | undefined {
+  if (input === null || input === undefined) return input as null | undefined;
+  const str = typeof input === "string" ? input : String(input);
+  return sanitizeHtml(str, SANITIZE_OPTIONS);
+}

--- a/Servers/utils/sanitization.utils.ts
+++ b/Servers/utils/sanitization.utils.ts
@@ -79,7 +79,7 @@ export const USER_HTML_ALLOWED_TAGS: string[] = [
  * Link and image attributes are restricted to safe, non-executable values.
  */
 export const USER_HTML_ALLOWED_ATTRIBUTES: sanitizeHtml.IOptions["allowedAttributes"] = {
-  "*": ["class"],
+  "*": ["class", "style"],
   a: ["href", "target", "rel", "title"],
   img: ["src", "alt", "width", "height", "title"],
   th: ["colspan", "rowspan"],

--- a/Servers/utils/sanitizeUserHtml.ts
+++ b/Servers/utils/sanitizeUserHtml.ts
@@ -1,55 +1,16 @@
 /**
  * @file sanitizeUserHtml.ts
- * @description Shared HTML sanitizer for user-generated rich-text content.
+ * @description Backward-compatibility re-export for the shared HTML sanitizer.
  *
- * Call this on every rich-text field before persisting (notes, evidence
- * descriptions, intake form descriptions, policy bodies, etc.) to mitigate
- * stored XSS. The allowlist mirrors the one in
- * services/policies/policyImporter.ts: safe formatting/structural tags plus
- * inline images, with `data:` and `javascript:` URIs explicitly blocked.
- *
- * Behavior:
- *   - null / undefined inputs are returned unchanged (handy for optional fields)
- *   - non-string inputs are coerced to string before sanitizing
- *   - <script>, <iframe>, <object>, on* event handlers, javascript:/data: URIs
- *     are all stripped
- *   - tag/attribute allowlist below; everything else is dropped silently
+ * The canonical implementation now lives in {@link ../sanitization.utils.ts}.
+ * Existing imports from this path continue to work; new code should import
+ * directly from `Servers/utils/sanitization.utils.ts`.
  */
 
-import sanitizeHtml from "sanitize-html";
-
-export const USER_HTML_ALLOWED_TAGS = sanitizeHtml.defaults.allowedTags.concat([
-  "h1",
-  "h2",
-  "h3",
-  "img",
-  "sup",
-  "sub",
-  "u",
-  "s",
-]);
-
-export const USER_HTML_ALLOWED_ATTRIBUTES: sanitizeHtml.IOptions["allowedAttributes"] = {
-  ...sanitizeHtml.defaults.allowedAttributes,
-  img: ["src", "alt", "width", "height"],
-  a: ["href", "target", "rel"],
-};
-
-// `data:` is intentionally excluded — it can carry executable payloads via
-// <iframe src="data:text/html,..."> or <img src="data:image/svg+xml,..."> with
-// inline scripts.
-export const USER_HTML_ALLOWED_SCHEMES = ["http", "https", "blob"];
-
-const SANITIZE_OPTIONS: sanitizeHtml.IOptions = {
-  allowedTags: USER_HTML_ALLOWED_TAGS,
-  allowedAttributes: USER_HTML_ALLOWED_ATTRIBUTES,
-  allowedSchemes: USER_HTML_ALLOWED_SCHEMES,
-};
-
-export function sanitizeUserHtml<T extends string | null | undefined>(input: T): T;
-export function sanitizeUserHtml(input: unknown): string | null | undefined;
-export function sanitizeUserHtml(input: unknown): string | null | undefined {
-  if (input === null || input === undefined) return input as null | undefined;
-  const str = typeof input === "string" ? input : String(input);
-  return sanitizeHtml(str, SANITIZE_OPTIONS);
-}
+export {
+  sanitizeUserHtml,
+  USER_HTML_ALLOWED_TAGS,
+  USER_HTML_ALLOWED_ATTRIBUTES,
+  USER_HTML_ALLOWED_STYLES,
+  USER_HTML_ALLOWED_SCHEMES,
+} from "./sanitization.utils";


### PR DESCRIPTION
## Describe your changes

Implements a strict, shared HTML allowlist for user-generated rich text: `Servers/utils/sanitization.utils.ts` sanitizes data before persistence for policies, evidence hub, intake forms, and notes, while a new `RichTextRenderer` component and `useRichTextSanitizer` hook provide matching frontend rendering with optional sandboxing and a content-stripped warning. Includes expanded backend unit tests, frontend renderer tests, and i18n coverage.

Fixes No. 2 of #4150 

## Please ensure all items are checked off before requesting a review:

- [x] I deployed the code locally.
- [x] I have performed a self-review of my code.
- [x] I have included the issue # in the PR.
- [x] I have labelled the PR correctly.
- [x] The issue I am working on is assigned to me.
- [x] I have avoided using hardcoded values to ensure scalability and maintain consistency across the application.
- [x] I have ensured that font sizes, color choices, and other UI elements are referenced from the theme.
- [x] My pull request is focused and addresses a single, specific feature.
- [ ] If there are UI changes, I have attached a screenshot or video to this PR.
- [ ] If I added or modified an API endpoint, the change is reflected in the generated OpenAPI spec (`npm run generate:swagger`).
- [ ] If the endpoint requires authentication, it uses `authenticateJWT` and the generated spec declares `bearerAuth` security.
- [ ] I ran `npm run check:api-drift` and committed the regenerated `swagger.yaml` and `endpoints.ts`.
- [ ] If this PR adds or modifies an organization-scoped table, the [tenant isolation registry](Servers/tests/integration/tenant-isolation/tenantIsolation.registry.ts) and [test matrix](Servers/tests/integration/tenant-isolation) are updated. See the [tenant isolation runbook](docs/technical/security/tenant-isolation.md) for details.
