### PR TITLE
Disable current password check validations

### DIFF
--- a/Clients/src/presentation/pages/SettingsPage/Password/index.tsx
+++ b/Clients/src/presentation/pages/SettingsPage/Password/index.tsx
@@ -24,7 +24,6 @@ const PasswordForm: React.FC = () => {
   const [newPassword, setNewPassword] = useState<string>("");
   const [confirmPassword, setConfirmPassword] = useState<string>("");
 
-  const [currentPasswordError, setCurrentPasswordError] = useState<string | null>(null);
   const [newPasswordError, setNewPasswordError] = useState<string | null>(null);
   const [confirmPasswordError, setConfirmPasswordError] = useState<string | null>(null);
 
@@ -46,22 +45,8 @@ const PasswordForm: React.FC = () => {
     visible: false,
   });
 
-  // Handle current password validation
   const handleCurrentPasswordChange = useCallback((e: React.ChangeEvent<HTMLInputElement>) => {
-    const value = e.target.value;
-    setCurrentPassword(value);
-
-    const validation = checkStringValidation(
-      "Current password",
-      value,
-      8,
-      128,
-      true, // hasUpperCase
-      true, // hasLowerCase
-      true, // hasNumber
-      true, // hasSpecialCharacter
-    );
-    setCurrentPasswordError(validation.accepted ? null : validation.message);
+    setCurrentPassword(e.target.value);
   }, []);
 
   // Handle new password validation
@@ -90,7 +75,6 @@ const PasswordForm: React.FC = () => {
 
   // Handle save
   const handleSave = useCallback(async () => {
-    setCurrentPasswordError(null);
     setNewPasswordError(null);
     setConfirmPasswordError(null);
 
@@ -175,7 +159,6 @@ const PasswordForm: React.FC = () => {
     !currentPassword ||
     !newPassword ||
     !confirmPassword ||
-    !!currentPasswordError ||
     !!newPasswordError ||
     !!confirmPasswordError;
 
@@ -212,11 +195,6 @@ const PasswordForm: React.FC = () => {
               type="password"
               sx={{ mb: 5, backgroundColor: `${background.main}` }}
             />
-            {currentPasswordError && (
-              <Typography color="error" variant="caption">
-                {currentPasswordError}
-              </Typography>
-            )}
 
             <Field
               id="New password"


### PR DESCRIPTION
## Describe your changes

- Disable current password check validations when updating password from settings

## Write your issue number after "Fixes "

Enter the corresponding issue number after "Fixes #"

## Please ensure all items are checked off before requesting a review:

- [ ] I deployed the code locally.
- [ ] I have performed a self-review of my code.
- [ ] I have included the issue # in the PR.
- [ ] I have labelled the PR correctly.
- [ ] The issue I am working on is assigned to me.
- [ ] I have avoided using hardcoded values to ensure scalability and maintain consistency across the application.
- [ ] I have ensured that font sizes, color choices, and other UI elements are referenced from the theme.
- [ ] My pull request is focused and addresses a single, specific feature.
- [ ] If there are UI changes, I have attached a screenshot or video to this PR.
- [ ] If I added or modified an API endpoint, the change is reflected in the generated OpenAPI spec (`npm run generate:swagger`).
- [ ] If the endpoint requires authentication, it uses `authenticateJWT` and the generated spec declares `bearerAuth` security.
- [ ] I ran `npm run check:api-drift` and committed the regenerated `swagger.yaml` and `endpoints.ts`.
- [ ] If this PR adds or modifies an organization-scoped table, the [tenant isolation registry](Servers/tests/integration/tenant-isolation/tenantIsolation.registry.ts) and [test matrix](Servers/tests/integration/tenant-isolation) are updated. See the [tenant isolation runbook](docs/technical/security/tenant-isolation.md) for details.
