### PR TITLE
fix(auth): return 401 when a valid token references a missing user

### DIFF
--- a/Servers/middleware/auth.middleware.ts
+++ b/Servers/middleware/auth.middleware.ts
@@ -164,6 +164,17 @@ const authenticateJWT = async (
     // name is sourced live from the roles table (cached, TTL 60s, invalidated
     // on role CRUD) so adding/renaming a role doesn't need a code change.
     const user = await getUserByIdQuery(decoded.id);
+    // A correctly-signed, unexpired token can still reference a user that no
+    // longer exists (deleted account, or a token minted against a different
+    // database). Treat that as an authentication failure with 401 rather than
+    // dereferencing `user.role_id` and throwing an unhandled 500.
+    if (!user) {
+      return res.status(401).json(
+        STATUS_CODE[401]({
+          message: req.t!("Unauthorized **"),
+        }),
+      );
+    }
     const expectedRoleName = await getRoleNameById(user.role_id);
     if (decoded.roleName !== expectedRoleName) {
       return res.status(403).json({ message: req.t!("Not allowed to access") });


### PR DESCRIPTION
## Overview

Every authenticated request threw an unhandled 500 when the JWT referenced a user that no longer existed in the database. `getUserByIdQuery(decoded.id)` returns `undefined` for a missing row, and the next line dereferenced `user.role_id`, producing "Cannot read properties of undefined (reading 'role_id')".

This happens with a correctly-signed, unexpired token whose user was deleted, or a token minted against a different database (for example a stale browser session after a database reset). A single bad token took down every endpoint, since the guard runs in shared auth middleware.

## Changes

- Guard the result of `getUserByIdQuery` in the auth middleware. When no user is found, return 401 Unauthorized, consistent with the other authentication failures in this file, instead of falling through to a 500.

## Result

- A token for a non-existent user now returns 401 (previously 500).
- Normal login and authenticated requests are unaffected.