### PR TITLE
fix(mrm): use IN instead of ANY() for array-bound stage filters in attestation

### DIFF
--- a/Servers/utils/mrmAttestation.utils.ts
+++ b/Servers/utils/mrmAttestation.utils.ts
@@ -147,7 +147,7 @@ const getOpenFindingsBySeverityQuery = async (
     `SELECT severity, COUNT(*)::int AS count
        FROM mrm_findings
       WHERE organization_id = :organizationId
-        AND stage = ANY(:openStages)
+        AND stage IN (:openStages)
       GROUP BY severity`,
     {
       replacements: {
@@ -206,8 +206,8 @@ const getPerTierAttestationQuery = async (
        ) t ON t.model_inventory_id = mi.id
        LEFT JOIN (
          SELECT model_inventory_id,
-                COUNT(*) FILTER (WHERE stage = ANY(:openStages)) AS open_findings,
-                COUNT(*) FILTER (WHERE stage = ANY(:openStages) AND severity IN (:critical, :high)) AS critical_high_findings
+                COUNT(*) FILTER (WHERE stage IN (:openStages)) AS open_findings,
+                COUNT(*) FILTER (WHERE stage IN (:openStages) AND severity IN (:critical, :high)) AS critical_high_findings
            FROM mrm_findings
           WHERE organization_id = :organizationId
           GROUP BY model_inventory_id


### PR DESCRIPTION
## Overview

The attestation summary endpoint (`GET /api/mrm/attestation/summary`) returned 500 "syntax error at or near ','" on every request, breaking the Model risk management Overview tab and the downloadable attestation report.

Three queries in `mrmAttestation.utils.ts` filtered findings with `stage = ANY(:openStages)`, binding a JavaScript array to `:openStages`. Sequelize expands a named replacement bound to an array into a parenthesised comma-separated list, so the SQL became `ANY('open','remediation_planned',...)`. Postgres `ANY()` accepts a single array argument, so the extra commas are a syntax error.

## Changes

- Replace `stage = ANY(:openStages)` with `stage IN (:openStages)` at all three call sites (open-findings-by-severity and the two per-tier aggregates). The `IN (...)` form is exactly what Sequelize's comma-list expansion produces valid SQL for.

## Result

- `GET /api/mrm/attestation/summary` returns 200 with a well-formed summary.
- No behavioural change to the roll-up logic; only the SQL binding is corrected.