### PR TITLE
feat(mrm): route sub-tabs and settings sections, add SectionNav

### DIFF
--- a/Clients/src/application/config/routes.tsx
+++ b/Clients/src/application/config/routes.tsx
@@ -641,6 +641,24 @@ export const createRoutes = (
         </Suspense>
       }
     />
+    {/* MRM sub-tab (overview, tiering, validation, findings, monitoring, settings) */}
+    <Route
+      path="/model-inventory/model-risk-management/:mrmTab"
+      element={
+        <Suspense fallback={<LazyFallback />}>
+          <ModelInventory />
+        </Suspense>
+      }
+    />
+    {/* MRM settings section (metrics-feed, tiering-rules, thresholds, alerts, roles) */}
+    <Route
+      path="/model-inventory/model-risk-management/settings/:settingsSection"
+      element={
+        <Suspense fallback={<LazyFallback />}>
+          <ModelInventory />
+        </Suspense>
+      }
+    />
     {/* Model lifecycle detail page - rendered by plugin */}
     <Route
       path="/model-inventory/models/:id"

--- a/Clients/src/presentation/components/SectionNav/index.tsx
+++ b/Clients/src/presentation/components/SectionNav/index.tsx
@@ -1,0 +1,190 @@
+import { FC, ReactNode } from "react";
+import { List, ListItemButton, ListItemIcon, ListItemText } from "@mui/material";
+import { useTheme } from "@mui/material";
+import { Link as RouterLink } from "react-router-dom";
+import { brand } from "../../themes/palette";
+
+/**
+ * A single item in a {@link SectionNav}.
+ */
+export interface SectionNavItem {
+  /** Stable identifier, compared against `activeId` to mark the active row. */
+  id: string;
+  /** Visible label. */
+  label: string;
+  /** Optional leading icon (typically a 16px lucide-react icon). */
+  icon?: ReactNode;
+  /** Disable the row. */
+  disabled?: boolean;
+}
+
+export interface SectionNavProps {
+  /** Rows to render, in display order. */
+  items: SectionNavItem[];
+  /** Id of the currently active row. */
+  activeId: string;
+  /**
+   * Routing mode: return the href for an item and each row renders as a router
+   * link, so navigation updates the URL. Takes precedence over `onSelect`.
+   */
+  getHref?: (id: string) => string;
+  /** Callback mode: called with the item id when a row is clicked. */
+  onSelect?: (id: string) => void;
+  /** Accessible label for the navigation landmark. */
+  ariaLabel?: string;
+  /** Fixed width for the nav column. Defaults to 240px. */
+  width?: number | string;
+}
+
+/**
+ * Vertical section navigation styled to match the application sidebar rows
+ * (see `SidebarShell`). Unlike the sidebar it is a lightweight, non-collapsible,
+ * in-page nav with no Redux, logo, or footer. Use it for a page's secondary
+ * section switcher, either URL-driven (`getHref`) or state-driven (`onSelect`).
+ */
+const SectionNav: FC<SectionNavProps> = ({
+  items,
+  activeId,
+  getHref,
+  onSelect,
+  ariaLabel = "Sections",
+  width = 240,
+}) => {
+  const theme = useTheme();
+
+  return (
+    <List
+      component="nav"
+      aria-label={ariaLabel}
+      disablePadding
+      sx={{
+        width,
+        flexShrink: 0,
+        display: "flex",
+        flexDirection: "column",
+        gap: "4px",
+      }}
+    >
+      {items.map((item) => {
+        const isActive = item.id === activeId;
+        const isDisabled = item.disabled;
+
+        // Routing mode: the row is a router link and navigation is handled by
+        // the href. Callback mode: the row fires `onSelect`. `getHref` takes
+        // precedence, and we must NOT also call `onSelect` in that case, or the
+        // click would navigate twice and race.
+        const useHref = Boolean(getHref) && !isDisabled;
+        const linkProps = useHref ? { component: RouterLink, to: getHref!(item.id) } : {};
+
+        return (
+          <ListItemButton
+            key={item.id}
+            {...linkProps}
+            disableRipple={theme.components?.MuiListItemButton?.defaultProps?.disableRipple}
+            className={isActive ? "selected-path" : "unselected"}
+            onClick={() => {
+              if (isDisabled || useHref) return;
+              onSelect?.(item.id);
+            }}
+            disabled={isDisabled}
+            aria-current={isActive ? "page" : undefined}
+            aria-label={item.label}
+            sx={{
+              "height": "32px",
+              "gap": theme.spacing(4),
+              "borderRadius": theme.shape.borderRadius,
+              "px": theme.spacing(4),
+              "justifyContent": "flex-start",
+              "opacity": isDisabled ? 0.5 : 1,
+              "cursor": isDisabled ? "not-allowed" : "pointer",
+              "background":
+                isActive && !isDisabled
+                  ? "linear-gradient(135deg, #F7F7F7 0%, #F2F2F2 100%)"
+                  : "transparent",
+              "border": isActive && !isDisabled ? "1px solid #E8E8E8" : "1px solid transparent",
+              "&:hover": {
+                background: isDisabled
+                  ? "transparent"
+                  : isActive
+                    ? "linear-gradient(135deg, #F7F7F7 0%, #F2F2F2 100%)"
+                    : "#FAFAFA",
+                border: isDisabled
+                  ? "1px solid transparent"
+                  : isActive
+                    ? "1px solid #E8E8E8"
+                    : "1px solid transparent",
+              },
+              "&:hover svg": isDisabled
+                ? {}
+                : {
+                    color: `${brand.primary} !important`,
+                    stroke: `${brand.primary} !important`,
+                  },
+              "&:hover svg path": isDisabled
+                ? {}
+                : {
+                    stroke: `${brand.primary} !important`,
+                  },
+              "&.Mui-disabled": {
+                opacity: 0.5,
+              },
+            }}
+          >
+            {item.icon && (
+              <ListItemIcon
+                sx={{
+                  "minWidth": 0,
+                  "display": "flex",
+                  "alignItems": "center",
+                  "justifyContent": "center",
+                  "width": "16px",
+                  "mr": 0,
+                  "& svg": {
+                    color: isDisabled
+                      ? `${theme.palette.text.disabled} !important`
+                      : isActive
+                        ? `${brand.primary} !important`
+                        : `${theme.palette.text.tertiary} !important`,
+                    stroke: isDisabled
+                      ? `${theme.palette.text.disabled} !important`
+                      : isActive
+                        ? `${brand.primary} !important`
+                        : `${theme.palette.text.tertiary} !important`,
+                    transition: "color 0.2s ease, stroke 0.2s ease",
+                  },
+                  "& svg path": {
+                    stroke: isDisabled
+                      ? `${theme.palette.text.disabled} !important`
+                      : isActive
+                        ? `${brand.primary} !important`
+                        : `${theme.palette.text.tertiary} !important`,
+                  },
+                }}
+              >
+                {item.icon}
+              </ListItemIcon>
+            )}
+            <ListItemText
+              sx={{
+                "my": 0,
+                "& .MuiListItemText-primary": {
+                  fontSize: "13px",
+                  fontWeight: isActive ? 600 : 400,
+                  color: isDisabled
+                    ? theme.palette.text.disabled
+                    : isActive
+                      ? theme.palette.text.primary
+                      : theme.palette.text.secondary,
+                },
+              }}
+            >
+              {item.label}
+            </ListItemText>
+          </ListItemButton>
+        );
+      })}
+    </List>
+  );
+};
+
+export default SectionNav;

--- a/Clients/src/presentation/pages/ModelInventory/mrm/MetricsFeedSection.tsx
+++ b/Clients/src/presentation/pages/ModelInventory/mrm/MetricsFeedSection.tsx
@@ -40,10 +40,10 @@ interface MetricsFeedSectionProps {
   onSuccess: (message: string) => void;
 }
 
-const ENDPOINT_URL = "POST https://app.verifywise.ai/api/mrm/models/{externalModelKey}/metrics";
+const ENDPOINT_URL = "POST https://your-server/api/mrm/models/{externalModelKey}/metrics";
 
 const EXAMPLE_REQUEST = `# push one metric reading for a model (key in the path)
-curl -X POST https://app.verifywise.ai/api/mrm/models/retail-pd-scorecard/metrics \\
+curl -X POST https://your-server/api/mrm/models/retail-pd-scorecard/metrics \\
   -H "Authorization: Bearer vw_mrm_..." \\
   -H "Content-Type: application/json" \\
   -d '{

--- a/Clients/src/presentation/pages/ModelInventory/mrm/SettingsTab.tsx
+++ b/Clients/src/presentation/pages/ModelInventory/mrm/SettingsTab.tsx
@@ -61,7 +61,12 @@ const TIERING_RULES = [
 const RolesSection = ({ users, onError, onSuccess }: SettingsTabProps) => {
   const { data: fleet = [] } = useFleetTiering();
   const [modelId, setModelId] = useState<number | "">("");
-  const { data: roles = [] } = useModelRoles(modelId === "" ? null : Number(modelId));
+  // Do NOT default to `= []` here: when the query is disabled (no model
+  // selected) `data` is undefined, and an inline `= []` would produce a fresh
+  // array reference on every render. That new reference would retrigger the
+  // effect below, which calls setAssignments, causing an infinite render loop.
+  // Keeping `roles` as React Query's stable `data` avoids that.
+  const { data: roles } = useModelRoles(modelId === "" ? null : Number(modelId));
   const setRoles = useSetModelRoles();
 
   const [assignments, setAssignments] = useState<Record<MrmModelRole, number | "">>({
@@ -78,7 +83,7 @@ const RolesSection = ({ users, onError, onSuccess }: SettingsTabProps) => {
       [MrmModelRole.VALIDATOR]: "",
       [MrmModelRole.APPROVER]: "",
     };
-    roles.forEach((r) => {
+    (roles ?? []).forEach((r) => {
       if (r.user_id != null) next[r.role] = Number(r.user_id);
     });
     setAssignments(next);

--- a/Clients/src/presentation/pages/ModelInventory/mrm/SettingsTab.tsx
+++ b/Clients/src/presentation/pages/ModelInventory/mrm/SettingsTab.tsx
@@ -1,4 +1,5 @@
-import { useEffect, useMemo, useState } from "react";
+import { ReactNode, useEffect, useMemo, useState } from "react";
+import { useParams } from "react-router-dom";
 import {
   Box,
   Stack,
@@ -9,8 +10,9 @@ import {
   TableHead,
   TableRow,
   Typography,
-  useTheme,
 } from "@mui/material";
+import { Rss, Layers, SlidersHorizontal, Bell, Users } from "lucide-react";
+import SectionNav, { SectionNavItem } from "../../../components/SectionNav";
 import { CustomizableButton } from "../../../components/button/customizable-button";
 import Select from "../../../components/Inputs/Select";
 import { EmptyState } from "../../../components/EmptyState";
@@ -41,13 +43,47 @@ interface SettingsTabProps {
 
 type SettingsSection = "metrics-feed" | "tiering-rules" | "default-thresholds" | "alerts" | "roles";
 
-const SECTION_ITEMS: { key: SettingsSection; label: string }[] = [
-  { key: "metrics-feed", label: "Metrics feed & tokens" },
-  { key: "tiering-rules", label: "Tiering rules" },
-  { key: "default-thresholds", label: "Default thresholds" },
-  { key: "alerts", label: "Alerts & notifications" },
-  { key: "roles", label: "Roles & independence" },
+const MRM_SETTINGS_BASE_PATH = "/model-inventory/model-risk-management/settings";
+
+// The URL slug and the internal section key differ only for thresholds, where
+// the URL uses the shorter "thresholds".
+const SECTION_ITEMS: { key: SettingsSection; slug: string; label: string; icon: ReactNode }[] = [
+  {
+    key: "metrics-feed",
+    slug: "metrics-feed",
+    label: "Metrics feed & tokens",
+    icon: <Rss size={16} strokeWidth={1.5} />,
+  },
+  {
+    key: "tiering-rules",
+    slug: "tiering-rules",
+    label: "Tiering rules",
+    icon: <Layers size={16} strokeWidth={1.5} />,
+  },
+  {
+    key: "default-thresholds",
+    slug: "thresholds",
+    label: "Default thresholds",
+    icon: <SlidersHorizontal size={16} strokeWidth={1.5} />,
+  },
+  {
+    key: "alerts",
+    slug: "alerts",
+    label: "Alerts & notifications",
+    icon: <Bell size={16} strokeWidth={1.5} />,
+  },
+  {
+    key: "roles",
+    slug: "roles",
+    label: "Roles & independence",
+    icon: <Users size={16} strokeWidth={1.5} />,
+  },
 ];
+
+const DEFAULT_SECTION = SECTION_ITEMS[0];
+
+const sectionFromSlug = (slug: string | undefined): (typeof SECTION_ITEMS)[number] =>
+  SECTION_ITEMS.find((item) => item.slug === slug) ?? DEFAULT_SECTION;
 
 const TIERING_RULES = [
   {
@@ -232,45 +268,30 @@ const TieringRulesSection = () => (
 );
 
 const SettingsTab = ({ users, onError, onSuccess }: SettingsTabProps) => {
-  const theme = useTheme();
-  const [section, setSection] = useState<SettingsSection>("metrics-feed");
+  const { settingsSection } = useParams<{ settingsSection?: string }>();
+
+  // The active section is driven by the URL slug; an absent or unrecognised
+  // slug falls back to the first section.
+  const active = sectionFromSlug(settingsSection);
+  const section: SettingsSection = active.key;
+
+  const navItems: SectionNavItem[] = SECTION_ITEMS.map((item) => ({
+    id: item.key,
+    label: item.label,
+    icon: item.icon,
+  }));
+
+  const slugForKey = (key: string) =>
+    SECTION_ITEMS.find((item) => item.key === key)?.slug ?? DEFAULT_SECTION.slug;
 
   return (
     <Stack direction="row" sx={{ gap: "48px", alignItems: "flex-start" }}>
-      <Box
-        role="tablist"
-        sx={{
-          minWidth: "200px",
-          border: `1px solid ${theme.palette.border.dark}`,
-          borderRadius: "4px",
-          overflow: "hidden",
-          flexShrink: 0,
-        }}
-      >
-        {SECTION_ITEMS.map((item) => (
-          <Box
-            key={item.key}
-            role="tab"
-            aria-selected={section === item.key}
-            tabIndex={0}
-            onClick={() => setSection(item.key)}
-            onKeyDown={(e) => {
-              if (e.key === "Enter" || e.key === " ") setSection(item.key);
-            }}
-            sx={{
-              padding: "12px 16px",
-              fontSize: "13px",
-              cursor: "pointer",
-              borderBottom: `1px solid ${theme.palette.border.light}`,
-              backgroundColor: section === item.key ? "background.accent" : "transparent",
-              color: section === item.key ? "primary.main" : "text.secondary",
-              fontWeight: section === item.key ? 600 : 400,
-            }}
-          >
-            {item.label}
-          </Box>
-        ))}
-      </Box>
+      <SectionNav
+        items={navItems}
+        activeId={section}
+        ariaLabel="Settings sections"
+        getHref={(key) => `${MRM_SETTINGS_BASE_PATH}/${slugForKey(key)}`}
+      />
 
       <Box sx={{ flex: 1, minWidth: 0 }}>
         {section === "metrics-feed" && (

--- a/Clients/src/presentation/pages/ModelInventory/mrm/index.tsx
+++ b/Clients/src/presentation/pages/ModelInventory/mrm/index.tsx
@@ -1,4 +1,5 @@
 import { useState } from "react";
+import { useLocation, useNavigate } from "react-router-dom";
 import { Box, Fade } from "@mui/material";
 import TabContext from "@mui/lab/TabContext";
 import TabBar from "../../../components/TabBar";
@@ -16,7 +17,21 @@ interface ModelRiskManagementTabProps {
   users: MrmUser[];
 }
 
-type MrmSubTab = "overview" | "tiering" | "validation" | "findings" | "monitoring" | "settings";
+const MRM_BASE_PATH = "/model-inventory/model-risk-management";
+
+const MRM_SUB_TABS = [
+  "overview",
+  "tiering",
+  "validation",
+  "findings",
+  "monitoring",
+  "settings",
+] as const;
+
+type MrmSubTab = (typeof MRM_SUB_TABS)[number];
+
+const isMrmSubTab = (value: string | undefined): value is MrmSubTab =>
+  !!value && (MRM_SUB_TABS as readonly string[]).includes(value);
 
 interface MrmToast {
   variant: "success" | "error" | "info";
@@ -24,7 +39,16 @@ interface MrmToast {
 }
 
 const ModelRiskManagementTab = ({ users }: ModelRiskManagementTabProps) => {
-  const [subTab, setSubTab] = useState<MrmSubTab>("overview");
+  const location = useLocation();
+  const navigate = useNavigate();
+
+  // The active sub-tab is derived from the path segment that follows the MRM
+  // base, so that deeper paths like ".../settings/thresholds" still resolve the
+  // "settings" tab. An absent or unrecognised segment falls back to "overview".
+  const afterBase = location.pathname.split(`${MRM_BASE_PATH}/`)[1];
+  const firstSegment = afterBase ? afterBase.split("/")[0] : undefined;
+  const subTab: MrmSubTab = isMrmSubTab(firstSegment) ? firstSegment : "overview";
+
   const [toast, setToast] = useState<MrmToast | null>(null);
   const [showToast, setShowToast] = useState(false);
 
@@ -70,7 +94,10 @@ const ModelRiskManagementTab = ({ users }: ModelRiskManagementTabProps) => {
               { label: "Settings", value: "settings", icon: "Settings" },
             ]}
             activeTab={subTab}
-            onChange={(_e, value) => setSubTab(value as MrmSubTab)}
+            onChange={(_e, value) => {
+              const next = value as MrmSubTab;
+              navigate(next === "overview" ? MRM_BASE_PATH : `${MRM_BASE_PATH}/${next}`);
+            }}
             dataJoyrideId="mrm-sub-tabs"
           />
         </Box>

--- a/shared/user-guide-content/content/ai-governance/mrm.ts
+++ b/shared/user-guide-content/content/ai-governance/mrm.ts
@@ -191,7 +191,7 @@ export const mrmContent: ArticleContent = {
     {
       type: 'code',
       language: 'text',
-      code: 'POST https://app.verifywise.ai/api/mrm/models/{externalModelKey}/metrics',
+      code: 'POST https://your-server/api/mrm/models/{externalModelKey}/metrics',
     },
     {
       type: 'paragraph',


### PR DESCRIPTION
## Overview

Makes the Model risk management sub-tabs and settings sections URL-driven, adds a reusable section navigation component, and fixes a pre-existing render loop that froze the settings area.

## Changes

- Drive the six MRM sub-tabs (Overview, Tiering, Validation, Findings, Monitoring, Settings) from the URL instead of local state, so each is deep-linkable and survives refresh and browser back/forward. Overview maps to the base path; the rest to `/model-risk-management/<tab>`.
- Route the settings sections too: `/model-risk-management/settings/<section>` (metrics-feed, tiering-rules, thresholds, alerts, roles).
- Add a reusable `SectionNav` component (`components/SectionNav`): a lightweight, non-collapsible vertical section navigation styled to match the application sidebar rows. Supports URL-driven (`getHref`) or callback (`onSelect`) modes.
- Replace the hand-rolled settings section list with `SectionNav`.
- Use a generic `https://your-server` placeholder for the metrics ingestion endpoint and example request instead of a specific host, since the server URL varies per deployment. Applied in the settings UI and the user-guide article.

## Fix included

- Stop an infinite render loop in the settings roles section. It read `const { data: roles = [] } = useModelRoles(...)`; when no model is selected the query is disabled and `data` is undefined, so the inline `= []` produced a new array reference every render, retriggering an effect keyed on it. This froze the sub-tab bar and section list. The default is dropped so `roles` is the stable query data, with the effect guarded by `(roles ?? [])`. This bug currently affects develop independently of the routing work.

## Notes

- New route params add specific static segments, so they take precedence over the existing `/model-inventory/:pluginTab` catch-all.
- No new user-facing strings; the i18n strict audit stays at 100%. Type check, lint/format, and i18n all pass.