### PR TITLE
fix(mrm): persist external_key on model inventory update

### DIFF
--- a/Servers/controllers/modelInventory.ctrl.ts
+++ b/Servers/controllers/modelInventory.ctrl.ts
@@ -387,6 +387,7 @@ export async function updateModelInventoryById(req: Request, res: Response) {
     hosting_provider,
     security_assessment_data,
     is_demo,
+    external_key,
     projects,
     frameworks,
     deleteProjects,
@@ -456,6 +457,7 @@ export async function updateModelInventoryById(req: Request, res: Response) {
       hosting_provider,
       security_assessment_data,
       is_demo,
+      external_key,
     });
 
     // Use the existing database query approach for updating

--- a/Servers/domain.layer/models/modelInventory/modelInventory.model.ts
+++ b/Servers/domain.layer/models/modelInventory/modelInventory.model.ts
@@ -505,6 +505,9 @@ export class ModelInventoryModel extends Model<ModelInventoryModel> implements I
     if (data.is_demo !== undefined) {
       existingModel.is_demo = data.is_demo;
     }
+    if (data.external_key !== undefined) {
+      existingModel.external_key = data.external_key;
+    }
 
     // Always update the updated_at timestamp
     existingModel.updated_at = new Date();

--- a/Servers/utils/modelInventory.utils.ts
+++ b/Servers/utils/modelInventory.utils.ts
@@ -306,7 +306,7 @@ export const updateModelInventoryByIdQuery = async (
   try {
     // First update the record
     await sequelize.query(
-      `UPDATE model_inventories SET provider_model = :provider_model, provider = :provider, model = :model, version = :version, approver = :approver, capabilities = :capabilities, security_assessment = :security_assessment, status = :status, status_date = :status_date, reference_link = :reference_link, biases = :biases, limitations = :limitations,  hosting_provider = :hosting_provider, security_assessment_data = :security_assessment_data, is_demo = :is_demo, updated_at = :updated_at WHERE organization_id = :organization_id AND id = :id`,
+      `UPDATE model_inventories SET provider_model = :provider_model, provider = :provider, model = :model, version = :version, approver = :approver, capabilities = :capabilities, security_assessment = :security_assessment, status = :status, status_date = :status_date, reference_link = :reference_link, biases = :biases, limitations = :limitations,  hosting_provider = :hosting_provider, security_assessment_data = :security_assessment_data, is_demo = :is_demo, external_key = :external_key, updated_at = :updated_at WHERE organization_id = :organization_id AND id = :id`,
       {
         replacements: {
           organization_id: organizationId,
@@ -328,6 +328,7 @@ export const updateModelInventoryByIdQuery = async (
           hosting_provider: modelInventory.hosting_provider,
           security_assessment_data: JSON.stringify(modelInventory.security_assessment_data || []),
           is_demo: modelInventory.is_demo,
+          external_key: modelInventory.external_key ?? null,
           updated_at,
         },
         transaction,


### PR DESCRIPTION
## Overview

The model-inventory update endpoint (`PATCH /api/modelInventory/:id`) accepted a request and returned 200 but silently dropped `external_key`. It was absent from the controller's request-body allow-list, the model's `updateModelInventory` method, and the UPDATE SQL column list.

Because `external_key` is the only handle the MRM metric-ingestion endpoint (`POST /api/mrm/models/:externalModelKey/metrics`) uses to resolve a model, there was no working way to set it. Every ingestion request returned `404 "Model not found for this key"`, which made MRM monitoring unusable end to end.

## Changes

- `controllers/modelInventory.ctrl.ts`: destructure `external_key` from the request body and pass it to `ModelInventoryModel.updateModelInventory`.
- `domain.layer/models/modelInventory/modelInventory.model.ts`: set `external_key` in `updateModelInventory` when provided (partial-update guard, so an omitted key leaves the existing value untouched).
- `utils/modelInventory.utils.ts`: add `external_key` to the UPDATE SET clause and replacements, defaulting to the existing value (`?? null`) so unrelated updates never wipe a previously set key.

## Result

`PATCH /api/modelInventory/:id { external_key }` now persists the key (database-confirmed), and metric ingestion resolves the model instead of 404.

## Notes

- Tenant isolation is unchanged (`WHERE organization_id = :organization_id AND id = :id`); the change only adds one parameterized column to the SET list.
- The read query uses `SELECT *`, so the model object carries the existing key through the update chain; `?? null` only applies to models that genuinely have no key.
- A follow-up covers making `external_key` settable at model-create time and in the UI form; this PR fixes the update path that ingestion depends on.