### PR TITLE
feat(mrm): scenario-driven metric simulator and gap-finder

### DIFF
--- a/docs/superpowers/plans/2026-07-04-mrm-model-eval-simulator.md
+++ b/docs/superpowers/plans/2026-07-04-mrm-model-eval-simulator.md
@@ -1,0 +1,1445 @@
+# MRM model-eval simulator — implementation plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Build a standalone TypeScript CLI (`tools/mrm-simulator`) that impersonates a model-monitoring platform, feeds scenario-driven metrics into VerifyWise's MRM ingestion API, and emits a gap-findings report.
+
+**Architecture:** A self-contained CLI with pure scenario/engine modules (unit-tested) and thin HTTP clients over the real MRM API. Commands: `setup` (idempotent fleet + thresholds + token via JWT), `backfill`/`live` (push metrics via ingestion token), `verify`/`report` (read MRM back, check the governance loop, write `gaps-report.md`).
+
+**Tech Stack:** TypeScript, tsx (runner), vitest (tests), node built-in `fetch`. No new repo-wide dependencies; the tool has its own `package.json`.
+
+## Global Constraints
+
+- Tool lives entirely under `tools/mrm-simulator/`. It does NOT modify the MRM feature, `Servers/`, or `Clients/`.
+- Ingestion auth header: `Authorization: Bearer mrm_<64 hex>` (no `vw_` prefix).
+- Response envelope is always `{ message, data }`. The useful payload is at `response.data` of the parsed JSON (e.g. login token = parsed `.data.token`).
+- Ingestion endpoint: `POST /api/mrm/models/:externalModelKey/metrics`, batch body `{ points: [...] }`, per-point fields `metric` (string ≤100), `value` (finite number), `at` (ISO-8601, ≤1h future), optional `window`/`segment`/`context`.
+- Per-point response `status` ∈ `ok | warn | breach | no_threshold | duplicate`.
+- Threshold ops: `gt | gte | lt | lte | outside`. `outside` needs `value_lo < value_hi`; others need `value_num`.
+- Tier values are strings: `"1" | "2" | "3"`.
+- `external_key` is set via `PATCH /api/modelInventory/:id`, NOT the tier endpoint.
+- Default base URL `http://localhost:3000`; refuse non-localhost unless `--i-know-what-im-doing`.
+- Dev credentials default: `gorkem.cetin@verifywise.ai` / `Verifywise#1` (overridable via env `VW_EMAIL` / `VW_PASSWORD`).
+- No secrets committed. Token cache `tools/mrm-simulator/.mrm-simulator.json` is git-ignored.
+
+---
+
+## File structure
+
+```
+tools/mrm-simulator/
+  package.json
+  tsconfig.json
+  vitest.config.ts
+  .gitignore
+  README.md
+  scenarios/
+    storylines.ts        # pure metric(model, dayIndex) -> value
+    storylines.test.ts
+    fleet.ts             # static fleet: models, tiers, external_keys, threshold specs
+  src/
+    types.ts             # shared types (MetricPoint, Finding, etc.)
+    config.ts            # base URL, creds, localhost guard, cache read/write
+    config.test.ts
+    engine.ts            # walk storylines over a date range -> MetricPoint[]
+    engine.test.ts
+    httpEnvelope.ts      # parse { message, data } envelope + errors
+    httpEnvelope.test.ts
+    jwtClient.ts         # login + JWT-authed calls
+    ingestClient.ts      # token-authed batched POST /metrics
+    setup.ts             # idempotent fleet + thresholds + token
+    verify.ts            # read-back + gap checks -> Finding[]
+    report.ts            # Finding[] -> gaps-report.md
+    report.test.ts
+    cli.ts               # arg parse + dispatch
+  gaps-report.md         # generated (git-ignored)
+```
+
+---
+
+### Task 1: Scaffold the tool
+
+**Files:**
+- Create: `tools/mrm-simulator/package.json`
+- Create: `tools/mrm-simulator/tsconfig.json`
+- Create: `tools/mrm-simulator/vitest.config.ts`
+- Create: `tools/mrm-simulator/.gitignore`
+
+**Interfaces:**
+- Produces: an installable, test-runnable TS package. Scripts: `npm test`, and `npx tsx src/cli.ts <command>`.
+
+- [ ] **Step 1: Create package.json**
+
+```json
+{
+  "name": "mrm-simulator",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "description": "Scenario-driven MRM metric simulator and gap-finder for VerifyWise",
+  "scripts": {
+    "test": "vitest run",
+    "sim": "tsx src/cli.ts"
+  },
+  "devDependencies": {
+    "tsx": "^4.19.2",
+    "typescript": "^5.6.3",
+    "vitest": "^2.1.8",
+    "@types/node": "^22.10.1"
+  }
+}
+```
+
+- [ ] **Step 2: Create tsconfig.json**
+
+```json
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ES2022",
+    "moduleResolution": "bundler",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "types": ["node"],
+    "noEmit": true
+  },
+  "include": ["src", "scenarios"]
+}
+```
+
+- [ ] **Step 3: Create vitest.config.ts**
+
+```typescript
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    include: ["**/*.test.ts"],
+    environment: "node",
+  },
+});
+```
+
+- [ ] **Step 4: Create .gitignore**
+
+```
+node_modules/
+.mrm-simulator.json
+gaps-report.md
+```
+
+- [ ] **Step 5: Install and verify**
+
+Run: `cd tools/mrm-simulator && npm install && npx vitest run`
+Expected: install succeeds; vitest runs with "No test files found" (exit 0 or a no-tests message).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add tools/mrm-simulator/package.json tools/mrm-simulator/tsconfig.json tools/mrm-simulator/vitest.config.ts tools/mrm-simulator/.gitignore
+git commit -m "chore(mrm-sim): scaffold simulator tool"
+```
+
+---
+
+### Task 2: Shared types
+
+**Files:**
+- Create: `tools/mrm-simulator/src/types.ts`
+
+**Interfaces:**
+- Produces: `MetricPoint`, `ThresholdSpec`, `FleetModel`, `Finding`, `SimConfig`, `IngestResultPoint` — consumed by every later task.
+
+- [ ] **Step 1: Write the types**
+
+```typescript
+// A single metric reading in the ingestion wire format.
+export interface MetricPoint {
+  metric: string;
+  value: number;
+  at: string; // ISO-8601
+  window?: string;
+  segment?: string;
+  context?: Record<string, unknown>;
+}
+
+// Threshold to create for a model during setup.
+export interface ThresholdSpec {
+  metric: string;
+  op: "gt" | "gte" | "lt" | "lte" | "outside";
+  value_num?: number | null;
+  value_lo?: number | null;
+  value_hi?: number | null;
+  severity: "warn" | "high" | "critical";
+  breach_action: "notify" | "notify_flag_revalidation";
+  segment?: string | null;
+  window?: string | null;
+}
+
+// A model in the scenario fleet.
+export interface FleetModel {
+  externalKey: string;
+  name: string;
+  provider: string;
+  tier: "1" | "2" | "3";
+  materialityDrivers: string;
+  metricKeys: string[]; // keys to register (e.g. psi, auc, gini, ks)
+  thresholds: ThresholdSpec[];
+}
+
+// Per-point result the ingestion API returns.
+export interface IngestResultPoint {
+  metric: string;
+  at: string;
+  status: "ok" | "warn" | "breach" | "no_threshold" | "duplicate";
+  pointId: number | null;
+  threshold?: {
+    op: string;
+    value_num: number | null;
+    value_lo: number | null;
+    value_hi: number | null;
+    severity: string;
+  };
+}
+
+// A gap-finding.
+export interface Finding {
+  category: "contract" | "workflow" | "ux";
+  severity: "high" | "medium" | "low";
+  title: string;
+  expected: string;
+  actual: string;
+  repro: string;
+}
+
+export interface SimConfig {
+  baseUrl: string;
+  email: string;
+  password: string;
+  allowRemote: boolean;
+}
+```
+
+- [ ] **Step 2: Typecheck**
+
+Run: `cd tools/mrm-simulator && npx tsc --noEmit`
+Expected: no errors.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add tools/mrm-simulator/src/types.ts
+git commit -m "feat(mrm-sim): shared types"
+```
+
+---
+
+### Task 3: Storylines (pure, TDD)
+
+**Files:**
+- Create: `tools/mrm-simulator/scenarios/storylines.ts`
+- Test: `tools/mrm-simulator/scenarios/storylines.test.ts`
+
+**Interfaces:**
+- Produces: `metricValue(externalKey: string, metric: string, dayIndex: number, segment?: string): number` — deterministic value for a model's metric on a given day. `dayIndex` 0 = oldest day of a backfill window.
+
+- [ ] **Step 1: Write the failing test**
+
+```typescript
+import { describe, it, expect } from "vitest";
+import { metricValue } from "./storylines";
+
+describe("storylines", () => {
+  it("credit-scoring-v3 PSI drifts across 0.20 around day 18", () => {
+    expect(metricValue("credit-scoring-v3", "psi", 0)).toBeLessThan(0.1);
+    expect(metricValue("credit-scoring-v3", "psi", 17)).toBeLessThan(0.2);
+    expect(metricValue("credit-scoring-v3", "psi", 20)).toBeGreaterThan(0.2);
+  });
+
+  it("fraud-detector-v2 stays healthy (psi never breaches 0.25)", () => {
+    for (let d = 0; d < 30; d++) {
+      expect(metricValue("fraud-detector-v2", "psi", d)).toBeLessThan(0.25);
+    }
+  });
+
+  it("loan-approval-v1 subprime gini drops below 0.45 while overall stays in band", () => {
+    const lateSubprime = metricValue("loan-approval-v1", "gini", 25, "subprime");
+    const lateOverall = metricValue("loan-approval-v1", "gini", 25, "overall");
+    expect(lateSubprime).toBeLessThan(0.45);
+    expect(lateOverall).toBeGreaterThanOrEqual(0.45);
+    expect(lateOverall).toBeLessThanOrEqual(0.75);
+  });
+
+  it("churn-propensity-v1 breaches psi>0.15 mid-window then recovers", () => {
+    expect(metricValue("churn-propensity-v1", "psi", 15)).toBeGreaterThan(0.15);
+    expect(metricValue("churn-propensity-v1", "psi", 28)).toBeLessThan(0.15);
+  });
+
+  it("is deterministic (same inputs -> same output)", () => {
+    expect(metricValue("credit-scoring-v3", "psi", 10)).toBe(
+      metricValue("credit-scoring-v3", "psi", 10),
+    );
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd tools/mrm-simulator && npx vitest run scenarios/storylines.test.ts`
+Expected: FAIL with "metricValue is not a function" / module not found.
+
+- [ ] **Step 3: Write the implementation**
+
+```typescript
+// Deterministic, seeded metric storylines. Values are a function of
+// (externalKey, metric, dayIndex, segment) with small reproducible noise so
+// charts look organic without random run-to-run variation.
+
+// Deterministic pseudo-noise in [-1, 1] from integer-ish inputs (no Math.random).
+const noise = (seed: number): number => {
+  const x = Math.sin(seed * 12.9898) * 43758.5453;
+  return (x - Math.floor(x)) * 2 - 1;
+};
+
+const clamp = (v: number, lo: number, hi: number): number => Math.min(hi, Math.max(lo, v));
+
+// Linear ramp helper.
+const ramp = (day: number, fromDay: number, toDay: number, fromVal: number, toVal: number): number => {
+  if (day <= fromDay) return fromVal;
+  if (day >= toDay) return toVal;
+  const t = (day - fromDay) / (toDay - fromDay);
+  return fromVal + t * (toVal - fromVal);
+};
+
+export const metricValue = (
+  externalKey: string,
+  metric: string,
+  dayIndex: number,
+  segment: string = "overall",
+): number => {
+  const n = noise(dayIndex + metric.length * 7 + externalKey.length * 13) * 0.01;
+
+  if (externalKey === "credit-scoring-v3") {
+    if (metric === "psi") return clamp(ramp(dayIndex, 0, 30, 0.05, 0.24) + n, 0, 1);
+    if (metric === "auc") return clamp(ramp(dayIndex, 0, 30, 0.86, 0.82) + n, 0, 1);
+    if (metric === "gini") return clamp(ramp(dayIndex, 0, 30, 0.7, 0.63) + n, 0, 1);
+    if (metric === "ks") return clamp(0.4 + n, 0, 1);
+  }
+
+  if (externalKey === "fraud-detector-v2") {
+    if (metric === "psi") return clamp(0.04 + n, 0, 1);
+    if (metric === "auc") return clamp(0.94 + n, 0, 1);
+    if (metric === "gini") return clamp(0.88 + n, 0, 1);
+    if (metric === "ks") return clamp(0.6 + n, 0, 1);
+  }
+
+  if (externalKey === "loan-approval-v1") {
+    if (metric === "gini") {
+      if (segment === "subprime") return clamp(ramp(dayIndex, 0, 30, 0.6, 0.4) + n, 0, 1);
+      return clamp(0.62 + n, 0, 1); // overall stays inside [0.45, 0.75]
+    }
+    if (metric === "psi") return clamp(0.06 + n, 0, 1);
+    if (metric === "auc") return clamp(0.83 + n, 0, 1);
+    if (metric === "ks") return clamp(0.45 + n, 0, 1);
+  }
+
+  if (externalKey === "churn-propensity-v1") {
+    if (metric === "psi") {
+      // healthy -> breach ~day 10 -> retrain recovery ~day 22
+      const drift = ramp(dayIndex, 5, 12, 0.08, 0.2);
+      const recover = ramp(dayIndex, 22, 26, 0.2, 0.08);
+      const v = dayIndex < 22 ? drift : recover;
+      return clamp(v + n, 0, 1);
+    }
+    if (metric === "auc") return clamp(0.8 + n, 0, 1);
+    if (metric === "gini") return clamp(0.55 + n, 0, 1);
+    if (metric === "ks") return clamp(0.38 + n, 0, 1);
+  }
+
+  // Unknown model/metric: benign flat value.
+  return clamp(0.5 + n, 0, 1);
+};
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd tools/mrm-simulator && npx vitest run scenarios/storylines.test.ts`
+Expected: PASS (all 5 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add tools/mrm-simulator/scenarios/storylines.ts tools/mrm-simulator/scenarios/storylines.test.ts
+git commit -m "feat(mrm-sim): deterministic metric storylines"
+```
+
+---
+
+### Task 4: Fleet definition
+
+**Files:**
+- Create: `tools/mrm-simulator/scenarios/fleet.ts`
+
+**Interfaces:**
+- Consumes: `FleetModel`, `ThresholdSpec` from `src/types.ts`.
+- Produces: `FLEET: FleetModel[]` — the four scenario models with their thresholds, consumed by `engine`, `setup`, and `verify`.
+
+- [ ] **Step 1: Write the fleet**
+
+```typescript
+import { FleetModel } from "../src/types.js";
+
+export const FLEET: FleetModel[] = [
+  {
+    externalKey: "credit-scoring-v3",
+    name: "Credit scoring v3",
+    provider: "in-house",
+    tier: "1",
+    materialityDrivers: "capital impact, regulatory reporting, customer exposure",
+    metricKeys: ["psi", "auc", "gini", "ks"],
+    thresholds: [
+      { metric: "psi", op: "gt", value_num: 0.2, severity: "high", breach_action: "notify_flag_revalidation" },
+      { metric: "auc", op: "lt", value_num: 0.8, severity: "warn", breach_action: "notify" },
+    ],
+  },
+  {
+    externalKey: "fraud-detector-v2",
+    name: "Fraud detector v2",
+    provider: "in-house",
+    tier: "1",
+    materialityDrivers: "fraud loss exposure, real-time decisioning",
+    metricKeys: ["psi", "auc", "gini", "ks"],
+    thresholds: [
+      { metric: "psi", op: "gt", value_num: 0.25, severity: "high", breach_action: "notify" },
+    ],
+  },
+  {
+    externalKey: "loan-approval-v1",
+    name: "Loan approval v1",
+    provider: "in-house",
+    tier: "2",
+    materialityDrivers: "lending decisions, fair-lending risk",
+    metricKeys: ["psi", "auc", "gini", "ks"],
+    thresholds: [
+      {
+        metric: "gini",
+        op: "outside",
+        value_lo: 0.45,
+        value_hi: 0.75,
+        severity: "high",
+        breach_action: "notify_flag_revalidation",
+        segment: "subprime",
+      },
+    ],
+  },
+  {
+    externalKey: "churn-propensity-v1",
+    name: "Churn propensity v1",
+    provider: "in-house",
+    tier: "3",
+    materialityDrivers: "retention spend allocation",
+    metricKeys: ["psi", "auc", "gini", "ks"],
+    thresholds: [
+      { metric: "psi", op: "gt", value_num: 0.15, severity: "warn", breach_action: "notify" },
+    ],
+  },
+];
+```
+
+- [ ] **Step 2: Typecheck**
+
+Run: `cd tools/mrm-simulator && npx tsc --noEmit`
+Expected: no errors.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add tools/mrm-simulator/scenarios/fleet.ts
+git commit -m "feat(mrm-sim): scenario fleet definition"
+```
+
+---
+
+### Task 5: Engine (pure, TDD)
+
+**Files:**
+- Create: `tools/mrm-simulator/src/engine.ts`
+- Test: `tools/mrm-simulator/src/engine.test.ts`
+
+**Interfaces:**
+- Consumes: `FLEET`, `metricValue`, `MetricPoint`.
+- Produces: `generatePoints(model: FleetModel, dayIndex: number, date: Date): MetricPoint[]` and `generateRange(model: FleetModel, startDate: Date, days: number): MetricPoint[]` — the points to push. Segmented `gini` is emitted for models whose thresholds reference a segment.
+
+- [ ] **Step 1: Write the failing test**
+
+```typescript
+import { describe, it, expect } from "vitest";
+import { generatePoints, generateRange } from "./engine";
+import { FLEET } from "../scenarios/fleet";
+
+const model = (key: string) => FLEET.find((m) => m.externalKey === key)!;
+
+describe("engine", () => {
+  it("generates one point per metric key plus segmented points where thresholds are segmented", () => {
+    const pts = generatePoints(model("loan-approval-v1"), 10, new Date("2026-07-01T00:00:00Z"));
+    // 4 base metric keys + 1 segmented gini (subprime)
+    expect(pts.filter((p) => p.segment === "subprime").length).toBe(1);
+    expect(pts.length).toBe(5);
+  });
+
+  it("stamps ISO 'at' and finite values", () => {
+    const pts = generatePoints(model("credit-scoring-v3"), 0, new Date("2026-07-01T00:00:00Z"));
+    for (const p of pts) {
+      expect(Number.isFinite(p.value)).toBe(true);
+      expect(p.at).toBe("2026-07-01T00:00:00.000Z");
+    }
+  });
+
+  it("generateRange produces days*perDay points", () => {
+    const pts = generateRange(model("fraud-detector-v2"), new Date("2026-06-01T00:00:00Z"), 30);
+    expect(pts.length).toBe(30 * 4); // 4 metric keys, no segmented threshold
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd tools/mrm-simulator && npx vitest run src/engine.test.ts`
+Expected: FAIL (module not found).
+
+- [ ] **Step 3: Write the implementation**
+
+```typescript
+import { FleetModel, MetricPoint } from "./types.js";
+import { metricValue } from "../scenarios/storylines.js";
+
+// Segments a model reports for a metric, derived from its segmented thresholds.
+const segmentsFor = (model: FleetModel, metric: string): string[] => {
+  const segs = model.thresholds
+    .filter((t) => t.metric === metric && t.segment)
+    .map((t) => t.segment as string);
+  return [...new Set(segs)];
+};
+
+export const generatePoints = (model: FleetModel, dayIndex: number, date: Date): MetricPoint[] => {
+  const at = date.toISOString();
+  const points: MetricPoint[] = [];
+  for (const metric of model.metricKeys) {
+    // Base (overall) point.
+    points.push({
+      metric,
+      value: Number(metricValue(model.externalKey, metric, dayIndex).toFixed(4)),
+      at,
+      window: "daily",
+      segment: "overall",
+      context: { source_job: "nightly-monitor", day_index: dayIndex },
+    });
+    // Segmented points where a threshold targets a sub-population.
+    for (const seg of segmentsFor(model, metric)) {
+      points.push({
+        metric,
+        value: Number(metricValue(model.externalKey, metric, dayIndex, seg).toFixed(4)),
+        at,
+        window: "daily",
+        segment: seg,
+        context: { source_job: "nightly-monitor", day_index: dayIndex },
+      });
+    }
+  }
+  return points;
+};
+
+export const generateRange = (model: FleetModel, startDate: Date, days: number): MetricPoint[] => {
+  const all: MetricPoint[] = [];
+  for (let d = 0; d < days; d++) {
+    const date = new Date(startDate.getTime() + d * 86_400_000);
+    all.push(...generatePoints(model, d, date));
+  }
+  return all;
+};
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd tools/mrm-simulator && npx vitest run src/engine.test.ts`
+Expected: PASS (3 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add tools/mrm-simulator/src/engine.ts tools/mrm-simulator/src/engine.test.ts
+git commit -m "feat(mrm-sim): metric generation engine"
+```
+
+---
+
+### Task 6: Config + localhost guard (TDD)
+
+**Files:**
+- Create: `tools/mrm-simulator/src/config.ts`
+- Test: `tools/mrm-simulator/src/config.test.ts`
+
+**Interfaces:**
+- Consumes: `SimConfig`.
+- Produces: `loadConfig(argv: string[]): SimConfig`, `assertSafeTarget(cfg: SimConfig): void`, `readCache(): CacheFile`, `writeCache(c: CacheFile): void`. `CacheFile = { token?: string; models: Record<string, number> }` (externalKey -> modelId).
+
+- [ ] **Step 1: Write the failing test**
+
+```typescript
+import { describe, it, expect } from "vitest";
+import { loadConfig, assertSafeTarget } from "./config";
+
+describe("config", () => {
+  it("defaults to localhost:3000", () => {
+    const cfg = loadConfig([]);
+    expect(cfg.baseUrl).toBe("http://localhost:3000");
+  });
+
+  it("assertSafeTarget allows localhost", () => {
+    expect(() => assertSafeTarget(loadConfig([]))).not.toThrow();
+  });
+
+  it("assertSafeTarget rejects a remote host without the override flag", () => {
+    const cfg = loadConfig(["--base-url", "https://app.example.com"]);
+    expect(() => assertSafeTarget(cfg)).toThrow(/refusing/i);
+  });
+
+  it("allows a remote host with --i-know-what-im-doing", () => {
+    const cfg = loadConfig(["--base-url", "https://app.example.com", "--i-know-what-im-doing"]);
+    expect(() => assertSafeTarget(cfg)).not.toThrow();
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd tools/mrm-simulator && npx vitest run src/config.test.ts`
+Expected: FAIL (module not found).
+
+- [ ] **Step 3: Write the implementation**
+
+```typescript
+import { readFileSync, writeFileSync, existsSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+import { SimConfig } from "./types.js";
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const CACHE_PATH = join(HERE, "..", ".mrm-simulator.json");
+
+export interface CacheFile {
+  token?: string;
+  models: Record<string, number>; // externalKey -> modelId
+}
+
+const flag = (argv: string[], name: string): string | undefined => {
+  const i = argv.indexOf(name);
+  return i >= 0 && i + 1 < argv.length ? argv[i + 1] : undefined;
+};
+
+const has = (argv: string[], name: string): boolean => argv.includes(name);
+
+export const loadConfig = (argv: string[]): SimConfig => ({
+  baseUrl: flag(argv, "--base-url") ?? "http://localhost:3000",
+  email: process.env.VW_EMAIL ?? "gorkem.cetin@verifywise.ai",
+  password: process.env.VW_PASSWORD ?? "Verifywise#1",
+  allowRemote: has(argv, "--i-know-what-im-doing"),
+});
+
+export const assertSafeTarget = (cfg: SimConfig): void => {
+  const isLocal = /^https?:\/\/(localhost|127\.0\.0\.1)(:\d+)?/.test(cfg.baseUrl);
+  if (!isLocal && !cfg.allowRemote) {
+    throw new Error(
+      `refusing to run against non-localhost target ${cfg.baseUrl}. ` +
+        `Pass --i-know-what-im-doing to override (this sends synthetic data).`,
+    );
+  }
+};
+
+export const readCache = (): CacheFile => {
+  if (!existsSync(CACHE_PATH)) return { models: {} };
+  return JSON.parse(readFileSync(CACHE_PATH, "utf8")) as CacheFile;
+};
+
+export const writeCache = (c: CacheFile): void => {
+  writeFileSync(CACHE_PATH, JSON.stringify(c, null, 2));
+};
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd tools/mrm-simulator && npx vitest run src/config.test.ts`
+Expected: PASS (4 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add tools/mrm-simulator/src/config.ts tools/mrm-simulator/src/config.test.ts
+git commit -m "feat(mrm-sim): config, cache, and localhost safety guard"
+```
+
+---
+
+### Task 7: HTTP envelope parser (TDD)
+
+**Files:**
+- Create: `tools/mrm-simulator/src/httpEnvelope.ts`
+- Test: `tools/mrm-simulator/src/httpEnvelope.test.ts`
+
+**Interfaces:**
+- Produces: `parseEnvelope<T>(res: Response): Promise<{ status: number; data: T }>` — reads the `{ message, data }` body, returns HTTP status + inner `data`. Throws `HttpError` (with `.status` and `.body`) on non-2xx unless caller opts to inspect.
+
+- [ ] **Step 1: Write the failing test**
+
+```typescript
+import { describe, it, expect } from "vitest";
+import { parseEnvelope, HttpError } from "./httpEnvelope";
+
+const fakeRes = (status: number, body: unknown): Response =>
+  new Response(JSON.stringify(body), { status, headers: { "content-type": "application/json" } });
+
+describe("httpEnvelope", () => {
+  it("returns inner data on 2xx", async () => {
+    const r = await parseEnvelope<{ token: string }>(fakeRes(202, { message: "Accepted", data: { token: "t" } }));
+    expect(r.status).toBe(202);
+    expect(r.data.token).toBe("t");
+  });
+
+  it("throws HttpError on non-2xx with the parsed body", async () => {
+    await expect(parseEnvelope(fakeRes(404, { message: "Not Found", data: "Model not found for this key" }))).rejects.toBeInstanceOf(HttpError);
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd tools/mrm-simulator && npx vitest run src/httpEnvelope.test.ts`
+Expected: FAIL (module not found).
+
+- [ ] **Step 3: Write the implementation**
+
+```typescript
+export class HttpError extends Error {
+  status: number;
+  body: unknown;
+  constructor(status: number, body: unknown) {
+    super(`HTTP ${status}: ${JSON.stringify(body)}`);
+    this.status = status;
+    this.body = body;
+  }
+}
+
+export const parseEnvelope = async <T>(res: Response): Promise<{ status: number; data: T }> => {
+  const text = await res.text();
+  let body: unknown;
+  try {
+    body = text ? JSON.parse(text) : {};
+  } catch {
+    throw new HttpError(res.status, text);
+  }
+  if (res.status < 200 || res.status >= 300) {
+    throw new HttpError(res.status, body);
+  }
+  const data = (body as { data: T }).data;
+  return { status: res.status, data };
+};
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd tools/mrm-simulator && npx vitest run src/httpEnvelope.test.ts`
+Expected: PASS (2 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add tools/mrm-simulator/src/httpEnvelope.ts tools/mrm-simulator/src/httpEnvelope.test.ts
+git commit -m "feat(mrm-sim): response envelope parser"
+```
+
+---
+
+### Task 8: JWT client and ingestion client
+
+**Files:**
+- Create: `tools/mrm-simulator/src/jwtClient.ts`
+- Create: `tools/mrm-simulator/src/ingestClient.ts`
+
+**Interfaces:**
+- Consumes: `SimConfig`, `parseEnvelope`, `MetricPoint`, `IngestResultPoint`, `ThresholdSpec`.
+- Produces (jwtClient): `class JwtClient` with `login()`, `createModel(name, provider)`, `setExternalKey(modelId, key)`, `assignTier(modelId, tier, drivers)`, `createMetricKey(key)`, `createThreshold(modelId, spec)`, `createIngestionToken(name)`, and read-backs `getAttestationSummary()`, `getRevalidationEvents(modelId)`, `getValidations(modelId)`, `getBreaches(modelId, metric)`.
+- Produces (ingestClient): `class IngestClient` with `pushBatch(externalKey, points): Promise<IngestResultPoint[]>`.
+
+- [ ] **Step 1: Write jwtClient.ts**
+
+```typescript
+import { SimConfig, ThresholdSpec } from "./types.js";
+import { parseEnvelope } from "./httpEnvelope.js";
+
+export class JwtClient {
+  private token = "";
+  constructor(private cfg: SimConfig) {}
+
+  private headers(): Record<string, string> {
+    return {
+      "Content-Type": "application/json",
+      ...(this.token ? { Authorization: `Bearer ${this.token}` } : {}),
+    };
+  }
+
+  async login(): Promise<void> {
+    const res = await fetch(`${this.cfg.baseUrl}/api/users/login`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ email: this.cfg.email, password: this.cfg.password }),
+    });
+    const { data } = await parseEnvelope<{ token: string }>(res);
+    this.token = data.token;
+  }
+
+  async createModel(name: string, provider: string): Promise<number> {
+    const res = await fetch(`${this.cfg.baseUrl}/api/modelInventory`, {
+      method: "POST",
+      headers: this.headers(),
+      body: JSON.stringify({ model: name, provider, status: "Approved" }),
+    });
+    const { data } = await parseEnvelope<{ id: number }>(res);
+    return data.id;
+  }
+
+  async setExternalKey(modelId: number, key: string): Promise<void> {
+    const res = await fetch(`${this.cfg.baseUrl}/api/modelInventory/${modelId}`, {
+      method: "PATCH",
+      headers: this.headers(),
+      body: JSON.stringify({ external_key: key }),
+    });
+    await parseEnvelope(res);
+  }
+
+  async assignTier(modelId: number, tier: "1" | "2" | "3", drivers: string): Promise<void> {
+    const res = await fetch(`${this.cfg.baseUrl}/api/mrm/models/${modelId}/tier`, {
+      method: "PUT",
+      headers: this.headers(),
+      body: JSON.stringify({ tier, materiality_drivers: drivers }),
+    });
+    await parseEnvelope(res);
+  }
+
+  async createMetricKey(key: string): Promise<void> {
+    const res = await fetch(`${this.cfg.baseUrl}/api/mrm/metric-keys`, {
+      method: "POST",
+      headers: this.headers(),
+      body: JSON.stringify({ key }),
+    });
+    // 409 (already exists) is fine — swallow it.
+    if (res.status !== 409) await parseEnvelope(res);
+  }
+
+  async createThreshold(modelId: number, spec: ThresholdSpec): Promise<void> {
+    const res = await fetch(`${this.cfg.baseUrl}/api/mrm/models/${modelId}/thresholds`, {
+      method: "POST",
+      headers: this.headers(),
+      body: JSON.stringify(spec),
+    });
+    await parseEnvelope(res);
+  }
+
+  async createIngestionToken(name: string): Promise<string> {
+    const res = await fetch(`${this.cfg.baseUrl}/api/mrm/ingestion-tokens`, {
+      method: "POST",
+      headers: this.headers(),
+      body: JSON.stringify({ name, model_inventory_id: null }),
+    });
+    const { data } = await parseEnvelope<{ token: string }>(res);
+    return data.token;
+  }
+
+  async getAttestationSummary(): Promise<any> {
+    const res = await fetch(`${this.cfg.baseUrl}/api/mrm/attestation/summary`, { headers: this.headers() });
+    const { data } = await parseEnvelope<any>(res);
+    return data;
+  }
+
+  async getRevalidationEvents(modelId: number): Promise<any[]> {
+    const res = await fetch(`${this.cfg.baseUrl}/api/mrm/models/${modelId}/revalidation-events`, { headers: this.headers() });
+    const { data } = await parseEnvelope<any[]>(res);
+    return data;
+  }
+
+  async getValidations(modelId: number): Promise<any[]> {
+    const res = await fetch(`${this.cfg.baseUrl}/api/mrm/validations?modelId=${modelId}`, { headers: this.headers() });
+    const { data } = await parseEnvelope<any[]>(res);
+    return data;
+  }
+
+  async getBreaches(modelId: number, metric?: string): Promise<any[]> {
+    const q = metric ? `?metric=${encodeURIComponent(metric)}` : "";
+    const res = await fetch(`${this.cfg.baseUrl}/api/mrm/models/${modelId}/monitoring/breaches${q}`, { headers: this.headers() });
+    const { data } = await parseEnvelope<any[]>(res);
+    return data;
+  }
+}
+```
+
+- [ ] **Step 2: Write ingestClient.ts**
+
+```typescript
+import { SimConfig, MetricPoint, IngestResultPoint } from "./types.js";
+import { parseEnvelope } from "./httpEnvelope.js";
+
+export class IngestClient {
+  constructor(private cfg: SimConfig, private token: string) {}
+
+  async pushBatch(externalKey: string, points: MetricPoint[]): Promise<IngestResultPoint[]> {
+    const res = await fetch(
+      `${this.cfg.baseUrl}/api/mrm/models/${encodeURIComponent(externalKey)}/metrics`,
+      {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: `Bearer ${this.token}`,
+        },
+        body: JSON.stringify({ points }),
+      },
+    );
+    const { data } = await parseEnvelope<{ accepted: number; results: IngestResultPoint[] }>(res);
+    return data.results;
+  }
+}
+```
+
+- [ ] **Step 3: Typecheck**
+
+Run: `cd tools/mrm-simulator && npx tsc --noEmit`
+Expected: no errors.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add tools/mrm-simulator/src/jwtClient.ts tools/mrm-simulator/src/ingestClient.ts
+git commit -m "feat(mrm-sim): JWT and ingestion HTTP clients"
+```
+
+---
+
+### Task 9: Setup orchestration
+
+**Files:**
+- Create: `tools/mrm-simulator/src/setup.ts`
+
+**Interfaces:**
+- Consumes: `FLEET`, `JwtClient`, `readCache`/`writeCache`, `SimConfig`.
+- Produces: `runSetup(cfg: SimConfig): Promise<{ token: string; models: Record<string, number>; findings: Finding[] }>`. Idempotent: if a model's externalKey is already in the cache, reuse the id and skip creation.
+
+- [ ] **Step 1: Write setup.ts**
+
+```typescript
+import { SimConfig, Finding } from "./types.js";
+import { JwtClient } from "./jwtClient.js";
+import { FLEET } from "../scenarios/fleet.js";
+import { readCache, writeCache } from "./config.js";
+
+export const runSetup = async (
+  cfg: SimConfig,
+): Promise<{ token: string; models: Record<string, number>; findings: Finding[] }> => {
+  const findings: Finding[] = [];
+  const cache = readCache();
+  const client = new JwtClient(cfg);
+  await client.login();
+
+  for (const model of FLEET) {
+    if (cache.models[model.externalKey]) continue; // idempotent reuse
+
+    const modelId = await client.createModel(model.name, model.provider);
+
+    // external_key is NOT on the tier endpoint — set it via modelInventory PATCH.
+    // This split is itself a contract friction worth recording.
+    await client.setExternalKey(modelId, model.externalKey);
+    findings.push({
+      category: "contract",
+      severity: "low",
+      title: "external_key requires a separate PATCH call",
+      expected: "Setting the ingestion key alongside tier in one MRM call",
+      actual: "external_key is only settable via PATCH /api/modelInventory/:id, separate from PUT /api/mrm/models/:id/tier",
+      repro: "Attempt to set external_key in the tier PUT body; it is ignored.",
+    });
+
+    await client.assignTier(modelId, model.tier, model.materialityDrivers);
+    for (const key of model.metricKeys) await client.createMetricKey(key);
+    for (const spec of model.thresholds) await client.createThreshold(modelId, spec);
+
+    cache.models[model.externalKey] = modelId;
+    writeCache(cache);
+  }
+
+  if (!cache.token) {
+    cache.token = await client.createIngestionToken("mrm-simulator");
+    writeCache(cache);
+  }
+
+  return { token: cache.token, models: cache.models, findings };
+};
+```
+
+- [ ] **Step 2: Typecheck**
+
+Run: `cd tools/mrm-simulator && npx tsc --noEmit`
+Expected: no errors.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add tools/mrm-simulator/src/setup.ts
+git commit -m "feat(mrm-sim): idempotent fleet + threshold + token setup"
+```
+
+---
+
+### Task 10: Verify (gap checks) + report (TDD for report)
+
+**Files:**
+- Create: `tools/mrm-simulator/src/verify.ts`
+- Create: `tools/mrm-simulator/src/report.ts`
+- Test: `tools/mrm-simulator/src/report.test.ts`
+
+**Interfaces:**
+- Consumes: `JwtClient`, `FLEET`, cache, `Finding`, per-point ingest results.
+- Produces (verify): `runVerify(cfg, models, ingestResults): Promise<Finding[]>` — checks the governance loop closed. `runContractChecks(ingestResults): Finding[]` — flags engineered breaches that came back `ok`/`no_threshold`.
+- Produces (report): `renderReport(findings: Finding[]): string` and `writeReport(findings: Finding[]): void`.
+
+- [ ] **Step 1: Write the failing test for report**
+
+```typescript
+import { describe, it, expect } from "vitest";
+import { renderReport } from "./report";
+import { Finding } from "./types";
+
+describe("report", () => {
+  it("groups findings by category with a summary count", () => {
+    const findings: Finding[] = [
+      { category: "contract", severity: "high", title: "A", expected: "x", actual: "y", repro: "z" },
+      { category: "workflow", severity: "medium", title: "B", expected: "x", actual: "y", repro: "z" },
+    ];
+    const md = renderReport(findings);
+    expect(md).toContain("# MRM simulator — gap report");
+    expect(md).toContain("2 findings");
+    expect(md).toContain("## Contract");
+    expect(md).toContain("## Workflow");
+    expect(md).toContain("A");
+  });
+
+  it("renders a clean bill of health when there are no findings", () => {
+    const md = renderReport([]);
+    expect(md).toContain("No gaps found");
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd tools/mrm-simulator && npx vitest run src/report.test.ts`
+Expected: FAIL (module not found).
+
+- [ ] **Step 3: Write report.ts**
+
+```typescript
+import { writeFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+import { Finding } from "./types.js";
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const REPORT_PATH = join(HERE, "..", "gaps-report.md");
+
+const CATEGORIES: Finding["category"][] = ["contract", "workflow", "ux"];
+const title = (c: string) => c.charAt(0).toUpperCase() + c.slice(1);
+
+export const renderReport = (findings: Finding[]): string => {
+  const lines: string[] = ["# MRM simulator — gap report", ""];
+  lines.push(`${findings.length} findings.`, "");
+  if (findings.length === 0) {
+    lines.push("No gaps found. The MRM governance loop behaved as documented.");
+    return lines.join("\n");
+  }
+  for (const cat of CATEGORIES) {
+    const group = findings.filter((f) => f.category === cat);
+    if (group.length === 0) continue;
+    lines.push(`## ${title(cat)}`, "");
+    for (const f of group) {
+      lines.push(`### [${f.severity}] ${f.title}`);
+      lines.push(`- **Expected:** ${f.expected}`);
+      lines.push(`- **Actual:** ${f.actual}`);
+      lines.push(`- **Repro:** ${f.repro}`);
+      lines.push("");
+    }
+  }
+  return lines.join("\n");
+};
+
+export const writeReport = (findings: Finding[]): void => {
+  writeFileSync(REPORT_PATH, renderReport(findings));
+};
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd tools/mrm-simulator && npx vitest run src/report.test.ts`
+Expected: PASS (2 tests).
+
+- [ ] **Step 5: Write verify.ts**
+
+```typescript
+import { SimConfig, Finding, IngestResultPoint } from "./types.js";
+import { JwtClient } from "./jwtClient.js";
+import { FLEET } from "../scenarios/fleet.js";
+
+// Which (externalKey, metric) pairs we engineered to breach during backfill.
+const EXPECTED_BREACHES: { externalKey: string; metric: string }[] = [
+  { externalKey: "credit-scoring-v3", metric: "psi" },
+  { externalKey: "loan-approval-v1", metric: "gini" },
+  { externalKey: "churn-propensity-v1", metric: "psi" },
+];
+
+// Contract check: engineered breaches must appear as warn/breach in results.
+export const runContractChecks = (
+  resultsByKey: Record<string, IngestResultPoint[]>,
+): Finding[] => {
+  const findings: Finding[] = [];
+  for (const exp of EXPECTED_BREACHES) {
+    const results = resultsByKey[exp.externalKey] ?? [];
+    const hit = results.some(
+      (r) => r.metric === exp.metric && (r.status === "breach" || r.status === "warn"),
+    );
+    if (!hit) {
+      findings.push({
+        category: "contract",
+        severity: "high",
+        title: `Engineered breach never fired for ${exp.externalKey}/${exp.metric}`,
+        expected: `At least one warn/breach status for ${exp.metric}`,
+        actual: "All points returned ok/no_threshold — threshold match or setup gap",
+        repro: `Backfill ${exp.externalKey} and inspect per-point statuses for ${exp.metric}`,
+      });
+    }
+  }
+  return findings;
+};
+
+// Workflow check: a flagged breach should have opened a revalidation event/task.
+export const runVerify = async (
+  cfg: SimConfig,
+  models: Record<string, number>,
+): Promise<Finding[]> => {
+  const findings: Finding[] = [];
+  const client = new JwtClient(cfg);
+  await client.login();
+
+  // credit-scoring-v3 psi breach is notify_flag_revalidation -> expect an event.
+  const creditId = models["credit-scoring-v3"];
+  if (creditId) {
+    const events = await client.getRevalidationEvents(creditId);
+    if (events.length === 0) {
+      findings.push({
+        category: "workflow",
+        severity: "high",
+        title: "PSI breach did not create a revalidation event",
+        expected: "A revalidation event (source=breach) after credit-scoring-v3 PSI crossed 0.20",
+        actual: "GET /revalidation-events returned an empty list",
+        repro: "Backfill 30d, then GET /api/mrm/models/<credit-scoring-v3 id>/revalidation-events",
+      });
+    }
+  }
+
+  // Attestation should reflect the fleet (>=4 models, some breaches).
+  const summary = await client.getAttestationSummary();
+  if (summary.models_total < FLEET.length) {
+    findings.push({
+      category: "workflow",
+      severity: "medium",
+      title: "Attestation summary undercounts the fleet",
+      expected: `models_total >= ${FLEET.length}`,
+      actual: `models_total = ${summary.models_total}`,
+      repro: "GET /api/mrm/attestation/summary after setup + backfill",
+    });
+  }
+
+  // UX checklist finding (always emitted — a guided manual pass).
+  findings.push({
+    category: "ux",
+    severity: "low",
+    title: "Manual UI review checklist",
+    expected: "Monitoring trends, breach chips, revalidation 'Triggered by', and attestation status look correct",
+    actual: "Not auto-verifiable — open the URLs and confirm visually",
+    repro:
+      "Open /model-inventory/model-risk-management (Monitoring, Validation drawer, Overview) and eyeball each model",
+  });
+
+  return findings;
+};
+```
+
+- [ ] **Step 6: Typecheck + run report test**
+
+Run: `cd tools/mrm-simulator && npx tsc --noEmit && npx vitest run src/report.test.ts`
+Expected: no type errors; report tests pass.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add tools/mrm-simulator/src/verify.ts tools/mrm-simulator/src/report.ts tools/mrm-simulator/src/report.test.ts
+git commit -m "feat(mrm-sim): verification gap-checks and report renderer"
+```
+
+---
+
+### Task 11: CLI wiring + README
+
+**Files:**
+- Create: `tools/mrm-simulator/src/cli.ts`
+- Create: `tools/mrm-simulator/README.md`
+
+**Interfaces:**
+- Consumes: everything above.
+- Produces: the runnable CLI. Commands: `setup`, `backfill [--days N]`, `live [--interval Ns]`, `verify`, `report`, `teardown`. `--dry-run` on backfill/live prints without POSTing.
+
+- [ ] **Step 1: Write cli.ts**
+
+```typescript
+import { loadConfig, assertSafeTarget, readCache, writeCache } from "./config.js";
+import { runSetup } from "./setup.js";
+import { runVerify, runContractChecks } from "./verify.js";
+import { writeReport } from "./report.js";
+import { IngestClient } from "./ingestClient.js";
+import { generateRange, generatePoints } from "./engine.js";
+import { FLEET } from "../scenarios/fleet.js";
+import { Finding, IngestResultPoint, MetricPoint } from "./types.js";
+
+const arg = (name: string, def: string): string => {
+  const i = process.argv.indexOf(name);
+  return i >= 0 && i + 1 < process.argv.length ? process.argv[i + 1] : def;
+};
+const dryRun = process.argv.includes("--dry-run");
+
+const chunk = <T>(xs: T[], n: number): T[][] => {
+  const out: T[][] = [];
+  for (let i = 0; i < xs.length; i += n) out.push(xs.slice(i, i + n));
+  return out;
+};
+
+const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
+
+const main = async () => {
+  const cmd = process.argv[2];
+  const cfg = loadConfig(process.argv);
+  assertSafeTarget(cfg);
+
+  if (cmd === "setup") {
+    const { token, models, findings } = await runSetup(cfg);
+    console.log(`setup complete. token cached. models: ${Object.keys(models).join(", ")}`);
+    const cache = readCache();
+    cache.token = token;
+    writeCache(cache);
+    if (findings.length) console.log(`${findings.length} setup finding(s) recorded`);
+    return;
+  }
+
+  if (cmd === "backfill") {
+    const days = Number(arg("--days", "30"));
+    const cache = readCache();
+    if (!cache.token) throw new Error("run `setup` first (no token cached)");
+    const client = new IngestClient(cfg, cache.token);
+    const start = new Date(Date.now() - days * 86_400_000);
+    const resultsByKey: Record<string, IngestResultPoint[]> = {};
+    for (const model of FLEET) {
+      const points = generateRange(model, start, days);
+      if (dryRun) {
+        console.log(`[dry-run] ${model.externalKey}: ${points.length} points`);
+        continue;
+      }
+      resultsByKey[model.externalKey] = [];
+      for (const batch of chunk(points, 200)) {
+        const results = await client.pushBatch(model.externalKey, batch);
+        resultsByKey[model.externalKey].push(...results);
+      }
+      const breaches = resultsByKey[model.externalKey].filter((r) => r.status === "breach" || r.status === "warn").length;
+      console.log(`${model.externalKey}: pushed ${points.length}, ${breaches} warn/breach`);
+    }
+    if (!dryRun) {
+      cache.lastBackfill = new Date(start.getTime()).toISOString();
+      writeCache(cache);
+      const contractFindings = runContractChecks(resultsByKey);
+      writeReport(contractFindings);
+    }
+    return;
+  }
+
+  if (cmd === "live") {
+    const interval = Number(arg("--interval", "5").replace("s", "")) * 1000;
+    const cache = readCache();
+    if (!cache.token) throw new Error("run `setup` first");
+    const client = new IngestClient(cfg, cache.token);
+    let day = 0;
+    console.log(`live mode: pushing every ${interval / 1000}s (Ctrl-C to stop)`);
+    // eslint-disable-next-line no-constant-condition
+    while (true) {
+      for (const model of FLEET) {
+        const points = generatePoints(model, day, new Date());
+        if (dryRun) {
+          console.log(`[dry-run] ${model.externalKey} day ${day}: ${points.length} points`);
+        } else {
+          const results = await client.pushBatch(model.externalKey, points);
+          const b = results.filter((r) => r.status === "breach" || r.status === "warn").length;
+          if (b) console.log(`${model.externalKey} day ${day}: ${b} warn/breach`);
+        }
+      }
+      day++;
+      await sleep(interval);
+    }
+  }
+
+  if (cmd === "verify") {
+    const cache = readCache();
+    const findings: Finding[] = await runVerify(cfg, cache.models);
+    writeReport(findings);
+    console.log(`verify complete: ${findings.length} finding(s) -> gaps-report.md`);
+    return;
+  }
+
+  if (cmd === "report") {
+    console.log("gaps-report.md is written by `backfill` and `verify`.");
+    return;
+  }
+
+  if (cmd === "teardown") {
+    console.log("teardown: decommission the created models in the UI, then delete .mrm-simulator.json");
+    return;
+  }
+
+  console.log("usage: sim <setup|backfill|live|verify|report|teardown> [--days N] [--interval Ns] [--dry-run] [--base-url URL]");
+};
+
+main().catch((e) => {
+  console.error(e instanceof Error ? e.message : e);
+  process.exit(1);
+});
+```
+
+Note: this references `cache.lastBackfill`. Add `lastBackfill?: string` to the `CacheFile` interface in `src/config.ts` as part of this step.
+
+- [ ] **Step 2: Add `lastBackfill` to CacheFile**
+
+In `src/config.ts`, update the interface:
+
+```typescript
+export interface CacheFile {
+  token?: string;
+  models: Record<string, number>;
+  lastBackfill?: string;
+}
+```
+
+- [ ] **Step 3: Write README.md**
+
+```markdown
+# MRM model-eval simulator
+
+A standalone tool that impersonates a model-monitoring platform and feeds
+scenario-driven metrics into VerifyWise's MRM ingestion API, then reports gaps.
+
+## Prerequisites
+
+- VerifyWise backend running locally (`http://localhost:3000`) with an admin login.
+- Node 22+.
+
+## Install
+
+```bash
+cd tools/mrm-simulator
+npm install
+```
+
+## Usage
+
+```bash
+npm run sim setup                 # create fleet + thresholds + token (idempotent)
+npm run sim backfill --days 30    # push 30 days of history
+npm run sim live --interval 5s    # keep pushing; watch a breach happen
+npm run sim verify                # read MRM back, write gaps-report.md
+```
+
+Add `--dry-run` to `backfill`/`live` to print without POSTing.
+Credentials come from `VW_EMAIL` / `VW_PASSWORD` (default dev creds).
+The tool refuses non-localhost targets unless `--i-know-what-im-doing` is passed.
+
+## Output
+
+`gaps-report.md` — categorised findings (Contract / Workflow / UX) to triage
+against the MRM feature.
+```
+
+- [ ] **Step 4: Typecheck**
+
+Run: `cd tools/mrm-simulator && npx tsc --noEmit`
+Expected: no errors.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add tools/mrm-simulator/src/cli.ts tools/mrm-simulator/src/config.ts tools/mrm-simulator/README.md
+git commit -m "feat(mrm-sim): CLI commands and README"
+```
+
+---
+
+### Task 12: End-to-end run against local backend
+
+**Files:** none (execution + first report).
+
+**Interfaces:** consumes the whole tool.
+
+- [ ] **Step 1: Confirm backend is up**
+
+Run: `curl -s -o /dev/null -w "%{http_code}" http://localhost:3000/api/mrm/attestation/summary`
+Expected: `401` (needs auth) — proves the server is up and the route exists.
+
+- [ ] **Step 2: Dry-run backfill (no writes)**
+
+Run: `cd tools/mrm-simulator && npm run sim setup && npm run sim backfill --days 30 --dry-run`
+Expected: setup prints the 4 models; dry-run prints point counts per model.
+
+- [ ] **Step 3: Real backfill**
+
+Run: `npm run sim backfill --days 30`
+Expected: each model prints pushed count; `credit-scoring-v3`, `loan-approval-v1`, `churn-propensity-v1` report > 0 warn/breach; `fraud-detector-v2` reports 0.
+
+- [ ] **Step 4: Verify + read the report**
+
+Run: `npm run sim verify && cat gaps-report.md`
+Expected: `gaps-report.md` exists, categorised. Triage any high-severity contract/workflow findings.
+
+- [ ] **Step 5: Commit the plan-completion note (not the generated report)**
+
+```bash
+# gaps-report.md and .mrm-simulator.json are git-ignored; nothing to commit here.
+echo "End-to-end run complete. Review gaps-report.md."
+```
+
+---
+
+## Self-review
+
+**Spec coverage:**
+- Purpose (demo/test/reference/gap-finder) → Tasks 3–12 ✓
+- Wire contract (auth, batch, fields, idempotency, ops, envelope) → Global Constraints + Tasks 7, 8 ✓
+- Scenario fleet + storylines + thresholds → Tasks 3, 4 ✓
+- Backfill + live + full setup → Tasks 9, 11 ✓
+- Gap-finding → categorised report → Tasks 10, 11 ✓
+- Seeded `vw_mrm_` vs `mrm_` discrepancy → captured in Global Constraints (auth header) and surfaced as the `external_key` split finding in Task 9; the `vw_mrm_` UI-copy gap is a UX finding to add during the run.
+- Safety (localhost guard, dry-run, ignored cache) → Task 6, .gitignore ✓
+- Testing (pure units + live verify) → Tasks 3, 5, 6, 7, 10, 12 ✓
+
+**Placeholder scan:** No TBD/TODO. Every code step shows complete code; every run step shows the command and expected output.
+
+**Type consistency:** `MetricPoint`, `Finding`, `IngestResultPoint`, `FleetModel`, `ThresholdSpec`, `CacheFile` are defined once and used consistently. `runContractChecks` takes `Record<string, IngestResultPoint[]>` (matches cli usage). `runVerify(cfg, models)` matches cli call. `renderReport`/`writeReport` signatures consistent.
+
+**Known follow-up:** the `vw_mrm_` UI copy is a real gap; recording it as a UX finding during Task 12 is the intended outcome, not a plan defect.

--- a/docs/superpowers/plans/2026-07-04-mrm-model-eval-simulator.md
+++ b/docs/superpowers/plans/2026-07-04-mrm-model-eval-simulator.md
@@ -648,7 +648,16 @@ export const loadConfig = (argv: string[]): SimConfig => ({
 });
 
 export const assertSafeTarget = (cfg: SimConfig): void => {
-  const isLocal = /^https?:\/\/(localhost|127\.0\.0\.1)(:\d+)?/.test(cfg.baseUrl);
+  // Parse the URL and match the exact hostname against an allowlist. A substring
+  // or unanchored-regex check is NOT safe: "http://localhost.evil.com" and
+  // "http://localhost@evil.com" would both pass while pointing at a remote host.
+  let hostname: string;
+  try {
+    hostname = new URL(cfg.baseUrl).hostname;
+  } catch {
+    throw new Error(`refusing to run: baseUrl is not a valid URL: ${cfg.baseUrl}`);
+  }
+  const isLocal = hostname === "localhost" || hostname === "127.0.0.1";
   if (!isLocal && !cfg.allowRemote) {
     throw new Error(
       `refusing to run against non-localhost target ${cfg.baseUrl}. ` +

--- a/docs/superpowers/specs/2026-07-04-mrm-external-key-followup.md
+++ b/docs/superpowers/specs/2026-07-04-mrm-external-key-followup.md
@@ -1,0 +1,63 @@
+# Follow-up: make MRM `external_key` fully settable (P1)
+
+> **Status:** Scoped, not started. Follow-up to the P0 fix `fix/mrm-external-key`.
+> **Date:** 2026-07-04
+
+## Context
+
+The MRM metric-ingestion endpoint (`POST /api/mrm/models/:externalModelKey/metrics`)
+resolves a model by its `external_key`. The P0 fix made the **update** path
+(`PATCH /api/modelInventory/:id`) persist `external_key`. Two gaps remain that
+stop a normal user from actually setting it.
+
+## Gap 1 — No UI field to set `external_key` (user-facing)
+
+The MRM "Metrics feed & tokens" section instructs the user to set a stable
+external key "on the model inventory record," but the model inventory
+create/edit form (`Clients/src/presentation/pages/ModelInventory/index.tsx`)
+has no input for it. So a UI-only user cannot enable ingestion for a model.
+
+**Work:** add an `external_key` field to the model create/edit form, wired to the
+existing create (`POST /api/modelInventory`) and update (`PATCH`) calls. Validate
+uniqueness-friendly input (trimmed, no spaces recommended). Surface the value on
+the model detail view too (see Gap 3).
+
+## Gap 2 — Create path drops `external_key` (backend, same class as the P0 bug)
+
+`createNewModelInventoryQuery` (`Servers/utils/modelInventory.utils.ts:157`)
+omits `external_key` from its INSERT column list, and the create controller +
+`ModelInventoryModel.createNewModelInventory` (`modelInventory.model.ts:427`) do
+not map it. So even the API cannot set `external_key` at create time — only via
+the now-fixed PATCH.
+
+**Work (mirror the P0 update fix across the create path):**
+- `Servers/controllers/modelInventory.ctrl.ts` — destructure `external_key` from
+  `req.body` in `createNewModelInventory` and pass it to the model factory.
+- `Servers/domain.layer/models/modelInventory/modelInventory.model.ts:427` —
+  map `external_key` in `createNewModelInventory`.
+- `Servers/utils/modelInventory.utils.ts:157` — add `external_key` to the INSERT
+  columns and the bound values.
+- Respect the existing partial-unique index
+  `(organization_id, external_key) WHERE external_key IS NOT NULL` — a duplicate
+  key should surface a clear validation error, not a 500.
+
+## Gap 3 — `GET /api/modelInventory/:id` MRM columns (P2, minor)
+
+During the simulator run, the model read endpoint did not surface persisted MRM
+columns (`external_key`, `mrm_tier`) even though the DB held them. Confirm
+whether the read projection/serialization drops MRM fields and, if so, include
+them so an integrator can verify setup through the same read endpoint. Lower
+priority than Gaps 1–2.
+
+## Acceptance
+
+- A user can set `external_key` when creating OR editing a model, in the UI and
+  via the API.
+- The value round-trips: create/edit → read shows it → ingestion resolves the
+  model (no 404).
+- Duplicate `external_key` within an org is rejected with a clear message.
+
+## Not in scope
+
+- Auto-generating `external_key` from the model name (could be a nicety later).
+- Any change to the ingestion endpoint itself (already works once the key is set).

--- a/docs/superpowers/specs/2026-07-04-mrm-model-eval-simulator-design.md
+++ b/docs/superpowers/specs/2026-07-04-mrm-model-eval-simulator-design.md
@@ -1,0 +1,212 @@
+# MRM model-eval simulator — design
+
+> **Status:** Approved design, pre-implementation
+> **Date:** 2026-07-04
+> **Scope:** A standalone in-repo tool. No changes to the MRM feature itself.
+
+## Purpose
+
+Build a standalone TypeScript CLI that impersonates a "world-class model
+monitoring platform" (a mock Evidently/Arize) and feeds realistic model-risk
+metrics into VerifyWise's MRM ingestion API, so the MRM feature can be seen
+working end-to-end.
+
+The tool serves three goals at once, from one scenario-driven design:
+
+1. **Demo / storytelling** — populate the Monitoring tab, breach history,
+   revalidation triggers, and attestation roll-up with believable data that
+   tells a story (a model drifts, breaches, and fires revalidation).
+2. **Dev / test harness** — exercise the ingestion API and threshold engine
+   with deterministic, controllable scenarios.
+3. **Reference integration** — a readable example of how a real monitoring
+   pipeline connects to VerifyWise MRM.
+
+A **fourth, explicit goal**: the tool doubles as a **gap-finder**. While driving
+realistic data through the real API and reading the results back, it surfaces
+workflow issues, contract friction, and UX rough edges in the MRM feature, and
+writes them to a findings report.
+
+## Non-goals (YAGNI)
+
+- No web UI or branded dashboard (the "phase 2" mock-product option is out).
+- No real ML computation — metrics are scripted, not learned.
+- No persistence beyond a local token/id cache.
+- No multi-org support.
+
+## The wire contract (ground truth)
+
+Grounded in the current backend. This is the exact format the simulator targets.
+
+### Ingestion
+
+- **Endpoint:** `POST /api/mrm/models/:externalModelKey/metrics`
+- **Auth:** `Authorization: Bearer mrm_<64 hex>`. Token is SHA-256 hashed and
+  looked up; the row carries `organization_id` (and optionally a single
+  `model_inventory_id` scope).
+- **Body — single point:** the body itself is the point.
+- **Body — batch:** `{ "points": [ ... ] }`. Empty `points: []` → 422.
+- **Batch semantics:** all-or-nothing. Every point is validated first; if any
+  fails, the whole request is rejected 422 with per-point errors and zero writes.
+- **Fields:**
+
+  | Field | Required | Type | Rules |
+  |-------|----------|------|-------|
+  | `metric` | Yes | string | non-empty trimmed, max 100 chars |
+  | `value` | Yes | number | finite only (no bool/NaN/Infinity) |
+  | `at` | Yes | ISO-8601 string | valid date; > 1h in future rejected; truncated to the second for dedup |
+  | `window` | No | string/null | default `""` |
+  | `segment` | No | string/null | default `"overall"` |
+  | `context` | No | object/null | non-array object; stored, never evaluated |
+
+- **Idempotency:** unique on `(organization_id, model_inventory_id, metric,
+  segment, window, at@second)`. A duplicate returns 200 with
+  `status: "duplicate"` — a no-op, not a 409.
+- **Rate limit:** per token id. Non-production: 100,000 / 15 min (not a concern
+  for local runs).
+- **Success response (200):** `{ status, data: { accepted, results: [ { metric,
+  at, status, pointId, threshold? } ] } }` where per-point `status` ∈ `ok |
+  warn | breach | no_threshold | duplicate`.
+- **Unknown external key:** 404 `"Model not found for this key"`.
+
+### Evaluation engine
+
+- A point matches a threshold when the threshold is active, `metric` matches
+  exactly, and segment/window either match or the threshold is unpinned.
+- Operator shapes (`op`): `gt`, `gte`, `lt`, `lte`, `outside` (breach when
+  `value < value_lo || value > value_hi`).
+- Severity `warn` → point status `warn`; `high`/`critical` → `breach`.
+- Breach action: `notify` (notification only) or `notify_flag_revalidation`
+  (notification + sets `mrm_revalidation_flagged` + opens a revalidation task).
+- Winner selection is most-conservative-wins: breaching beats non-breaching,
+  then higher severity, then more specific, then lowest id.
+
+### Model wiring & setup
+
+- `model_inventories.external_key` (VARCHAR, unique per org) maps the URL key to
+  a model. Set via the tiering/model-edit flow (`PUT /api/mrm/models/:id/tier`).
+- Metric keys are free-form (advisory catalogue only) — any string ≤ 100 chars
+  is accepted; unknown keys are stored and flagged `no_threshold`.
+- **Token creation:** `POST /api/mrm/ingestion-tokens` (JWT, Admin) returns the
+  plaintext `mrm_...` token exactly once. Only the hash is stored.
+
+## Architecture
+
+Standalone TS CLI at `tools/mrm-simulator/`. Each file has one clear job.
+
+```
+tools/mrm-simulator/
+  scenarios/
+    fleet.ts          # the 4 models: tiers, external_keys, threshold specs
+    storylines.ts     # per-model metric(dayIndex) -> value (seeded, deterministic)
+  src/
+    config.ts         # base URL, creds, token/id cache (.mrm-simulator.json)
+    jwtClient.ts      # login + JWT-authed calls (setup, read-back)
+    ingestClient.ts   # token-authed POST /metrics (batched, retry, capture responses)
+    engine.ts         # walk storylines over a date range -> metric points
+    setup.ts          # create models/keys/thresholds/token (idempotent)
+    verify.ts         # read MRM back; run contract + workflow gap checks
+    report.ts         # accumulate findings -> gaps-report.md
+    cli.ts            # setup | backfill | live | verify | report | teardown
+  README.md
+```
+
+### Commands
+
+- **`setup`** — logs in via JWT once. Idempotently creates the fleet (models +
+  `external_key` + tier), registers metric keys, configures each scenario's
+  thresholds, and mints one ingestion token. Caches token + model ids to a
+  git-ignored `.mrm-simulator.json`. Re-running reuses models by `external_key`.
+- **`backfill --days N`** — walks each storyline over the last N days and pushes
+  the points in batches via the ingestion token. Captures every per-point
+  `status`. Idempotent (endpoint dedup makes re-runs safe no-ops).
+- **`live --interval Ns`** — continues ticking forward from "now" so a breach
+  can be watched happening on screen.
+- **`verify`** — reads MRM back through the JWT API and runs the gap checks.
+- **`report`** — writes/updates `gaps-report.md`.
+- **`teardown`** — best-effort decommission of created models.
+
+### Data flow
+
+`cli → setup (jwtClient) → backfill/live (engine → ingestClient, capturing
+per-point status) → verify (jwtClient reads back) → report`. Findings accumulate
+across commands into one `gaps-report.md`.
+
+### Config & safety
+
+- `config.ts` reads base URL + login from env/flags. Default `localhost:3000`
+  and the dev credentials.
+- **Dev-only guard:** refuses to run against a non-localhost base URL unless
+  `--i-know-what-im-doing` is passed. This is synthetic data and must never
+  accidentally hit a real deployment.
+- `--dry-run` prints what would be sent without POSTing.
+- No secrets in code or committed files; the token cache is git-ignored.
+
+## Scenario fleet
+
+Four models, each a deliberate storyline exercising a different governance path.
+All metric values are deterministic functions of day-index (seeded) with
+realistic noise, so runs are reproducible and expected breaches are known.
+
+| Model (`external_key`) | Tier | Storyline | Exercises |
+|---|---|---|---|
+| `credit-scoring-v3` | 1 | PSI creeps 0.05 → 0.12 → 0.22 over 30d, crosses `psi > 0.20` ~day 18. AUC sags 0.86 → 0.82. | The headline breach → `notify_flag_revalidation` → revalidation task + event log. |
+| `fraud-detector-v2` | 1 | Healthy throughout: AUC ~0.94, PSI ~0.04, KS stable. | The control — proves "green" looks right; no false breaches. |
+| `loan-approval-v1` | 2 | Overall gini fine, but `segment=subprime` gini drops below a band. | Segment/fairness path + `outside` (band) threshold + most-conservative-wins. |
+| `churn-propensity-v1` | 3 | Drifts and breaches ~day 10, then recovers after a simulated retrain ~day 22. | Recovery narrative + warn-vs-breach severity + lighter Tier 3 cadence. |
+
+Metrics per model per day: `psi`, `auc`, `gini`, `ks` (scalar), plus segmented
+`gini` for `loan-approval-v1`.
+
+Thresholds `setup` configures:
+
+- `credit-scoring-v3`: `psi > 0.20` (high, notify+flag); `auc < 0.80` (warn).
+- `loan-approval-v1`: `gini outside [0.45, 0.75]` on `segment=subprime` (high).
+- `churn-propensity-v1`: `psi > 0.15` (warn) — softer, to show warn vs breach.
+- `fraud-detector-v2`: `psi > 0.25` (never trips — proves the control stays green).
+
+## Gap-finding
+
+The simulator asserts and observes at every step, then emits
+`tools/mrm-simulator/gaps-report.md`, categorised Contract / Workflow / UX. Each
+finding records severity, what was expected, what happened, and a repro.
+
+**1. Contract gaps (automatic).** For every call, compare expected vs actual:
+
+- A point engineered to breach comes back `ok`/`no_threshold` → threshold
+  matching or setup gap.
+- Setup steps that should exist but don't (e.g. no dedicated `external_key`
+  endpoint; had to piggyback on the tier PUT).
+- Error responses that don't match the documented shape, missing fields, wrong
+  status codes, confusing messages.
+- Verify documented behaviours actually hold: idempotency, rate limit,
+  future-timestamp rejection, batch all-or-nothing. Flag any surprise.
+
+**2. Workflow gaps (semi-automatic).** After backfill, read MRM back through the
+JWT API and check the governance loop closes:
+
+- A flagged breach — did it create a revalidation task and an event-log entry?
+  Visible in the validation drawer's "Triggered by"?
+- Does the attestation roll-up reflect the breaches (overdue, blocked tiers)?
+- Are breach notifications delivered to the model's assigned roles?
+- Anything the SR 26-2 governance narrative implies should happen but didn't.
+
+**3. UX / observation gaps (manual, guided).** The report ends with a "go look
+at this" checklist — specific URLs and what to inspect in the UI — plus friction
+noted during development.
+
+**Seeded known discrepancy (to confirm during implementation):** the ingestion
+UI example (`MetricsFeedSection.tsx`) shows a `vw_mrm_...` bearer token, but the
+backend generates and expects `mrm_...` (no `vw_` prefix). If confirmed, this is
+a real doc/UX gap that would mislead an integrator, and belongs in the report.
+
+## Testing
+
+- Storyline functions and the engine are pure and unit-tested (e.g. assert
+  `credit-scoring-v3` PSI crosses 0.20 at the expected day).
+- The clients are exercised live against the running backend during `verify` —
+  that run is both the integration test and the gap-finder.
+
+## Deliverables
+
+- `tools/mrm-simulator/` (the CLI, scenarios, README).
+- `tools/mrm-simulator/gaps-report.md` (generated) — the MRM punch-list.

--- a/tools/mrm-simulator/.gitignore
+++ b/tools/mrm-simulator/.gitignore
@@ -1,0 +1,3 @@
+node_modules/
+.mrm-simulator.json
+gaps-report.md

--- a/tools/mrm-simulator/README.md
+++ b/tools/mrm-simulator/README.md
@@ -1,0 +1,34 @@
+# MRM model-eval simulator
+
+A standalone tool that impersonates a model-monitoring platform and feeds
+scenario-driven metrics into VerifyWise's MRM ingestion API, then reports gaps.
+
+## Prerequisites
+
+- VerifyWise backend running locally (`http://localhost:3000`) with an admin login.
+- Node 22+.
+
+## Install
+
+```bash
+cd tools/mrm-simulator
+npm install
+```
+
+## Usage
+
+```bash
+npm run sim setup                 # create fleet + thresholds + token (idempotent)
+npm run sim backfill --days 30    # push 30 days of history
+npm run sim live --interval 5s    # keep pushing; watch a breach happen
+npm run sim verify                # read MRM back, write gaps-report.md
+```
+
+Add `--dry-run` to `backfill`/`live` to print without POSTing.
+Credentials come from `VW_EMAIL` / `VW_PASSWORD` (default dev creds).
+The tool refuses non-localhost targets unless `--i-know-what-im-doing` is passed.
+
+## Output
+
+`gaps-report.md` — categorised findings (Contract / Workflow / UX) to triage
+against the MRM feature.

--- a/tools/mrm-simulator/package-lock.json
+++ b/tools/mrm-simulator/package-lock.json
@@ -1,0 +1,1958 @@
+{
+  "name": "mrm-simulator",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "mrm-simulator",
+      "version": "0.1.0",
+      "devDependencies": {
+        "@types/node": "^22.10.1",
+        "tsx": "^4.19.2",
+        "typescript": "^5.6.3",
+        "vitest": "^2.1.8"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.1.tgz",
+      "integrity": "sha512-Svl7tq8k/08+p6CXPpRjQ1fKX+1odH/BQbb48fV6fj3CWHhsoIOoY87w1oHXm0qEpkIK3ZfVgp0hed3XBXzXMQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.1.tgz",
+      "integrity": "sha512-0k2F129Xdio1TdJfzJ8sy1Q47vUD2NnwdhiAf7drUN1EBTfPf4hsFCtmMgu/6m8JSzsBrlmVjudMBQqOfG8usQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.1.tgz",
+      "integrity": "sha512-34EGEbCIAgosYz6goLcopX6Mo7NyGv9tfwEM2/7Ce2VcVRk568iSvniGWcUXIy7wEDR1wzolcxcriFVrWYcwBg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.1.tgz",
+      "integrity": "sha512-dbwY7ltSMDWsRatcRpCnES4F+im88OCUgGZjy52shC7GqHRE/cYlxNbB4Z4UpJswpcc4Qxd2oE/ufM0p61IKng==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.1.tgz",
+      "integrity": "sha512-TZbWkQY7kvTAXbXUT7uVACR5cMHsDiSz9z7ZKAX/RTq/WJEk3QyRr0wZpNhBDX+/0CtdqUIJlOiodQcta6tY3Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.1.tgz",
+      "integrity": "sha512-zfdzgK9ACBNZLI/CyHTOx81SyNbM6YXn7rxSgX97VjyiPl9W1i4Ka4fgKECEoFCKGpvBj5qArWIGgQjOwkgskQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-wG2EA8ENdEI0qhkSZMjfqrdY+ziCYCPMmtZjjIwOmXFjmyzEHn+UUxk5of+SYsjtfs3VpnlC7QLzSI5hY/rOAw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.1.tgz",
+      "integrity": "sha512-i7dZ9vQgnvSCzi/rYCXNgtF/U+eKZNJBzu3eTQbRgHnM7tNSizLOkRFAl3qzVc/Op/u5YkHHa4pf/3DOYHthLQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.1.tgz",
+      "integrity": "sha512-qVXBOHQS+d5Y722GwJzJUtOLlX7km3CraOaGormF1pDtPd2C/l1SHRPgjLunLGe51Sh5YYWKMFDyV4SxgMQYTQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.1.tgz",
+      "integrity": "sha512-yHs+0uc8+nvEAfAfxrWQKK5peSNzBc4PegcMO0EJ2hT71uA7vB8Ihg2e77R2P7SG5uYjPbHlLLmve4LLLRCf0g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.1.tgz",
+      "integrity": "sha512-d1z4ZuP0ajrfz/FhGT4vv278rX8KnPPJx8i5+AtK7TYbx9Le9F1hyzurZpkEyjkGa9dUGhQow4C1NmeGvqxN2w==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.1.tgz",
+      "integrity": "sha512-M5sRjUVZrkm1OAPR3dlOYzNmN+loZKGVi1VUQGrwuqLcbR6qeAz+famMhjASeH3YVKvZz+zT1jlh/keC3Rj/lg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.1.tgz",
+      "integrity": "sha512-mRObBZeHh2OxcBFPWE/FjylkRgZdYuiTR3vaTozquCGOH14iP9oN4x4Ge81CoIDYQrXmIxpFumJBu5MtZpnQJQ==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.1.tgz",
+      "integrity": "sha512-slScBsMAb3GFDcdrCgLwZtPYRoH2H/youv10QiZyRjmsP48fznoveWytSgCI/R0ZcUgpc0ZhIUEx6LHts8yrfQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.1.tgz",
+      "integrity": "sha512-kw0owk1o0GFETUJyW0jc0G4Yzs0BHZn0JDZ8JRT088vjJYX777BAs1fDGxAC+q831qOs2DTC96mNsG2opdfyyQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.1.tgz",
+      "integrity": "sha512-/lAIjX8aYFRByhh6L5rYtPEDRqa9de/4V/juOXcta5frjvzXO4/sqEtyytse0g3zZFuWu5cDN0MkLz2qRDD2Ag==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.1.tgz",
+      "integrity": "sha512-u/anNYF2mmVOEDwLtnQ1wOr3EZ9sTNGLWrsYGYwHWzGA3Si84IOkHXlbWTD1NB+9/1lcnweYKO54uhxZydNzfA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-oks0DYbLwWMmaakTsCb+zL4E+aHRVLom9IJZOAthMQEPiQmydXHkziYEsGYRx0uNV/IjEKGAV941JzH02pflqw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.1.tgz",
+      "integrity": "sha512-aeL6lAnN89Hz43Mlh1G8ARasbuoYvSITDEx0tHh5b7jJnHcssqgjy9Yx430GDpmCa6OyrKoS0aNRjKundRizGg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-MEFJe5C3R8pwXdZ5Y21oo6m7ePiS0d9pWucn99O/wvyJZChoIQKrQDxKrGeW8F5+T0okTHesAmDeiHDTIq0V/Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.1.tgz",
+      "integrity": "sha512-i/ZLIOafE0Z8cI/XANJAixoJL/uRAoS2xOA3rb0xN+KK0K177cMAsQYkzHtBrtMXAKuAc7HGgcWiZ/sRC1Nxgw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.1.tgz",
+      "integrity": "sha512-ge+Z7EXFNt2BO1oAMsVpiQ8EwndV9i1xXerAeTIK7AtPs3bKFXQM7nlRxDSIUIMeueR1CNXxqztLzdNeReKBJg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.1.tgz",
+      "integrity": "sha512-BEjgtECkL3vY+SaSQ6nzVfiALUeFxpawyp8Jmf5PtYhf1Ug40N1h/hxlhts+f1FvSvarEigdxS3BlSMI2PJLcQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.1.tgz",
+      "integrity": "sha512-lCv9eK/H6ZJWbE7bh2nw54CZ9M2nupBxJcTsdk/QQnWkdSjKGuxmmH8/GWrlT1eMmZfn4dGcCjRte397WqfQXA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.1.tgz",
+      "integrity": "sha512-zvb/mB2bSCoJOpoCBgYKKpX6YM6mJBlBUVUtVj41DlZJVEB6/0CKlRYxP5wWl1C1ILiCoAU5wZZ4q1P3qeS6Eg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.1.tgz",
+      "integrity": "sha512-bm4Mowrv+GXMlpWX++EcXw/iLyd1o3+bJkC2DkWXYVvgZCqD/bSj9ctZeAMC3cIxgjRVR2Dufaiu4YPxr5gW1A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@rollup/rollup-android-arm-eabi": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.62.2.tgz",
+      "integrity": "sha512-6o7ZLZK+BeenkZCFNDXqpbjw9bD6nuWonvS/lwQJp7NoVVxm6p3qE7qQ5jGuBjiFsgvqjD8mZAU5oWxTmbOeOg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-android-arm64": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.62.2.tgz",
+      "integrity": "sha512-BaH7BllCACHoH1LguOU56UItGfUWjujlO65kS9LAodViaN4bwIKd7oeW/ZHJ/4ljr/7MIiENnNy3HJ0zXv8Zkw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-arm64": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.62.2.tgz",
+      "integrity": "sha512-v39RCCvj4He82I9sFmk+M1VZ0PLM9sfsLVikjfx2hYBNALhrrOR2D3JjQA6AhlaSOgcR+RzrKY7e1+bT6SUO/A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-x64": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.62.2.tgz",
+      "integrity": "sha512-yl0y2vq3S3lHeuXhEdss6TWfKW8vkujImO12tn4ZkG/4oghr09LvdYm2RElVjokTQiUvDUGXLGsYeLqUMCKpGA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-arm64": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.62.2.tgz",
+      "integrity": "sha512-tT4pvt4qXD+vEoezupCWi+a1F0vvDiksiHc+PxRlYTOH1I6/X4id9jPxTP+Fg+545euaFT1jJVs4CEdHZAU1vw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-x64": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.62.2.tgz",
+      "integrity": "sha512-6nU5F2wCW+qvCBhTn1pdIU3bzsIoF7EUwsCDRxilWGprQR6yd508YnH9+OKFCwpfS8pjZqDUmnCAr7exax0XCg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.62.2.tgz",
+      "integrity": "sha512-n1GJHPOvpIfhi3TmrCeh6S6URt9BFCt0KQE3qvexyGCTAKpR4Lg+eWvNZEqu7epxwus/8ElT3hacYEucm49SZg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.62.2.tgz",
+      "integrity": "sha512-JqgflS8wEB+UXV/vS1RpRbifGBeN4D5lz8D8oOFbFZw4vedvdOgCFAjfBmIMdW3yL10XpQQ0Ambepw6MXrhOnA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-gnu": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.62.2.tgz",
+      "integrity": "sha512-wnFJkogWvN4jm/hQRF2UBaeUmk20j5+DmHvoyWii2b8HJDyvz1MF2OU/6ynXt2KR63rbZLWkFpoytpdc/yBuSA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-musl": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.62.2.tgz",
+      "integrity": "sha512-HVu2bp0zhvJ8xHEV9+UUs7S90VadmBSY3LcIMvozbPo4AuMGDWlz3ymHLHZPX4hR67TKTt8Qp5PJ5RBg/i+RMQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-gnu": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.62.2.tgz",
+      "integrity": "sha512-mQqqAV8QaoSgr9I2fKDLY2BAVvmKjWoGiu/cSYQonsLvtqwEn1E4QYfnCOcp5zoEqNhsDYin1s6jx/VJmrxlZg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-musl": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.62.2.tgz",
+      "integrity": "sha512-IxKLoxCQ2IWi6bT2akyDUBGsOImDKB+sPp4EsTmwFQ/fMwpCKm8uLSSgP/Kx/QYUgKis6SEZ5/Nlhup0DIA0PQ==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-gnu": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.62.2.tgz",
+      "integrity": "sha512-Mk5ha2RQSgyFfmYYLkBpPnUk8D8FriBxesO1u9O75X0mHgXL1UQcH5Itl2lurWL2tj0RxV9b9tJgipac0hRY9A==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-musl": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.62.2.tgz",
+      "integrity": "sha512-CjvEnqJL/0/TQ3TXX3OPIJ/kmBellrWd4heXUmHeJlTnmwjKpSJzoehLaL6Xk0ZnMHBu9dZuFADNOrtjF4v+2w==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.62.2.tgz",
+      "integrity": "sha512-1SiZbzwdkaDURsew/tSOrooKiYy7EQGT6m8ufavAi9NEyQb/6VuIxFXAL1fqa4iZe3g4NbNk4P7J32z2tw5Mgg==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-musl": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.62.2.tgz",
+      "integrity": "sha512-nQts12zJ3NQRoE6uYljOH89v7szzLDvG2JD/vsX+vGXU8w/At1GowTZ5/7qeFQ8m7L55rpR8Okugnuo5bgjy2Q==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-s390x-gnu": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.62.2.tgz",
+      "integrity": "sha512-E9/ll019jhPIJgpzfZoIkBGhcz+kKNgVWYRY0zr9srBdPPFVpvOKW8VaJKUbeK+eZXyQF9ltME+Kk6affeaPgg==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.62.2.tgz",
+      "integrity": "sha512-5BqxR/pshjey51iliyzTD5Xi3EN0aLmQ2lZ3lvefVV9c82BvrLo2/6OT55iifpWBufs6kdwWbuOKS841DrmK9A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-musl": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.62.2.tgz",
+      "integrity": "sha512-uNN83XxQrRAh/w0/pmAfibcwyb6YWt4gP+dpnQKPVJshAloQ785ii8CT8ZCIxkGg9opVsvAlGhFitSm6D1Jjpg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-openbsd-x64": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.62.2.tgz",
+      "integrity": "sha512-srjEIxSH3LRnJN6THczDHWQplqEMFiAJrTab0msUryh9kwNpkICf3Ea6q6MN/2cZwRFUNx5w+h6Hpi4QuHS6Zg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-openharmony-arm64": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.62.2.tgz",
+      "integrity": "sha512-8hOJnxgbyObnCm5AlRA3A931xX19xq80RjVTKgJOvEKWqJruP/Uf12IbAOaDjjEXYRewwHLfmF0YRIdK3OwKWA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-arm64-msvc": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.62.2.tgz",
+      "integrity": "sha512-mmF4AY1i0hG/bLWUctUq59gtmgaSIRa3cu/A3JFRp/sCNEme2bgDEiDS22P9FbnJB8NJNF4jPJiSP5RHQpUTDg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-ia32-msvc": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.62.2.tgz",
+      "integrity": "sha512-DZgkknc6jhHrk46V25vbAM0zZkyP0nSDkJB8/dRkLTxv470dOmWDqGoEJl/9A0dFfS7yE3REOwNDxpHwSLSt0Q==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-gnu": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.62.2.tgz",
+      "integrity": "sha512-T6xr6ucWSFto+VGajA8YH26LdpHRuP4YLHEKAtCWvJDOlnmWcDZVCI2Jmjr+IFHDlt2zRaTAKE4tfjTaWLgJBg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-msvc": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.62.2.tgz",
+      "integrity": "sha512-BfzEnDJOt9T8M989/lA37EcJgat01wLRnoi5dQf3QzOH7jzpqTAzdDbVfRljVr5r+jzKqpbHeyOfAaXxAd0PAA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
+      "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/node": {
+      "version": "22.20.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.20.0.tgz",
+      "integrity": "sha512-QWlFW2wf3nTjC13/DqRnBpR4ZO36VJH/JVBkA/vcnmbTBNQIlnObqyqZE1tUR7+Ni23Lda8R1BxMfbXRpCUx5g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/@vitest/expect": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-2.1.9.tgz",
+      "integrity": "sha512-UJCIkTBenHeKT1TTlKMJWy1laZewsRIzYighyYiJKZreqtdxSos/S1t+ktRMQWu2CKqaarrkeszJx1cgC5tGZw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "2.1.9",
+        "@vitest/utils": "2.1.9",
+        "chai": "^5.1.2",
+        "tinyrainbow": "^1.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-2.1.9.tgz",
+      "integrity": "sha512-tVL6uJgoUdi6icpxmdrn5YNo3g3Dxv+IHJBr0GXHaEdTcw3F+cPKnsXFhli6nO+f/6SDKPHEK1UN+k+TQv0Ehg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "2.1.9",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.12"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-2.1.9.tgz",
+      "integrity": "sha512-KhRIdGV2U9HOUzxfiHmY8IFHTdqtOhIzCpd8WRdJiE7D/HUcZVD0EgQCVjm+Q9gkUXWgBvMmTtZgIG48wq7sOQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^1.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-2.1.9.tgz",
+      "integrity": "sha512-ZXSSqTFIrzduD63btIfEyOmNcBmQvgOVsPNPe0jYtESiXkhd8u2erDLnMxmGrDCwHCCHE7hxwRDCT3pt0esT4g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "2.1.9",
+        "pathe": "^1.1.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-2.1.9.tgz",
+      "integrity": "sha512-oBO82rEjsxLNJincVhLhaxxZdEtV0EFHMK5Kmx5sJ6H9L183dHECjiefOAdnqpIgT5eZwT04PoggUnW88vOBNQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "2.1.9",
+        "magic-string": "^0.30.12",
+        "pathe": "^1.1.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-2.1.9.tgz",
+      "integrity": "sha512-E1B35FwzXXTs9FHNK6bDszs7mtydNi5MIfUWpceJ8Xbfb1gBMscAnwLbEu+B44ed6W3XjL9/ehLPHR1fkf1KLQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyspy": "^3.0.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-2.1.9.tgz",
+      "integrity": "sha512-v0psaMSkNJ3A2NMrUEHFRzJtDPFn+/VWZ5WxImB21T9fjucJRmS7xCS3ppEnARb9y11OAzaD+P2Ps+b+BGX5iQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "2.1.9",
+        "loupe": "^3.1.2",
+        "tinyrainbow": "^1.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/cac": {
+      "version": "6.7.14",
+      "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
+      "integrity": "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/chai": {
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-5.3.3.tgz",
+      "integrity": "sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "assertion-error": "^2.0.1",
+        "check-error": "^2.1.1",
+        "deep-eql": "^5.0.1",
+        "loupe": "^3.1.0",
+        "pathval": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/check-error": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-2.1.3.tgz",
+      "integrity": "sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 16"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/deep-eql": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-5.0.2.tgz",
+      "integrity": "sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/es-module-lexer": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
+      "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/esbuild": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.1.tgz",
+      "integrity": "sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.28.1",
+        "@esbuild/android-arm": "0.28.1",
+        "@esbuild/android-arm64": "0.28.1",
+        "@esbuild/android-x64": "0.28.1",
+        "@esbuild/darwin-arm64": "0.28.1",
+        "@esbuild/darwin-x64": "0.28.1",
+        "@esbuild/freebsd-arm64": "0.28.1",
+        "@esbuild/freebsd-x64": "0.28.1",
+        "@esbuild/linux-arm": "0.28.1",
+        "@esbuild/linux-arm64": "0.28.1",
+        "@esbuild/linux-ia32": "0.28.1",
+        "@esbuild/linux-loong64": "0.28.1",
+        "@esbuild/linux-mips64el": "0.28.1",
+        "@esbuild/linux-ppc64": "0.28.1",
+        "@esbuild/linux-riscv64": "0.28.1",
+        "@esbuild/linux-s390x": "0.28.1",
+        "@esbuild/linux-x64": "0.28.1",
+        "@esbuild/netbsd-arm64": "0.28.1",
+        "@esbuild/netbsd-x64": "0.28.1",
+        "@esbuild/openbsd-arm64": "0.28.1",
+        "@esbuild/openbsd-x64": "0.28.1",
+        "@esbuild/openharmony-arm64": "0.28.1",
+        "@esbuild/sunos-x64": "0.28.1",
+        "@esbuild/win32-arm64": "0.28.1",
+        "@esbuild/win32-ia32": "0.28.1",
+        "@esbuild/win32-x64": "0.28.1"
+      }
+    },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.4.0.tgz",
+      "integrity": "sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/loupe": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/loupe/-/loupe-3.2.1.tgz",
+      "integrity": "sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.15",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.15.tgz",
+      "integrity": "sha512-y7Wygv/7mEOvxTuEQDB8StXdMRBWf1kR/tlhAzBRUFkB2jfcLOAxO/SHmOO2zgz1pVgK29/kyupn059/bCHdjA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/pathe": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-1.1.2.tgz",
+      "integrity": "sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/pathval": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/pathval/-/pathval-2.0.1.tgz",
+      "integrity": "sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14.16"
+      }
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/postcss": {
+      "version": "8.5.16",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.16.tgz",
+      "integrity": "sha512-vuwillviilfKZsg0VGj5R/YwwcHx4SLsIOI/7K6mQkWx+l5cUHTjj5g0AasTBcyXsbfTgrwsUNmVUb5xVwyPwg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.12",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/rollup": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.62.2.tgz",
+      "integrity": "sha512-RFnrW4lhXA3s3eqHDZvN654g8OTjzRfqpIRJYczCGB6HzphckVAi/Qh4tbPUbRuDi7s1Llv8g/NspLkttY3gTA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "1.0.9"
+      },
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "@rollup/rollup-android-arm-eabi": "4.62.2",
+        "@rollup/rollup-android-arm64": "4.62.2",
+        "@rollup/rollup-darwin-arm64": "4.62.2",
+        "@rollup/rollup-darwin-x64": "4.62.2",
+        "@rollup/rollup-freebsd-arm64": "4.62.2",
+        "@rollup/rollup-freebsd-x64": "4.62.2",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.62.2",
+        "@rollup/rollup-linux-arm-musleabihf": "4.62.2",
+        "@rollup/rollup-linux-arm64-gnu": "4.62.2",
+        "@rollup/rollup-linux-arm64-musl": "4.62.2",
+        "@rollup/rollup-linux-loong64-gnu": "4.62.2",
+        "@rollup/rollup-linux-loong64-musl": "4.62.2",
+        "@rollup/rollup-linux-ppc64-gnu": "4.62.2",
+        "@rollup/rollup-linux-ppc64-musl": "4.62.2",
+        "@rollup/rollup-linux-riscv64-gnu": "4.62.2",
+        "@rollup/rollup-linux-riscv64-musl": "4.62.2",
+        "@rollup/rollup-linux-s390x-gnu": "4.62.2",
+        "@rollup/rollup-linux-x64-gnu": "4.62.2",
+        "@rollup/rollup-linux-x64-musl": "4.62.2",
+        "@rollup/rollup-openbsd-x64": "4.62.2",
+        "@rollup/rollup-openharmony-arm64": "4.62.2",
+        "@rollup/rollup-win32-arm64-msvc": "4.62.2",
+        "@rollup/rollup-win32-ia32-msvc": "4.62.2",
+        "@rollup/rollup-win32-x64-gnu": "4.62.2",
+        "@rollup/rollup-win32-x64-msvc": "4.62.2",
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz",
+      "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-0.3.2.tgz",
+      "integrity": "sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinypool": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/tinypool/-/tinypool-1.1.1.tgz",
+      "integrity": "sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-1.2.0.tgz",
+      "integrity": "sha512-weEDEq7Z5eTHPDh4xjX789+fHfF+P8boiFB+0vbWzpbnbsEr/GRaohi/uMKxg8RZMXnl1ItAi/IUHWMsjDV7kQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tinyspy": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-3.0.2.tgz",
+      "integrity": "sha512-n1cw8k1k0x4pgA2+9XrOkFydTerNcJ1zWCO5Nn9scWHTD+5tp8dghT2x1uduQePZTZgd3Tupf+x9BxJjeJi77Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tsx": {
+      "version": "4.23.0",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.23.0.tgz",
+      "integrity": "sha512-eUdUIaCr963q2h5u3+QwvYp0+eqPvn+egeqZUm0hwERCqqx1E3kK5ehbGCvqSE5MQAULr67ww0cA3jKc3YkM1w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "~0.28.0"
+      },
+      "bin": {
+        "tsx": "dist/cli.mjs"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/vite": {
+      "version": "5.4.21",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-5.4.21.tgz",
+      "integrity": "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "^0.21.3",
+        "postcss": "^8.4.43",
+        "rollup": "^4.20.0"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^18.0.0 || >=20.0.0",
+        "less": "*",
+        "lightningcss": "^1.21.0",
+        "sass": "*",
+        "sass-embedded": "*",
+        "stylus": "*",
+        "sugarss": "*",
+        "terser": "^5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vite-node": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-2.1.9.tgz",
+      "integrity": "sha512-AM9aQ/IPrW/6ENLQg3AGY4K1N2TGZdR5e4gu/MmmR2xR3Ll1+dib+nook92g4TV3PXVyeyxdWwtaCAiUL0hMxA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cac": "^6.7.14",
+        "debug": "^4.3.7",
+        "es-module-lexer": "^1.5.4",
+        "pathe": "^1.1.2",
+        "vite": "^5.0.0"
+      },
+      "bin": {
+        "vite-node": "vite-node.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/aix-ppc64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/android-arm": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.21.5.tgz",
+      "integrity": "sha512-vCPvzSjpPHEi1siZdlvAlsPxXl7WbOVUBBAowWug4rJHb68Ox8KualB+1ocNvT5fjv6wpkX6o/iEpbDrf68zcg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/android-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.21.5.tgz",
+      "integrity": "sha512-c0uX9VAUBQ7dTDCjq+wdyGLowMdtR/GoC2U5IYk/7D1H1JYC0qseD7+11iMP2mRLN9RcCMRcjC4YMclCzGwS/A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/android-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.21.5.tgz",
+      "integrity": "sha512-D7aPRUUNHRBwHxzxRvp856rjUHRFW1SdQATKXH2hqA0kAZb1hKmi02OpYRacl0TxIGz/ZmXWlbZgjwWYaCakTA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/darwin-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.21.5.tgz",
+      "integrity": "sha512-DwqXqZyuk5AiWWf3UfLiRDJ5EDd49zg6O9wclZ7kUMv2WRFr4HKjXp/5t8JZ11QbQfUS6/cRCKGwYhtNAY88kQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/darwin-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.21.5.tgz",
+      "integrity": "sha512-se/JjF8NlmKVG4kNIuyWMV/22ZaerB+qaSi5MdrXtd6R08kvs2qCN4C09miupktDitvh8jRFflwGFBQcxZRjbw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.21.5.tgz",
+      "integrity": "sha512-5JcRxxRDUJLX8JXp/wcBCy3pENnCgBR9bN6JsY4OmhfUtIHe3ZW0mawA7+RDAcMLrMIZaf03NlQiX9DGyB8h4g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/freebsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.21.5.tgz",
+      "integrity": "sha512-J95kNBj1zkbMXtHVH29bBriQygMXqoVQOQYA+ISs0/2l3T9/kj42ow2mpqerRBxDJnmkUDCaQT/dfNXWX/ZZCQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-arm": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.21.5.tgz",
+      "integrity": "sha512-bPb5AHZtbeNGjCKVZ9UGqGwo8EUu4cLq68E95A53KlxAPRmUyYv2D6F0uUI65XisGOL1hBP5mTronbgo+0bFcA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.21.5.tgz",
+      "integrity": "sha512-ibKvmyYzKsBeX8d8I7MH/TMfWDXBF3db4qM6sy+7re0YXya+K1cem3on9XgdT2EQGMu4hQyZhan7TeQ8XkGp4Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-ia32": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.21.5.tgz",
+      "integrity": "sha512-YvjXDqLRqPDl2dvRODYmmhz4rPeVKYvppfGYKSNGdyZkA01046pLWyRKKI3ax8fbJoK5QbxblURkwK/MWY18Tg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-loong64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.21.5.tgz",
+      "integrity": "sha512-uHf1BmMG8qEvzdrzAqg2SIG/02+4/DHB6a9Kbya0XDvwDEKCoC8ZRWI5JJvNdUjtciBGFQ5PuBlpEOXQj+JQSg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-mips64el": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.21.5.tgz",
+      "integrity": "sha512-IajOmO+KJK23bj52dFSNCMsz1QP1DqM6cwLUv3W1QwyxkyIWecfafnI555fvSGqEKwjMXVLokcV5ygHW5b3Jbg==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-ppc64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1hHV/Z4OEfMwpLO8rp7CvlhBDnjsC3CttJXIhBi+5Aj5r+MBvy4egg7wCbe//hSsT+RvDAG7s81tAvpL2XAE4w==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-riscv64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.21.5.tgz",
+      "integrity": "sha512-2HdXDMd9GMgTGrPWnJzP2ALSokE/0O5HhTUvWIbD3YdjME8JwvSCnNGBnTThKGEB91OZhzrJ4qIIxk/SBmyDDA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-s390x": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.21.5.tgz",
+      "integrity": "sha512-zus5sxzqBJD3eXxwvjN1yQkRepANgxE9lgOW2qLnmr8ikMTphkjgXu1HR01K4FJg8h1kEEDAqDcZQtbrRnB41A==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.21.5.tgz",
+      "integrity": "sha512-1rYdTpyv03iycF1+BhzrzQJCdOuAOtaqHTWJZCWvijKD2N5Xu0TtVC8/+1faWqcP9iBCWOmjmhoH94dH82BxPQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/netbsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-Woi2MXzXjMULccIwMnLciyZH4nCIMpWQAs049KEeMvOcNADVxo0UBIQPfSmxB3CWKedngg7sWZdLvLczpe0tLg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/openbsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-HLNNw99xsvx12lFBUwoT8EVCsSvRNDVxNpjZ7bPn947b8gJPzeHWyNVhFsaerc0n3TsbOINvRP2byTZ5LKezow==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/sunos-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.21.5.tgz",
+      "integrity": "sha512-6+gjmFpfy0BHU5Tpptkuh8+uw3mnrvgs+dSPQXQOv3ekbordwnzTVEb4qnIvQcYXq6gzkyTnoZ9dZG+D4garKg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/win32-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.21.5.tgz",
+      "integrity": "sha512-Z0gOTd75VvXqyq7nsl93zwahcTROgqvuAcYDUr+vOv8uHhNSKROyU961kgtCD1e95IqPKSQKH7tBTslnS3tA8A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/win32-ia32": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.21.5.tgz",
+      "integrity": "sha512-SWXFF1CL2RVNMaVs+BBClwtfZSvDgtL//G/smwAc5oVK/UPu2Gu9tIaRgFmYFFKrmg3SyAjSrElf0TiJ1v8fYA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/win32-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.21.5.tgz",
+      "integrity": "sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/esbuild": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.21.5.tgz",
+      "integrity": "sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.21.5",
+        "@esbuild/android-arm": "0.21.5",
+        "@esbuild/android-arm64": "0.21.5",
+        "@esbuild/android-x64": "0.21.5",
+        "@esbuild/darwin-arm64": "0.21.5",
+        "@esbuild/darwin-x64": "0.21.5",
+        "@esbuild/freebsd-arm64": "0.21.5",
+        "@esbuild/freebsd-x64": "0.21.5",
+        "@esbuild/linux-arm": "0.21.5",
+        "@esbuild/linux-arm64": "0.21.5",
+        "@esbuild/linux-ia32": "0.21.5",
+        "@esbuild/linux-loong64": "0.21.5",
+        "@esbuild/linux-mips64el": "0.21.5",
+        "@esbuild/linux-ppc64": "0.21.5",
+        "@esbuild/linux-riscv64": "0.21.5",
+        "@esbuild/linux-s390x": "0.21.5",
+        "@esbuild/linux-x64": "0.21.5",
+        "@esbuild/netbsd-x64": "0.21.5",
+        "@esbuild/openbsd-x64": "0.21.5",
+        "@esbuild/sunos-x64": "0.21.5",
+        "@esbuild/win32-arm64": "0.21.5",
+        "@esbuild/win32-ia32": "0.21.5",
+        "@esbuild/win32-x64": "0.21.5"
+      }
+    },
+    "node_modules/vitest": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-2.1.9.tgz",
+      "integrity": "sha512-MSmPM9REYqDGBI8439mA4mWhV5sKmDlBKWIYbA3lRb2PTHACE0mgKwA8yQ2xq9vxDTuk4iPrECBAEW2aoFXY0Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "2.1.9",
+        "@vitest/mocker": "2.1.9",
+        "@vitest/pretty-format": "^2.1.9",
+        "@vitest/runner": "2.1.9",
+        "@vitest/snapshot": "2.1.9",
+        "@vitest/spy": "2.1.9",
+        "@vitest/utils": "2.1.9",
+        "chai": "^5.1.2",
+        "debug": "^4.3.7",
+        "expect-type": "^1.1.0",
+        "magic-string": "^0.30.12",
+        "pathe": "^1.1.2",
+        "std-env": "^3.8.0",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^0.3.1",
+        "tinypool": "^1.0.1",
+        "tinyrainbow": "^1.2.0",
+        "vite": "^5.0.0",
+        "vite-node": "2.1.9",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@types/node": "^18.0.0 || >=20.0.0",
+        "@vitest/browser": "2.1.9",
+        "@vitest/ui": "2.1.9",
+        "happy-dom": "*",
+        "jsdom": "*"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    }
+  }
+}

--- a/tools/mrm-simulator/package.json
+++ b/tools/mrm-simulator/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "mrm-simulator",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "description": "Scenario-driven MRM metric simulator and gap-finder for VerifyWise",
+  "scripts": {
+    "test": "vitest run",
+    "sim": "tsx src/cli.ts"
+  },
+  "devDependencies": {
+    "tsx": "^4.19.2",
+    "typescript": "^5.6.3",
+    "vitest": "^2.1.8",
+    "@types/node": "^22.10.1"
+  }
+}

--- a/tools/mrm-simulator/scenarios/fleet.ts
+++ b/tools/mrm-simulator/scenarios/fleet.ts
@@ -1,0 +1,57 @@
+import { FleetModel } from "../src/types.js";
+
+export const FLEET: FleetModel[] = [
+  {
+    externalKey: "credit-scoring-v3",
+    name: "Credit scoring v3",
+    provider: "in-house",
+    tier: "1",
+    materialityDrivers: "capital impact, regulatory reporting, customer exposure",
+    metricKeys: ["psi", "auc", "gini", "ks"],
+    thresholds: [
+      { metric: "psi", op: "gt", value_num: 0.2, severity: "high", breach_action: "notify_flag_revalidation" },
+      { metric: "auc", op: "lt", value_num: 0.8, severity: "warn", breach_action: "notify" },
+    ],
+  },
+  {
+    externalKey: "fraud-detector-v2",
+    name: "Fraud detector v2",
+    provider: "in-house",
+    tier: "1",
+    materialityDrivers: "fraud loss exposure, real-time decisioning",
+    metricKeys: ["psi", "auc", "gini", "ks"],
+    thresholds: [
+      { metric: "psi", op: "gt", value_num: 0.25, severity: "high", breach_action: "notify" },
+    ],
+  },
+  {
+    externalKey: "loan-approval-v1",
+    name: "Loan approval v1",
+    provider: "in-house",
+    tier: "2",
+    materialityDrivers: "lending decisions, fair-lending risk",
+    metricKeys: ["psi", "auc", "gini", "ks"],
+    thresholds: [
+      {
+        metric: "gini",
+        op: "outside",
+        value_lo: 0.45,
+        value_hi: 0.75,
+        severity: "high",
+        breach_action: "notify_flag_revalidation",
+        segment: "subprime",
+      },
+    ],
+  },
+  {
+    externalKey: "churn-propensity-v1",
+    name: "Churn propensity v1",
+    provider: "in-house",
+    tier: "3",
+    materialityDrivers: "retention spend allocation",
+    metricKeys: ["psi", "auc", "gini", "ks"],
+    thresholds: [
+      { metric: "psi", op: "gt", value_num: 0.15, severity: "warn", breach_action: "notify" },
+    ],
+  },
+];

--- a/tools/mrm-simulator/scenarios/storylines.test.ts
+++ b/tools/mrm-simulator/scenarios/storylines.test.ts
@@ -6,6 +6,9 @@ describe("storylines", () => {
     expect(metricValue("credit-scoring-v3", "psi", 0)).toBeLessThan(0.1);
     expect(metricValue("credit-scoring-v3", "psi", 17)).toBeLessThan(0.2);
     expect(metricValue("credit-scoring-v3", "psi", 20)).toBeGreaterThan(0.2);
+    // Robustness: worst-case noise-adjusted floor is 0.2247, well above 0.215.
+    // This catches regressions to a thin margin (e.g. old endpoint 0.28 would fail here).
+    expect(metricValue("credit-scoring-v3", "psi", 20)).toBeGreaterThan(0.215);
   });
 
   it("fraud-detector-v2 stays healthy (psi never breaches 0.25)", () => {

--- a/tools/mrm-simulator/scenarios/storylines.test.ts
+++ b/tools/mrm-simulator/scenarios/storylines.test.ts
@@ -1,0 +1,35 @@
+import { describe, it, expect } from "vitest";
+import { metricValue } from "./storylines";
+
+describe("storylines", () => {
+  it("credit-scoring-v3 PSI drifts across 0.20 around day 18", () => {
+    expect(metricValue("credit-scoring-v3", "psi", 0)).toBeLessThan(0.1);
+    expect(metricValue("credit-scoring-v3", "psi", 17)).toBeLessThan(0.2);
+    expect(metricValue("credit-scoring-v3", "psi", 20)).toBeGreaterThan(0.2);
+  });
+
+  it("fraud-detector-v2 stays healthy (psi never breaches 0.25)", () => {
+    for (let d = 0; d < 30; d++) {
+      expect(metricValue("fraud-detector-v2", "psi", d)).toBeLessThan(0.25);
+    }
+  });
+
+  it("loan-approval-v1 subprime gini drops below 0.45 while overall stays in band", () => {
+    const lateSubprime = metricValue("loan-approval-v1", "gini", 25, "subprime");
+    const lateOverall = metricValue("loan-approval-v1", "gini", 25, "overall");
+    expect(lateSubprime).toBeLessThan(0.45);
+    expect(lateOverall).toBeGreaterThanOrEqual(0.45);
+    expect(lateOverall).toBeLessThanOrEqual(0.75);
+  });
+
+  it("churn-propensity-v1 breaches psi>0.15 mid-window then recovers", () => {
+    expect(metricValue("churn-propensity-v1", "psi", 15)).toBeGreaterThan(0.15);
+    expect(metricValue("churn-propensity-v1", "psi", 28)).toBeLessThan(0.15);
+  });
+
+  it("is deterministic (same inputs -> same output)", () => {
+    expect(metricValue("credit-scoring-v3", "psi", 10)).toBe(
+      metricValue("credit-scoring-v3", "psi", 10),
+    );
+  });
+});

--- a/tools/mrm-simulator/scenarios/storylines.ts
+++ b/tools/mrm-simulator/scenarios/storylines.ts
@@ -18,16 +18,31 @@ const ramp = (day: number, fromDay: number, toDay: number, fromVal: number, toVa
   return fromVal + t * (toVal - fromVal);
 };
 
+// Content-based character sum — avoids seed collisions between same-length strings.
+const charSum = (s: string): number => {
+  let sum = 0;
+  for (let i = 0; i < s.length; i++) sum += s.charCodeAt(i);
+  return sum;
+};
+
 export const metricValue = (
   externalKey: string,
   metric: string,
   dayIndex: number,
   segment: string = "overall",
 ): number => {
-  const n = noise(dayIndex + metric.length * 7 + externalKey.length * 13) * 0.01;
+  // FINDING 2 FIX: incorporate string content (not just length) so same-length
+  // keys produce different seeds and noise values don't collide.
+  const n = noise(dayIndex + charSum(metric) + charSum(externalKey)) * 0.01;
 
   if (externalKey === "credit-scoring-v3") {
-    if (metric === "psi") return clamp(ramp(dayIndex, 0, 30, 0.05, 0.28) + n, 0, 1);
+    // FINDING 1 FIX: ramp from day 11→30 (flat at 0.05 before day 11) with endpoint 0.44.
+    // Boundary arithmetic (noise amplitude = ±0.01):
+    //   ramp(17) = 0.05 + (6/19)*0.39 = 0.05 + 0.1232 = 0.1732 → worst-case high = 0.1832 < 0.20  ✓ margin 0.017
+    //   ramp(20) = 0.05 + (9/19)*0.39 = 0.05 + 0.1847 = 0.2347 → worst-case low  = 0.2247 > 0.215 ✓ margin 0.010
+    //   ramp( 0) = 0.05 (flat before day 11)                     → worst-case high = 0.06   < 0.10  ✓
+    //   ramp(30) = 0.44 ≥ 0.30, so fleet PSI > 0.20 threshold fires as intended.
+    if (metric === "psi") return clamp(ramp(dayIndex, 11, 30, 0.05, 0.44) + n, 0, 1);
     if (metric === "auc") return clamp(ramp(dayIndex, 0, 30, 0.86, 0.82) + n, 0, 1);
     if (metric === "gini") return clamp(ramp(dayIndex, 0, 30, 0.7, 0.63) + n, 0, 1);
     if (metric === "ks") return clamp(0.4 + n, 0, 1);

--- a/tools/mrm-simulator/scenarios/storylines.ts
+++ b/tools/mrm-simulator/scenarios/storylines.ts
@@ -1,0 +1,68 @@
+// Deterministic, seeded metric storylines. Values are a function of
+// (externalKey, metric, dayIndex, segment) with small reproducible noise so
+// charts look organic without random run-to-run variation.
+
+// Deterministic pseudo-noise in [-1, 1] from integer-ish inputs (no Math.random).
+const noise = (seed: number): number => {
+  const x = Math.sin(seed * 12.9898) * 43758.5453;
+  return (x - Math.floor(x)) * 2 - 1;
+};
+
+const clamp = (v: number, lo: number, hi: number): number => Math.min(hi, Math.max(lo, v));
+
+// Linear ramp helper.
+const ramp = (day: number, fromDay: number, toDay: number, fromVal: number, toVal: number): number => {
+  if (day <= fromDay) return fromVal;
+  if (day >= toDay) return toVal;
+  const t = (day - fromDay) / (toDay - fromDay);
+  return fromVal + t * (toVal - fromVal);
+};
+
+export const metricValue = (
+  externalKey: string,
+  metric: string,
+  dayIndex: number,
+  segment: string = "overall",
+): number => {
+  const n = noise(dayIndex + metric.length * 7 + externalKey.length * 13) * 0.01;
+
+  if (externalKey === "credit-scoring-v3") {
+    if (metric === "psi") return clamp(ramp(dayIndex, 0, 30, 0.05, 0.28) + n, 0, 1);
+    if (metric === "auc") return clamp(ramp(dayIndex, 0, 30, 0.86, 0.82) + n, 0, 1);
+    if (metric === "gini") return clamp(ramp(dayIndex, 0, 30, 0.7, 0.63) + n, 0, 1);
+    if (metric === "ks") return clamp(0.4 + n, 0, 1);
+  }
+
+  if (externalKey === "fraud-detector-v2") {
+    if (metric === "psi") return clamp(0.04 + n, 0, 1);
+    if (metric === "auc") return clamp(0.94 + n, 0, 1);
+    if (metric === "gini") return clamp(0.88 + n, 0, 1);
+    if (metric === "ks") return clamp(0.6 + n, 0, 1);
+  }
+
+  if (externalKey === "loan-approval-v1") {
+    if (metric === "gini") {
+      if (segment === "subprime") return clamp(ramp(dayIndex, 0, 30, 0.6, 0.4) + n, 0, 1);
+      return clamp(0.62 + n, 0, 1); // overall stays inside [0.45, 0.75]
+    }
+    if (metric === "psi") return clamp(0.06 + n, 0, 1);
+    if (metric === "auc") return clamp(0.83 + n, 0, 1);
+    if (metric === "ks") return clamp(0.45 + n, 0, 1);
+  }
+
+  if (externalKey === "churn-propensity-v1") {
+    if (metric === "psi") {
+      // healthy -> breach ~day 10 -> retrain recovery ~day 22
+      const drift = ramp(dayIndex, 5, 12, 0.08, 0.2);
+      const recover = ramp(dayIndex, 22, 26, 0.2, 0.08);
+      const v = dayIndex < 22 ? drift : recover;
+      return clamp(v + n, 0, 1);
+    }
+    if (metric === "auc") return clamp(0.8 + n, 0, 1);
+    if (metric === "gini") return clamp(0.55 + n, 0, 1);
+    if (metric === "ks") return clamp(0.38 + n, 0, 1);
+  }
+
+  // Unknown model/metric: benign flat value.
+  return clamp(0.5 + n, 0, 1);
+};

--- a/tools/mrm-simulator/src/cli.ts
+++ b/tools/mrm-simulator/src/cli.ts
@@ -1,0 +1,117 @@
+import { loadConfig, assertSafeTarget, readCache, writeCache } from "./config.js";
+import { runSetup } from "./setup.js";
+import { runVerify, runContractChecks } from "./verify.js";
+import { writeReport } from "./report.js";
+import { IngestClient } from "./ingestClient.js";
+import { generateRange, generatePoints } from "./engine.js";
+import { FLEET } from "../scenarios/fleet.js";
+import { Finding, IngestResultPoint, MetricPoint } from "./types.js";
+
+const arg = (name: string, def: string): string => {
+  const i = process.argv.indexOf(name);
+  return i >= 0 && i + 1 < process.argv.length ? process.argv[i + 1] : def;
+};
+const dryRun = process.argv.includes("--dry-run");
+
+const chunk = <T>(xs: T[], n: number): T[][] => {
+  const out: T[][] = [];
+  for (let i = 0; i < xs.length; i += n) out.push(xs.slice(i, i + n));
+  return out;
+};
+
+const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
+
+const main = async () => {
+  const cmd = process.argv[2];
+  const cfg = loadConfig(process.argv);
+  assertSafeTarget(cfg);
+
+  if (cmd === "setup") {
+    const { token, models, findings } = await runSetup(cfg);
+    console.log(`setup complete. token cached. models: ${Object.keys(models).join(", ")}`);
+    const cache = readCache();
+    cache.token = token;
+    writeCache(cache);
+    if (findings.length) console.log(`${findings.length} setup finding(s) recorded`);
+    return;
+  }
+
+  if (cmd === "backfill") {
+    const days = Number(arg("--days", "30"));
+    const cache = readCache();
+    if (!cache.token) throw new Error("run `setup` first (no token cached)");
+    const client = new IngestClient(cfg, cache.token);
+    const start = new Date(Date.now() - days * 86_400_000);
+    const resultsByKey: Record<string, IngestResultPoint[]> = {};
+    for (const model of FLEET) {
+      const points = generateRange(model, start, days);
+      if (dryRun) {
+        console.log(`[dry-run] ${model.externalKey}: ${points.length} points`);
+        continue;
+      }
+      resultsByKey[model.externalKey] = [];
+      for (const batch of chunk(points, 200)) {
+        const results = await client.pushBatch(model.externalKey, batch);
+        resultsByKey[model.externalKey].push(...results);
+      }
+      const breaches = resultsByKey[model.externalKey].filter((r) => r.status === "breach" || r.status === "warn").length;
+      console.log(`${model.externalKey}: pushed ${points.length}, ${breaches} warn/breach`);
+    }
+    if (!dryRun) {
+      cache.lastBackfill = new Date(start.getTime()).toISOString();
+      writeCache(cache);
+      const contractFindings = runContractChecks(resultsByKey);
+      writeReport(contractFindings);
+    }
+    return;
+  }
+
+  if (cmd === "live") {
+    const interval = Number(arg("--interval", "5").replace("s", "")) * 1000;
+    const cache = readCache();
+    if (!cache.token) throw new Error("run `setup` first");
+    const client = new IngestClient(cfg, cache.token);
+    let day = 0;
+    console.log(`live mode: pushing every ${interval / 1000}s (Ctrl-C to stop)`);
+    // eslint-disable-next-line no-constant-condition
+    while (true) {
+      for (const model of FLEET) {
+        const points = generatePoints(model, day, new Date());
+        if (dryRun) {
+          console.log(`[dry-run] ${model.externalKey} day ${day}: ${points.length} points`);
+        } else {
+          const results = await client.pushBatch(model.externalKey, points);
+          const b = results.filter((r) => r.status === "breach" || r.status === "warn").length;
+          if (b) console.log(`${model.externalKey} day ${day}: ${b} warn/breach`);
+        }
+      }
+      day++;
+      await sleep(interval);
+    }
+  }
+
+  if (cmd === "verify") {
+    const cache = readCache();
+    const findings: Finding[] = await runVerify(cfg, cache.models);
+    writeReport(findings);
+    console.log(`verify complete: ${findings.length} finding(s) -> gaps-report.md`);
+    return;
+  }
+
+  if (cmd === "report") {
+    console.log("gaps-report.md is written by `backfill` and `verify`.");
+    return;
+  }
+
+  if (cmd === "teardown") {
+    console.log("teardown: decommission the created models in the UI, then delete .mrm-simulator.json");
+    return;
+  }
+
+  console.log("usage: sim <setup|backfill|live|verify|report|teardown> [--days N] [--interval Ns] [--dry-run] [--base-url URL]");
+};
+
+main().catch((e) => {
+  console.error(e instanceof Error ? e.message : e);
+  process.exit(1);
+});

--- a/tools/mrm-simulator/src/config.test.ts
+++ b/tools/mrm-simulator/src/config.test.ts
@@ -1,0 +1,23 @@
+import { describe, it, expect } from "vitest";
+import { loadConfig, assertSafeTarget } from "./config";
+
+describe("config", () => {
+  it("defaults to localhost:3000", () => {
+    const cfg = loadConfig([]);
+    expect(cfg.baseUrl).toBe("http://localhost:3000");
+  });
+
+  it("assertSafeTarget allows localhost", () => {
+    expect(() => assertSafeTarget(loadConfig([]))).not.toThrow();
+  });
+
+  it("assertSafeTarget rejects a remote host without the override flag", () => {
+    const cfg = loadConfig(["--base-url", "https://app.example.com"]);
+    expect(() => assertSafeTarget(cfg)).toThrow(/refusing/i);
+  });
+
+  it("allows a remote host with --i-know-what-im-doing", () => {
+    const cfg = loadConfig(["--base-url", "https://app.example.com", "--i-know-what-im-doing"]);
+    expect(() => assertSafeTarget(cfg)).not.toThrow();
+  });
+});

--- a/tools/mrm-simulator/src/config.test.ts
+++ b/tools/mrm-simulator/src/config.test.ts
@@ -20,4 +20,14 @@ describe("config", () => {
     const cfg = loadConfig(["--base-url", "https://app.example.com", "--i-know-what-im-doing"]);
     expect(() => assertSafeTarget(cfg)).not.toThrow();
   });
+
+  it("assertSafeTarget rejects a localhost-prefixed subdomain", () => {
+    const cfg = loadConfig(["--base-url", "http://localhost.evil.com"]);
+    expect(() => assertSafeTarget(cfg)).toThrow(/refusing/i);
+  });
+
+  it("assertSafeTarget rejects the userinfo trick (localhost@evil.com)", () => {
+    const cfg = loadConfig(["--base-url", "http://localhost@evil.com"]);
+    expect(() => assertSafeTarget(cfg)).toThrow(/refusing/i);
+  });
 });

--- a/tools/mrm-simulator/src/config.ts
+++ b/tools/mrm-simulator/src/config.ts
@@ -1,0 +1,45 @@
+import { readFileSync, writeFileSync, existsSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+import { SimConfig } from "./types.js";
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const CACHE_PATH = join(HERE, "..", ".mrm-simulator.json");
+
+export interface CacheFile {
+  token?: string;
+  models: Record<string, number>; // externalKey -> modelId
+}
+
+const flag = (argv: string[], name: string): string | undefined => {
+  const i = argv.indexOf(name);
+  return i >= 0 && i + 1 < argv.length ? argv[i + 1] : undefined;
+};
+
+const has = (argv: string[], name: string): boolean => argv.includes(name);
+
+export const loadConfig = (argv: string[]): SimConfig => ({
+  baseUrl: flag(argv, "--base-url") ?? "http://localhost:3000",
+  email: process.env.VW_EMAIL ?? "gorkem.cetin@verifywise.ai",
+  password: process.env.VW_PASSWORD ?? "Verifywise#1",
+  allowRemote: has(argv, "--i-know-what-im-doing"),
+});
+
+export const assertSafeTarget = (cfg: SimConfig): void => {
+  const isLocal = /^https?:\/\/(localhost|127\.0\.0\.1)(:\d+)?/.test(cfg.baseUrl);
+  if (!isLocal && !cfg.allowRemote) {
+    throw new Error(
+      `refusing to run against non-localhost target ${cfg.baseUrl}. ` +
+        `Pass --i-know-what-im-doing to override (this sends synthetic data).`,
+    );
+  }
+};
+
+export const readCache = (): CacheFile => {
+  if (!existsSync(CACHE_PATH)) return { models: {} };
+  return JSON.parse(readFileSync(CACHE_PATH, "utf8")) as CacheFile;
+};
+
+export const writeCache = (c: CacheFile): void => {
+  writeFileSync(CACHE_PATH, JSON.stringify(c, null, 2));
+};

--- a/tools/mrm-simulator/src/config.ts
+++ b/tools/mrm-simulator/src/config.ts
@@ -26,7 +26,13 @@ export const loadConfig = (argv: string[]): SimConfig => ({
 });
 
 export const assertSafeTarget = (cfg: SimConfig): void => {
-  const isLocal = /^https?:\/\/(localhost|127\.0\.0\.1)(:\d+)?/.test(cfg.baseUrl);
+  let hostname: string;
+  try {
+    hostname = new URL(cfg.baseUrl).hostname;
+  } catch {
+    throw new Error(`refusing to run: baseUrl is not a valid URL: ${cfg.baseUrl}`);
+  }
+  const isLocal = hostname === "localhost" || hostname === "127.0.0.1";
   if (!isLocal && !cfg.allowRemote) {
     throw new Error(
       `refusing to run against non-localhost target ${cfg.baseUrl}. ` +

--- a/tools/mrm-simulator/src/config.ts
+++ b/tools/mrm-simulator/src/config.ts
@@ -9,6 +9,7 @@ const CACHE_PATH = join(HERE, "..", ".mrm-simulator.json");
 export interface CacheFile {
   token?: string;
   models: Record<string, number>; // externalKey -> modelId
+  lastBackfill?: string;
 }
 
 const flag = (argv: string[], name: string): string | undefined => {

--- a/tools/mrm-simulator/src/engine.test.ts
+++ b/tools/mrm-simulator/src/engine.test.ts
@@ -1,0 +1,27 @@
+import { describe, it, expect } from "vitest";
+import { generatePoints, generateRange } from "./engine";
+import { FLEET } from "../scenarios/fleet";
+
+const model = (key: string) => FLEET.find((m) => m.externalKey === key)!;
+
+describe("engine", () => {
+  it("generates one point per metric key plus segmented points where thresholds are segmented", () => {
+    const pts = generatePoints(model("loan-approval-v1"), 10, new Date("2026-07-01T00:00:00Z"));
+    // 4 base metric keys + 1 segmented gini (subprime)
+    expect(pts.filter((p) => p.segment === "subprime").length).toBe(1);
+    expect(pts.length).toBe(5);
+  });
+
+  it("stamps ISO 'at' and finite values", () => {
+    const pts = generatePoints(model("credit-scoring-v3"), 0, new Date("2026-07-01T00:00:00Z"));
+    for (const p of pts) {
+      expect(Number.isFinite(p.value)).toBe(true);
+      expect(p.at).toBe("2026-07-01T00:00:00.000Z");
+    }
+  });
+
+  it("generateRange produces days*perDay points", () => {
+    const pts = generateRange(model("fraud-detector-v2"), new Date("2026-06-01T00:00:00Z"), 30);
+    expect(pts.length).toBe(30 * 4); // 4 metric keys, no segmented threshold
+  });
+});

--- a/tools/mrm-simulator/src/engine.ts
+++ b/tools/mrm-simulator/src/engine.ts
@@ -1,0 +1,47 @@
+import { FleetModel, MetricPoint } from "./types.js";
+import { metricValue } from "../scenarios/storylines.js";
+
+// Segments a model reports for a metric, derived from its segmented thresholds.
+const segmentsFor = (model: FleetModel, metric: string): string[] => {
+  const segs = model.thresholds
+    .filter((t) => t.metric === metric && t.segment)
+    .map((t) => t.segment as string);
+  return [...new Set(segs)];
+};
+
+export const generatePoints = (model: FleetModel, dayIndex: number, date: Date): MetricPoint[] => {
+  const at = date.toISOString();
+  const points: MetricPoint[] = [];
+  for (const metric of model.metricKeys) {
+    // Base (overall) point.
+    points.push({
+      metric,
+      value: Number(metricValue(model.externalKey, metric, dayIndex).toFixed(4)),
+      at,
+      window: "daily",
+      segment: "overall",
+      context: { source_job: "nightly-monitor", day_index: dayIndex },
+    });
+    // Segmented points where a threshold targets a sub-population.
+    for (const seg of segmentsFor(model, metric)) {
+      points.push({
+        metric,
+        value: Number(metricValue(model.externalKey, metric, dayIndex, seg).toFixed(4)),
+        at,
+        window: "daily",
+        segment: seg,
+        context: { source_job: "nightly-monitor", day_index: dayIndex },
+      });
+    }
+  }
+  return points;
+};
+
+export const generateRange = (model: FleetModel, startDate: Date, days: number): MetricPoint[] => {
+  const all: MetricPoint[] = [];
+  for (let d = 0; d < days; d++) {
+    const date = new Date(startDate.getTime() + d * 86_400_000);
+    all.push(...generatePoints(model, d, date));
+  }
+  return all;
+};

--- a/tools/mrm-simulator/src/engine.ts
+++ b/tools/mrm-simulator/src/engine.ts
@@ -9,6 +9,24 @@ const segmentsFor = (model: FleetModel, metric: string): string[] => {
   return [...new Set(segs)];
 };
 
+// Rounded metric value with an explicit finite guard: the engine feeds the
+// ingestion API, which rejects non-finite values, so surface a clear local
+// error rather than pushing a NaN/Infinity that the server would silently drop.
+const roundedValue = (
+  externalKey: string,
+  metric: string,
+  dayIndex: number,
+  segment?: string,
+): number => {
+  const raw = metricValue(externalKey, metric, dayIndex, segment);
+  if (!Number.isFinite(raw)) {
+    throw new Error(
+      `Non-finite metric value for ${externalKey}/${metric} (day ${dayIndex}, segment ${segment ?? "overall"})`,
+    );
+  }
+  return Number(raw.toFixed(4));
+};
+
 export const generatePoints = (model: FleetModel, dayIndex: number, date: Date): MetricPoint[] => {
   const at = date.toISOString();
   const points: MetricPoint[] = [];
@@ -16,7 +34,7 @@ export const generatePoints = (model: FleetModel, dayIndex: number, date: Date):
     // Base (overall) point.
     points.push({
       metric,
-      value: Number(metricValue(model.externalKey, metric, dayIndex).toFixed(4)),
+      value: roundedValue(model.externalKey, metric, dayIndex),
       at,
       window: "daily",
       segment: "overall",
@@ -26,7 +44,7 @@ export const generatePoints = (model: FleetModel, dayIndex: number, date: Date):
     for (const seg of segmentsFor(model, metric)) {
       points.push({
         metric,
-        value: Number(metricValue(model.externalKey, metric, dayIndex, seg).toFixed(4)),
+        value: roundedValue(model.externalKey, metric, dayIndex, seg),
         at,
         window: "daily",
         segment: seg,

--- a/tools/mrm-simulator/src/httpEnvelope.test.ts
+++ b/tools/mrm-simulator/src/httpEnvelope.test.ts
@@ -1,0 +1,17 @@
+import { describe, it, expect } from "vitest";
+import { parseEnvelope, HttpError } from "./httpEnvelope";
+
+const fakeRes = (status: number, body: unknown): Response =>
+  new Response(JSON.stringify(body), { status, headers: { "content-type": "application/json" } });
+
+describe("httpEnvelope", () => {
+  it("returns inner data on 2xx", async () => {
+    const r = await parseEnvelope<{ token: string }>(fakeRes(202, { message: "Accepted", data: { token: "t" } }));
+    expect(r.status).toBe(202);
+    expect(r.data.token).toBe("t");
+  });
+
+  it("throws HttpError on non-2xx with the parsed body", async () => {
+    await expect(parseEnvelope(fakeRes(404, { message: "Not Found", data: "Model not found for this key" }))).rejects.toBeInstanceOf(HttpError);
+  });
+});

--- a/tools/mrm-simulator/src/httpEnvelope.ts
+++ b/tools/mrm-simulator/src/httpEnvelope.ts
@@ -1,0 +1,24 @@
+export class HttpError extends Error {
+  status: number;
+  body: unknown;
+  constructor(status: number, body: unknown) {
+    super(`HTTP ${status}: ${JSON.stringify(body)}`);
+    this.status = status;
+    this.body = body;
+  }
+}
+
+export const parseEnvelope = async <T>(res: Response): Promise<{ status: number; data: T }> => {
+  const text = await res.text();
+  let body: unknown;
+  try {
+    body = text ? JSON.parse(text) : {};
+  } catch {
+    throw new HttpError(res.status, text);
+  }
+  if (res.status < 200 || res.status >= 300) {
+    throw new HttpError(res.status, body);
+  }
+  const data = (body as { data: T }).data;
+  return { status: res.status, data };
+};

--- a/tools/mrm-simulator/src/ingestClient.ts
+++ b/tools/mrm-simulator/src/ingestClient.ts
@@ -1,0 +1,22 @@
+import { SimConfig, MetricPoint, IngestResultPoint } from "./types.js";
+import { parseEnvelope } from "./httpEnvelope.js";
+
+export class IngestClient {
+  constructor(private cfg: SimConfig, private token: string) {}
+
+  async pushBatch(externalKey: string, points: MetricPoint[]): Promise<IngestResultPoint[]> {
+    const res = await fetch(
+      `${this.cfg.baseUrl}/api/mrm/models/${encodeURIComponent(externalKey)}/metrics`,
+      {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: `Bearer ${this.token}`,
+        },
+        body: JSON.stringify({ points }),
+      },
+    );
+    const { data } = await parseEnvelope<{ accepted: number; results: IngestResultPoint[] }>(res);
+    return data.results;
+  }
+}

--- a/tools/mrm-simulator/src/jwtClient.ts
+++ b/tools/mrm-simulator/src/jwtClient.ts
@@ -1,0 +1,106 @@
+import { SimConfig, ThresholdSpec } from "./types.js";
+import { parseEnvelope } from "./httpEnvelope.js";
+
+export class JwtClient {
+  private token = "";
+  constructor(private cfg: SimConfig) {}
+
+  private headers(): Record<string, string> {
+    return {
+      "Content-Type": "application/json",
+      ...(this.token ? { Authorization: `Bearer ${this.token}` } : {}),
+    };
+  }
+
+  async login(): Promise<void> {
+    const res = await fetch(`${this.cfg.baseUrl}/api/users/login`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ email: this.cfg.email, password: this.cfg.password }),
+    });
+    const { data } = await parseEnvelope<{ token: string }>(res);
+    this.token = data.token;
+  }
+
+  async createModel(name: string, provider: string): Promise<number> {
+    const res = await fetch(`${this.cfg.baseUrl}/api/modelInventory`, {
+      method: "POST",
+      headers: this.headers(),
+      body: JSON.stringify({ model: name, provider, status: "Approved" }),
+    });
+    const { data } = await parseEnvelope<{ id: number }>(res);
+    return data.id;
+  }
+
+  async setExternalKey(modelId: number, key: string): Promise<void> {
+    const res = await fetch(`${this.cfg.baseUrl}/api/modelInventory/${modelId}`, {
+      method: "PATCH",
+      headers: this.headers(),
+      body: JSON.stringify({ external_key: key }),
+    });
+    await parseEnvelope(res);
+  }
+
+  async assignTier(modelId: number, tier: "1" | "2" | "3", drivers: string): Promise<void> {
+    const res = await fetch(`${this.cfg.baseUrl}/api/mrm/models/${modelId}/tier`, {
+      method: "PUT",
+      headers: this.headers(),
+      body: JSON.stringify({ tier, materiality_drivers: drivers }),
+    });
+    await parseEnvelope(res);
+  }
+
+  async createMetricKey(key: string): Promise<void> {
+    const res = await fetch(`${this.cfg.baseUrl}/api/mrm/metric-keys`, {
+      method: "POST",
+      headers: this.headers(),
+      body: JSON.stringify({ key }),
+    });
+    // 409 (already exists) is fine — swallow it.
+    if (res.status !== 409) await parseEnvelope(res);
+  }
+
+  async createThreshold(modelId: number, spec: ThresholdSpec): Promise<void> {
+    const res = await fetch(`${this.cfg.baseUrl}/api/mrm/models/${modelId}/thresholds`, {
+      method: "POST",
+      headers: this.headers(),
+      body: JSON.stringify(spec),
+    });
+    await parseEnvelope(res);
+  }
+
+  async createIngestionToken(name: string): Promise<string> {
+    const res = await fetch(`${this.cfg.baseUrl}/api/mrm/ingestion-tokens`, {
+      method: "POST",
+      headers: this.headers(),
+      body: JSON.stringify({ name, model_inventory_id: null }),
+    });
+    const { data } = await parseEnvelope<{ token: string }>(res);
+    return data.token;
+  }
+
+  async getAttestationSummary(): Promise<any> {
+    const res = await fetch(`${this.cfg.baseUrl}/api/mrm/attestation/summary`, { headers: this.headers() });
+    const { data } = await parseEnvelope<any>(res);
+    return data;
+  }
+
+  async getRevalidationEvents(modelId: number): Promise<any[]> {
+    const res = await fetch(`${this.cfg.baseUrl}/api/mrm/models/${modelId}/revalidation-events`, { headers: this.headers() });
+    const { data } = await parseEnvelope<any[]>(res);
+    return data;
+  }
+
+  async getValidations(modelId: number): Promise<any[]> {
+    const res = await fetch(`${this.cfg.baseUrl}/api/mrm/validations?modelId=${modelId}`, { headers: this.headers() });
+    const { data } = await parseEnvelope<any[]>(res);
+    return data;
+  }
+
+  async getBreaches(modelId: number, metric?: string): Promise<any[]> {
+    const q = metric ? `?metric=${encodeURIComponent(metric)}` : "";
+    const res = await fetch(`${this.cfg.baseUrl}/api/mrm/models/${modelId}/monitoring/breaches${q}`, { headers: this.headers() });
+    const { data } = await parseEnvelope<any[]>(res);
+    return data;
+  }
+}

--- a/tools/mrm-simulator/src/report.test.ts
+++ b/tools/mrm-simulator/src/report.test.ts
@@ -1,0 +1,23 @@
+import { describe, it, expect } from "vitest";
+import { renderReport } from "./report";
+import { Finding } from "./types";
+
+describe("report", () => {
+  it("groups findings by category with a summary count", () => {
+    const findings: Finding[] = [
+      { category: "contract", severity: "high", title: "A", expected: "x", actual: "y", repro: "z" },
+      { category: "workflow", severity: "medium", title: "B", expected: "x", actual: "y", repro: "z" },
+    ];
+    const md = renderReport(findings);
+    expect(md).toContain("# MRM simulator — gap report");
+    expect(md).toContain("2 findings");
+    expect(md).toContain("## Contract");
+    expect(md).toContain("## Workflow");
+    expect(md).toContain("A");
+  });
+
+  it("renders a clean bill of health when there are no findings", () => {
+    const md = renderReport([]);
+    expect(md).toContain("No gaps found");
+  });
+});

--- a/tools/mrm-simulator/src/report.ts
+++ b/tools/mrm-simulator/src/report.ts
@@ -1,0 +1,36 @@
+import { writeFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+import { Finding } from "./types.js";
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const REPORT_PATH = join(HERE, "..", "gaps-report.md");
+
+const CATEGORIES: Finding["category"][] = ["contract", "workflow", "ux"];
+const title = (c: string) => c.charAt(0).toUpperCase() + c.slice(1);
+
+export const renderReport = (findings: Finding[]): string => {
+  const lines: string[] = ["# MRM simulator — gap report", ""];
+  lines.push(`${findings.length} findings.`, "");
+  if (findings.length === 0) {
+    lines.push("No gaps found. The MRM governance loop behaved as documented.");
+    return lines.join("\n");
+  }
+  for (const cat of CATEGORIES) {
+    const group = findings.filter((f) => f.category === cat);
+    if (group.length === 0) continue;
+    lines.push(`## ${title(cat)}`, "");
+    for (const f of group) {
+      lines.push(`### [${f.severity}] ${f.title}`);
+      lines.push(`- **Expected:** ${f.expected}`);
+      lines.push(`- **Actual:** ${f.actual}`);
+      lines.push(`- **Repro:** ${f.repro}`);
+      lines.push("");
+    }
+  }
+  return lines.join("\n");
+};
+
+export const writeReport = (findings: Finding[]): void => {
+  writeFileSync(REPORT_PATH, renderReport(findings));
+};

--- a/tools/mrm-simulator/src/setup.ts
+++ b/tools/mrm-simulator/src/setup.ts
@@ -1,0 +1,45 @@
+import { SimConfig, Finding } from "./types.js";
+import { JwtClient } from "./jwtClient.js";
+import { FLEET } from "../scenarios/fleet.js";
+import { readCache, writeCache } from "./config.js";
+
+export const runSetup = async (
+  cfg: SimConfig,
+): Promise<{ token: string; models: Record<string, number>; findings: Finding[] }> => {
+  const findings: Finding[] = [];
+  const cache = readCache();
+  const client = new JwtClient(cfg);
+  await client.login();
+
+  for (const model of FLEET) {
+    if (cache.models[model.externalKey]) continue; // idempotent reuse
+
+    const modelId = await client.createModel(model.name, model.provider);
+
+    // external_key is NOT on the tier endpoint — set it via modelInventory PATCH.
+    // This split is itself a contract friction worth recording.
+    await client.setExternalKey(modelId, model.externalKey);
+    findings.push({
+      category: "contract",
+      severity: "low",
+      title: "external_key requires a separate PATCH call",
+      expected: "Setting the ingestion key alongside tier in one MRM call",
+      actual: "external_key is only settable via PATCH /api/modelInventory/:id, separate from PUT /api/mrm/models/:id/tier",
+      repro: "Attempt to set external_key in the tier PUT body; it is ignored.",
+    });
+
+    await client.assignTier(modelId, model.tier, model.materialityDrivers);
+    for (const key of model.metricKeys) await client.createMetricKey(key);
+    for (const spec of model.thresholds) await client.createThreshold(modelId, spec);
+
+    cache.models[model.externalKey] = modelId;
+    writeCache(cache);
+  }
+
+  if (!cache.token) {
+    cache.token = await client.createIngestionToken("mrm-simulator");
+    writeCache(cache);
+  }
+
+  return { token: cache.token, models: cache.models, findings };
+};

--- a/tools/mrm-simulator/src/types.ts
+++ b/tools/mrm-simulator/src/types.ts
@@ -1,0 +1,65 @@
+// A single metric reading in the ingestion wire format.
+export interface MetricPoint {
+  metric: string;
+  value: number;
+  at: string; // ISO-8601
+  window?: string;
+  segment?: string;
+  context?: Record<string, unknown>;
+}
+
+// Threshold to create for a model during setup.
+export interface ThresholdSpec {
+  metric: string;
+  op: "gt" | "gte" | "lt" | "lte" | "outside";
+  value_num?: number | null;
+  value_lo?: number | null;
+  value_hi?: number | null;
+  severity: "warn" | "high" | "critical";
+  breach_action: "notify" | "notify_flag_revalidation";
+  segment?: string | null;
+  window?: string | null;
+}
+
+// A model in the scenario fleet.
+export interface FleetModel {
+  externalKey: string;
+  name: string;
+  provider: string;
+  tier: "1" | "2" | "3";
+  materialityDrivers: string;
+  metricKeys: string[]; // keys to register (e.g. psi, auc, gini, ks)
+  thresholds: ThresholdSpec[];
+}
+
+// Per-point result the ingestion API returns.
+export interface IngestResultPoint {
+  metric: string;
+  at: string;
+  status: "ok" | "warn" | "breach" | "no_threshold" | "duplicate";
+  pointId: number | null;
+  threshold?: {
+    op: string;
+    value_num: number | null;
+    value_lo: number | null;
+    value_hi: number | null;
+    severity: string;
+  };
+}
+
+// A gap-finding.
+export interface Finding {
+  category: "contract" | "workflow" | "ux";
+  severity: "high" | "medium" | "low";
+  title: string;
+  expected: string;
+  actual: string;
+  repro: string;
+}
+
+export interface SimConfig {
+  baseUrl: string;
+  email: string;
+  password: string;
+  allowRemote: boolean;
+}

--- a/tools/mrm-simulator/src/verify.ts
+++ b/tools/mrm-simulator/src/verify.ts
@@ -42,18 +42,24 @@ export const runVerify = async (
   const client = new JwtClient(cfg);
   await client.login();
 
-  // credit-scoring-v3 psi breach is notify_flag_revalidation -> expect an event.
-  const creditId = models["credit-scoring-v3"];
-  if (creditId) {
-    const events = await client.getRevalidationEvents(creditId);
+  // Every model with a notify_flag_revalidation threshold should have opened a
+  // revalidation event once its metric breached during backfill. Derive that set
+  // from the fleet so this stays correct if the fleet changes.
+  const flaggingModels = FLEET.filter((m) =>
+    m.thresholds.some((t) => t.breach_action === "notify_flag_revalidation"),
+  );
+  for (const model of flaggingModels) {
+    const modelId = models[model.externalKey];
+    if (modelId === undefined) continue; // not set up (e.g. not in cache) — skip
+    const events = await client.getRevalidationEvents(modelId);
     if (events.length === 0) {
       findings.push({
         category: "workflow",
         severity: "high",
-        title: "PSI breach did not create a revalidation event",
-        expected: "A revalidation event (source=breach) after credit-scoring-v3 PSI crossed 0.20",
+        title: `Breach did not create a revalidation event for ${model.externalKey}`,
+        expected: `A revalidation event after ${model.externalKey} breached its flagged threshold`,
         actual: "GET /revalidation-events returned an empty list",
-        repro: "Backfill 30d, then GET /api/mrm/models/<credit-scoring-v3 id>/revalidation-events",
+        repro: `Backfill 30d, then GET /api/mrm/models/<${model.externalKey} id>/revalidation-events`,
       });
     }
   }

--- a/tools/mrm-simulator/src/verify.ts
+++ b/tools/mrm-simulator/src/verify.ts
@@ -1,0 +1,86 @@
+import { SimConfig, Finding, IngestResultPoint } from "./types.js";
+import { JwtClient } from "./jwtClient.js";
+import { FLEET } from "../scenarios/fleet.js";
+
+// Which (externalKey, metric) pairs we engineered to breach during backfill.
+const EXPECTED_BREACHES: { externalKey: string; metric: string }[] = [
+  { externalKey: "credit-scoring-v3", metric: "psi" },
+  { externalKey: "loan-approval-v1", metric: "gini" },
+  { externalKey: "churn-propensity-v1", metric: "psi" },
+];
+
+// Contract check: engineered breaches must appear as warn/breach in results.
+export const runContractChecks = (
+  resultsByKey: Record<string, IngestResultPoint[]>,
+): Finding[] => {
+  const findings: Finding[] = [];
+  for (const exp of EXPECTED_BREACHES) {
+    const results = resultsByKey[exp.externalKey] ?? [];
+    const hit = results.some(
+      (r) => r.metric === exp.metric && (r.status === "breach" || r.status === "warn"),
+    );
+    if (!hit) {
+      findings.push({
+        category: "contract",
+        severity: "high",
+        title: `Engineered breach never fired for ${exp.externalKey}/${exp.metric}`,
+        expected: `At least one warn/breach status for ${exp.metric}`,
+        actual: "All points returned ok/no_threshold — threshold match or setup gap",
+        repro: `Backfill ${exp.externalKey} and inspect per-point statuses for ${exp.metric}`,
+      });
+    }
+  }
+  return findings;
+};
+
+// Workflow check: a flagged breach should have opened a revalidation event/task.
+export const runVerify = async (
+  cfg: SimConfig,
+  models: Record<string, number>,
+): Promise<Finding[]> => {
+  const findings: Finding[] = [];
+  const client = new JwtClient(cfg);
+  await client.login();
+
+  // credit-scoring-v3 psi breach is notify_flag_revalidation -> expect an event.
+  const creditId = models["credit-scoring-v3"];
+  if (creditId) {
+    const events = await client.getRevalidationEvents(creditId);
+    if (events.length === 0) {
+      findings.push({
+        category: "workflow",
+        severity: "high",
+        title: "PSI breach did not create a revalidation event",
+        expected: "A revalidation event (source=breach) after credit-scoring-v3 PSI crossed 0.20",
+        actual: "GET /revalidation-events returned an empty list",
+        repro: "Backfill 30d, then GET /api/mrm/models/<credit-scoring-v3 id>/revalidation-events",
+      });
+    }
+  }
+
+  // Attestation should reflect the fleet (>=4 models, some breaches).
+  const summary = await client.getAttestationSummary();
+  if (summary.models_total < FLEET.length) {
+    findings.push({
+      category: "workflow",
+      severity: "medium",
+      title: "Attestation summary undercounts the fleet",
+      expected: `models_total >= ${FLEET.length}`,
+      actual: `models_total = ${summary.models_total}`,
+      repro: "GET /api/mrm/attestation/summary after setup + backfill",
+    });
+  }
+
+  // UX checklist finding (always emitted — a guided manual pass).
+  findings.push({
+    category: "ux",
+    severity: "low",
+    title: "Manual UI review checklist",
+    expected: "Monitoring trends, breach chips, revalidation 'Triggered by', and attestation status look correct",
+    actual: "Not auto-verifiable — open the URLs and confirm visually",
+    repro:
+      "Open /model-inventory/model-risk-management (Monitoring, Validation drawer, Overview) and eyeball each model",
+  });
+
+  return findings;
+};

--- a/tools/mrm-simulator/tsconfig.json
+++ b/tools/mrm-simulator/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ES2022",
+    "moduleResolution": "bundler",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "types": ["node"],
+    "noEmit": true
+  },
+  "include": ["src", "scenarios"]
+}

--- a/tools/mrm-simulator/vitest.config.ts
+++ b/tools/mrm-simulator/vitest.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    include: ["**/*.test.ts"],
+    environment: "node",
+  },
+});


### PR DESCRIPTION
## Overview

Adds a standalone developer tool, `tools/mrm-simulator/`, that impersonates a model-monitoring platform and feeds scenario-driven metrics into the MRM ingestion API, then reports gaps it finds in the MRM feature.

It serves as a demo populator, a dev/test harness, and a reference integration, and it doubles as a gap-finder that drives realistic data end to end and surfaces workflow and contract issues.

## What it does

- `setup` — idempotently creates a four-model fleet (with external keys, tiers, metric keys, thresholds) and an ingestion token, via the JWT API.
- `backfill --days N` — pushes N days of scenario metrics so trends, breach history, and the attestation roll-up populate instantly.
- `live --interval Ns` — keeps ticking so a breach can be watched happening.
- `verify` / `report` — reads MRM back, checks the governance loop closed, and writes a categorised `gaps-report.md`.

## Scenario fleet

Four models with scripted, deterministic storylines: a model that drifts and breaches PSI (firing revalidation), a healthy control, a segment-level fairness breach, and a breach-then-recovery. The metric math is unit-tested so expected breaches cross at known days.

## Notes

- Dev-only tool; it refuses non-localhost targets unless explicitly overridden, and the token cache and report are git-ignored.
- 18 unit tests cover the storylines, engine, config/safety-guard, envelope parser, and report renderer.
- Includes the design spec and implementation plan under `docs/superpowers/`, plus a scoped follow-up for making `external_key` settable in the UI and at create time.
- Depends on the `external_key` update fix (separate PR) to run end to end; that fix lands independently on develop first.