### PR TITLE
fix(mrm): batch metric ingestion 500s when a batch contains a duplicate point

### DIFF
--- a/Servers/utils/mrmMonitoring.utils.ts
+++ b/Servers/utils/mrmMonitoring.utils.ts
@@ -421,6 +421,14 @@ export const ingestPointQuery = async (
   transaction: Transaction,
 ): Promise<IngestPointResult> => {
   let metricId: number;
+  // Wrap the metrics INSERT in a SAVEPOINT. A duplicate hits the idempotency
+  // UNIQUE and raises 23505, which aborts the enclosing transaction in Postgres —
+  // catching it in JS is not enough. Without the savepoint, a single duplicate in
+  // a batch poisons the transaction and every later point fails with "current
+  // transaction is aborted". Rolling back to the savepoint isolates the failed
+  // insert so the rest of the batch still commits.
+  const savepoint = `sp_ingest_${Date.now()}_${Math.floor(Math.random() * 1e6)}`;
+  await sequelize.query(`SAVEPOINT ${savepoint}`, { transaction });
   try {
     // SELECT type parses the RETURNING rows as a flat array (an INSERT ...
     // RETURNING behaves like a SELECT for result mapping); QueryTypes.INSERT
@@ -456,9 +464,12 @@ export const ingestPointQuery = async (
       },
     )) as { id: number }[];
     metricId = rows[0].id;
+    await sequelize.query(`RELEASE SAVEPOINT ${savepoint}`, { transaction });
   } catch (error) {
     if ((error as any)?.original?.code === PG_UNIQUE_VIOLATION) {
-      // Idempotent duplicate — a no-op success, not an error (O1).
+      // Idempotent duplicate — roll back just this insert and report a no-op
+      // success, leaving the enclosing transaction usable for the rest of the batch.
+      await sequelize.query(`ROLLBACK TO SAVEPOINT ${savepoint}`, { transaction });
       return { duplicate: true, metricId: null, evaluation: null };
     }
     throw error;


### PR DESCRIPTION
## Overview

Batch metric ingestion (`POST /api/mrm/models/:externalModelKey/metrics` with a `points` array) returned `500 Internal Server Error` ("current transaction is aborted, commands ignored until end of transaction block") whenever any point in the batch was an idempotent duplicate. Because points dedup on `(metric, segment, window, at)`, this happens on effectively every re-ingestion of an overlapping window — so batch ingestion was broken for any pipeline that retries or re-sends.

## Root cause

`ingestPointQuery` inserts into `mrm_metrics` and catches the idempotency UNIQUE violation (SQLSTATE 23505) in JavaScript to report a no-op duplicate. But in PostgreSQL a failed statement aborts the entire transaction; catching it in JS does not undo that. A single point works (no later statement), but in a batch the duplicate poisons the transaction and every subsequent point in the same request fails.

## Fix

Wrap the `mrm_metrics` INSERT in a `SAVEPOINT`: `RELEASE` it on success, `ROLLBACK TO` it on the 23505 duplicate. The failed insert is isolated, so the enclosing batch transaction stays usable and the remaining points still commit. Non-duplicate errors still propagate to the controller's outer rollback.

## Verified

- A duplicate 3-point batch that returned 500 now returns 200 with each point reported `duplicate`.
- A mixed batch (one duplicate, one new) returns 200 `accepted:1`: the duplicate is skipped, the new point commits with a real pointId.

## Notes

- Server build and format-check pass. The savepoint name is generated from numeric, developer-controlled values (strictly `[a-z0-9_]`); the batch loop is sequential so no two savepoints are live at once.
- Found by the MRM metric simulator during a dashboard run.