### PR TITLE
Feat: Async Boundary

### DIFF
--- a/Clients/src/application/repository/modelEvaluations.repository.ts
+++ b/Clients/src/application/repository/modelEvaluations.repository.ts
@@ -25,5 +25,5 @@ export interface ModelEvaluationsResponse {
 
 export async function getAllModelEvaluations(): Promise<ModelEvaluationsResponse> {
   const response = await apiServices.get("/modelInventory/evaluations");
-  return response.data as ModelEvaluationsResponse;
+  return (response.data as { data: ModelEvaluationsResponse }).data;
 }

--- a/Clients/src/application/repository/tests/modelEvaluations.repository.test.ts
+++ b/Clients/src/application/repository/tests/modelEvaluations.repository.test.ts
@@ -37,7 +37,11 @@ describe("Test Model Evaluations Repository", () => {
     };
 
     it("should make a GET request to /modelInventory/evaluations", async () => {
-      const mockResponse = { data: mockData, status: 200, statusText: "OK" };
+      const mockResponse = {
+        data: { message: "OK", data: mockData },
+        status: 200,
+        statusText: "OK",
+      };
       vi.mocked(apiServices.get).mockResolvedValue(mockResponse);
 
       await getAllModelEvaluations();
@@ -47,7 +51,11 @@ describe("Test Model Evaluations Repository", () => {
     });
 
     it("should return the response data on successful fetch", async () => {
-      const mockResponse = { data: mockData, status: 200, statusText: "OK" };
+      const mockResponse = {
+        data: { message: "OK", data: mockData },
+        status: 200,
+        statusText: "OK",
+      };
       vi.mocked(apiServices.get).mockResolvedValue(mockResponse);
 
       const result = await getAllModelEvaluations();
@@ -59,7 +67,11 @@ describe("Test Model Evaluations Repository", () => {
 
     it("should return empty arrays when no evaluations exist", async () => {
       const emptyData = { experiments: [], biasAudits: [] };
-      const mockResponse = { data: emptyData, status: 200, statusText: "OK" };
+      const mockResponse = {
+        data: { message: "OK", data: emptyData },
+        status: 200,
+        statusText: "OK",
+      };
       vi.mocked(apiServices.get).mockResolvedValue(mockResponse);
 
       const result = await getAllModelEvaluations();

--- a/Clients/src/domain/interfaces/i.modelInventory.ts
+++ b/Clients/src/domain/interfaces/i.modelInventory.ts
@@ -68,6 +68,8 @@ export interface MLFlowModel {
 export interface ModelInventoryTableProps {
   data: IModelInventory[];
   isLoading?: boolean;
+  error?: Error | string | unknown;
+  onRetry?: () => void;
   onEdit?: (id: string) => void;
   onDelete?: (id: string, deleteRisks?: boolean) => void;
   onCheckModelHasRisks?: (id: string) => Promise<boolean>;

--- a/Clients/src/i18n/translations.ts
+++ b/Clients/src/i18n/translations.ts
@@ -25,6 +25,11 @@ export type Lang = "en" | "de" | "fr" | "es";
 
 export const translations: Record<string, Record<string, string>> = {
   de: {
+    // AsyncBoundary
+    "Loading": "Wird geladen...",
+    "Retry loading data": "Daten erneut laden",
+    "Something went wrong. Please try again.":
+      "Etwas ist schiefgelaufen. Bitte versuchen Sie es erneut.",
     // Rich text renderer
     "Rich text content": "Rich-Text-Inhalt",
     // Settings — help text
@@ -8881,6 +8886,10 @@ export const translations: Record<string, Record<string, string>> = {
   },
 
   fr: {
+    // AsyncBoundary
+    "Loading": "Chargement...",
+    "Retry loading data": "Réessayer le chargement des données",
+    "Something went wrong. Please try again.": "Une erreur s'est produite. Veuillez réessayer.",
     // Rich text renderer
     "Rich text content": "Contenu de texte enrichi",
     // Settings — help text
@@ -17692,6 +17701,10 @@ export const translations: Record<string, Record<string, string>> = {
     "Select a log to view details.": "Sélectionnez un journal pour voir les détails.",
   },
   es: {
+    // AsyncBoundary
+    "Loading": "Cargando...",
+    "Retry loading data": "Reintentar cargar datos",
+    "Something went wrong. Please try again.": "Algo salió mal. Por favor, inténtelo de nuevo.",
     // Rich text renderer
     "Rich text content": "Contenido de texto enriquecido",
     // Settings — help text

--- a/Clients/src/infrastructure/api/__tests__/evalModelsService.test.ts
+++ b/Clients/src/infrastructure/api/__tests__/evalModelsService.test.ts
@@ -18,10 +18,9 @@ describe("evalModelsService", () => {
       expect(result).toEqual([{ id: "m1", name: "GPT-4", provider: "openai" }]);
     });
 
-    it("returns empty array on error", async () => {
+    it("throws on error", async () => {
       server.use(http.get("/api/deepeval/models", () => HttpResponse.error()));
-      const result = await evalModelsService.listModels();
-      expect(result).toEqual([]);
+      await expect(evalModelsService.listModels()).rejects.toThrow();
     });
   });
 
@@ -39,10 +38,9 @@ describe("evalModelsService", () => {
       expect(result?.name).toBe("Claude");
     });
 
-    it("returns null on error", async () => {
+    it("throws on error", async () => {
       server.use(http.post("/api/deepeval/models", () => HttpResponse.error()));
-      const result = await evalModelsService.createModel({ name: "X", provider: "y" });
-      expect(result).toBeNull();
+      await expect(evalModelsService.createModel({ name: "X", provider: "y" })).rejects.toThrow();
     });
   });
 
@@ -60,26 +58,23 @@ describe("evalModelsService", () => {
       expect(result?.name).toBe("Updated");
     });
 
-    it("returns null on error", async () => {
+    it("throws on error", async () => {
       server.use(http.put("/api/deepeval/models/:id", () => HttpResponse.error()));
-      const result = await evalModelsService.updateModel("m1", { name: "X" });
-      expect(result).toBeNull();
+      await expect(evalModelsService.updateModel("m1", { name: "X" })).rejects.toThrow();
     });
   });
 
   describe("deleteModel", () => {
-    it("returns true on success", async () => {
+    it("resolves on success", async () => {
       server.use(
         http.delete("/api/deepeval/models/:id", () => HttpResponse.json({ message: "deleted" })),
       );
-      const result = await evalModelsService.deleteModel("m1");
-      expect(result).toBe(true);
+      await expect(evalModelsService.deleteModel("m1")).resolves.toBeUndefined();
     });
 
-    it("returns false on error", async () => {
+    it("throws on error", async () => {
       server.use(http.delete("/api/deepeval/models/:id", () => HttpResponse.error()));
-      const result = await evalModelsService.deleteModel("m1");
-      expect(result).toBe(false);
+      await expect(evalModelsService.deleteModel("m1")).rejects.toThrow();
     });
   });
 });

--- a/Clients/src/infrastructure/api/evalModelsService.ts
+++ b/Clients/src/infrastructure/api/evalModelsService.ts
@@ -99,85 +99,60 @@ class EvalModelsService {
    * Get all saved models for the organization
    */
   async listModels(orgId?: string): Promise<SavedModel[]> {
-    try {
-      const params = orgId ? { org_id: orgId } : {};
-      const response = await CustomAxios.get<ListModelsResponse>(this.baseUrl, { params });
-      return response.data.models || [];
-    } catch (error) {
-      console.error("Failed to fetch models:", error);
-      return [];
-    }
+    const params = orgId ? { org_id: orgId } : {};
+    const response = await CustomAxios.get<ListModelsResponse>(this.baseUrl, { params });
+    return response.data.models || [];
   }
 
   /**
    * Create a new saved model configuration
    */
-  async createModel(request: CreateModelRequest): Promise<SavedModel | null> {
-    try {
-      const response = await CustomAxios.post<CreateModelResponse>(this.baseUrl, request);
-      return response.data.model;
-    } catch (error) {
-      console.error("Failed to create model:", error);
-      return null;
-    }
+  async createModel(request: CreateModelRequest): Promise<SavedModel> {
+    const response = await CustomAxios.post<CreateModelResponse>(this.baseUrl, request);
+    return response.data.model;
   }
 
   /**
    * Update an existing saved model
    */
-  async updateModel(modelId: string, request: UpdateModelRequest): Promise<SavedModel | null> {
-    try {
-      const response = await CustomAxios.put<UpdateModelResponse>(
-        `${this.baseUrl}/${modelId}`,
-        request,
-      );
-      return response.data.model;
-    } catch (error) {
-      console.error("Failed to update model:", error);
-      return null;
-    }
+  async updateModel(modelId: string, request: UpdateModelRequest): Promise<SavedModel> {
+    const response = await CustomAxios.put<UpdateModelResponse>(
+      `${this.baseUrl}/${modelId}`,
+      request,
+    );
+    return response.data.model;
   }
 
   /**
    * Delete a saved model
    */
-  async deleteModel(modelId: string): Promise<boolean> {
-    try {
-      await CustomAxios.delete<DeleteModelResponse>(`${this.baseUrl}/${modelId}`);
-      return true;
-    } catch (error) {
-      console.error("Failed to delete model:", error);
-      return false;
-    }
+  async deleteModel(modelId: string): Promise<void> {
+    await CustomAxios.delete<DeleteModelResponse>(`${this.baseUrl}/${modelId}`);
   }
 
   /**
    * Fetch the live LiteLLM model catalog from AI Gateway and return chat-mode
    * models for the given frontend provider ID (e.g. "openai", "google").
-   * Results are cached for 5 minutes. Falls back to [] if AI Gateway is down.
+   * Results are cached for 5 minutes. Throws on failure so callers can handle errors.
    */
   async getGatewayModelsForProvider(evalProvider: string): Promise<ModelInfo[]> {
     const litellmProvider = EVAL_TO_LITELLM[evalProvider];
     if (!litellmProvider) return [];
 
-    try {
-      if (!_gatewayModelsCache || Date.now() > _gatewayModelsCacheExpiry) {
-        const response = await CustomAxios.get<GatewayModelsResponse>("/ai-gateway/v1/models");
-        _gatewayModelsCache = response.data;
-        _gatewayModelsCacheExpiry = Date.now() + GATEWAY_MODELS_TTL_MS;
-      }
-
-      const providerModels = _gatewayModelsCache?.models?.[litellmProvider] ?? [];
-      return providerModels
-        .filter((m) => m.mode === "chat")
-        .map((m) => ({
-          id: normalizeModelId(m.id, litellmProvider),
-          name: normalizeModelId(m.id, litellmProvider),
-        }))
-        .sort((a, b) => a.name.localeCompare(b.name));
-    } catch {
-      return [];
+    if (!_gatewayModelsCache || Date.now() > _gatewayModelsCacheExpiry) {
+      const response = await CustomAxios.get<GatewayModelsResponse>("/ai-gateway/v1/models");
+      _gatewayModelsCache = response.data;
+      _gatewayModelsCacheExpiry = Date.now() + GATEWAY_MODELS_TTL_MS;
     }
+
+    const providerModels = _gatewayModelsCache?.models?.[litellmProvider] ?? [];
+    return providerModels
+      .filter((m) => m.mode === "chat")
+      .map((m) => ({
+        id: normalizeModelId(m.id, litellmProvider),
+        name: normalizeModelId(m.id, litellmProvider),
+      }))
+      .sort((a, b) => a.name.localeCompare(b.name));
   }
 }
 

--- a/Clients/src/presentation/components/AsyncBoundary/__tests__/AsyncBoundary.test.tsx
+++ b/Clients/src/presentation/components/AsyncBoundary/__tests__/AsyncBoundary.test.tsx
@@ -28,7 +28,10 @@ describe("AsyncBoundary", () => {
 
   it("renders custom loading fallback when provided", () => {
     renderWithProviders(
-      <AsyncBoundary isLoading={true} loadingFallback={<div data-testid="custom-loading">Custom loading</div>}>
+      <AsyncBoundary
+        isLoading={true}
+        loadingFallback={<div data-testid="custom-loading">Custom loading</div>}
+      >
         <div>Loaded content</div>
       </AsyncBoundary>,
     );

--- a/Clients/src/presentation/components/AsyncBoundary/__tests__/AsyncBoundary.test.tsx
+++ b/Clients/src/presentation/components/AsyncBoundary/__tests__/AsyncBoundary.test.tsx
@@ -1,0 +1,140 @@
+import { screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { renderWithProviders } from "../../../../test/renderWithProviders";
+import { AsyncBoundary } from "../index";
+import { Database } from "lucide-react";
+
+describe("AsyncBoundary", () => {
+  it("renders children when not loading, empty, or errored", () => {
+    renderWithProviders(
+      <AsyncBoundary isLoading={false}>
+        <div data-testid="content">Loaded content</div>
+      </AsyncBoundary>,
+    );
+
+    expect(screen.getByTestId("content")).toBeInTheDocument();
+  });
+
+  it("renders the loading skeleton when isLoading is true", () => {
+    renderWithProviders(
+      <AsyncBoundary isLoading={true}>
+        <div>Loaded content</div>
+      </AsyncBoundary>,
+    );
+
+    expect(screen.getByRole("status", { name: "Loading" })).toBeInTheDocument();
+    expect(screen.queryByText("Loaded content")).not.toBeInTheDocument();
+  });
+
+  it("renders custom loading fallback when provided", () => {
+    renderWithProviders(
+      <AsyncBoundary isLoading={true} loadingFallback={<div data-testid="custom-loading">Custom loading</div>}>
+        <div>Loaded content</div>
+      </AsyncBoundary>,
+    );
+
+    expect(screen.getByTestId("custom-loading")).toBeInTheDocument();
+  });
+
+  it("renders the empty state when isEmpty is true", () => {
+    renderWithProviders(
+      <AsyncBoundary isLoading={false} isEmpty={true} emptyMessage="No models found.">
+        <div>Loaded content</div>
+      </AsyncBoundary>,
+    );
+
+    expect(screen.getByText("No models found.")).toBeInTheDocument();
+    expect(screen.queryByText("Loaded content")).not.toBeInTheDocument();
+  });
+
+  it("renders custom empty icon and children", () => {
+    renderWithProviders(
+      <AsyncBoundary
+        isLoading={false}
+        isEmpty={true}
+        emptyIcon={Database}
+        emptyMessage="No datasets found."
+        emptyChildren={<div data-testid="empty-tip">Add a dataset</div>}
+      >
+        <div>Loaded content</div>
+      </AsyncBoundary>,
+    );
+
+    expect(screen.getByText("No datasets found.")).toBeInTheDocument();
+    expect(screen.getByTestId("empty-tip")).toBeInTheDocument();
+  });
+
+  it("renders the error state from an Error object", () => {
+    renderWithProviders(
+      <AsyncBoundary isLoading={false} error={new Error("Network request failed")}>
+        <div>Loaded content</div>
+      </AsyncBoundary>,
+    );
+
+    expect(screen.getByRole("alert")).toBeInTheDocument();
+    expect(screen.getByText("Network request failed")).toBeInTheDocument();
+  });
+
+  it("renders the error state from a string", () => {
+    renderWithProviders(
+      <AsyncBoundary isLoading={false} error="Something went wrong.">
+        <div>Loaded content</div>
+      </AsyncBoundary>,
+    );
+
+    expect(screen.getByText("Something went wrong.")).toBeInTheDocument();
+  });
+
+  it("renders custom error fallback when provided", () => {
+    renderWithProviders(
+      <AsyncBoundary
+        isLoading={false}
+        error={new Error("Failed")}
+        errorFallback={<div data-testid="custom-error">Custom error UI</div>}
+      >
+        <div>Loaded content</div>
+      </AsyncBoundary>,
+    );
+
+    expect(screen.getByTestId("custom-error")).toBeInTheDocument();
+    expect(screen.queryByText("Failed")).not.toBeInTheDocument();
+  });
+
+  it("calls onRetry when the retry button is clicked", async () => {
+    const user = userEvent.setup();
+    const onRetry = vi.fn();
+
+    renderWithProviders(
+      <AsyncBoundary isLoading={false} error={new Error("Failed")} onRetry={onRetry}>
+        <div>Loaded content</div>
+      </AsyncBoundary>,
+    );
+
+    const retryButton = screen.getByRole("button", { name: "Retry loading data" });
+    await user.click(retryButton);
+
+    expect(onRetry).toHaveBeenCalledTimes(1);
+  });
+
+  it("gives error state precedence over loading", () => {
+    renderWithProviders(
+      <AsyncBoundary isLoading={true} error={new Error("Failed")}>
+        <div>Loaded content</div>
+      </AsyncBoundary>,
+    );
+
+    expect(screen.getByRole("alert")).toBeInTheDocument();
+    expect(screen.getByText("Failed")).toBeInTheDocument();
+  });
+
+  it("gives loading state precedence over empty", () => {
+    renderWithProviders(
+      <AsyncBoundary isLoading={true} isEmpty={true}>
+        <div>Loaded content</div>
+      </AsyncBoundary>,
+    );
+
+    expect(screen.getByRole("status", { name: "Loading" })).toBeInTheDocument();
+    expect(screen.queryByText("There is currently no data in this table.")).not.toBeInTheDocument();
+  });
+});

--- a/Clients/src/presentation/components/AsyncBoundary/__tests__/AsyncBoundary.test.tsx
+++ b/Clients/src/presentation/components/AsyncBoundary/__tests__/AsyncBoundary.test.tsx
@@ -100,6 +100,21 @@ describe("AsyncBoundary", () => {
     expect(screen.queryByText("Failed")).not.toBeInTheDocument();
   });
 
+  it("renders custom empty fallback when provided", () => {
+    renderWithProviders(
+      <AsyncBoundary
+        isLoading={false}
+        isEmpty={true}
+        emptyFallback={<div data-testid="custom-empty">Custom empty UI</div>}
+      >
+        <div>Loaded content</div>
+      </AsyncBoundary>,
+    );
+
+    expect(screen.getByTestId("custom-empty")).toBeInTheDocument();
+    expect(screen.queryByText("Loaded content")).not.toBeInTheDocument();
+  });
+
   it("calls onRetry when the retry button is clicked", async () => {
     const user = userEvent.setup();
     const onRetry = vi.fn();

--- a/Clients/src/presentation/components/AsyncBoundary/index.tsx
+++ b/Clients/src/presentation/components/AsyncBoundary/index.tsx
@@ -20,6 +20,8 @@ export interface AsyncBoundaryProps {
   loadingFallback?: ReactNode;
   /** Custom error UI. Defaults to the standard error card. */
   errorFallback?: ReactNode;
+  /** Custom empty UI. Defaults to EmptyState. */
+  emptyFallback?: ReactNode;
   /** Icon for the empty state. Defaults to Inbox. */
   emptyIcon?: LucideIcon;
   /** Message for the empty state. */
@@ -44,6 +46,7 @@ export const AsyncBoundary: FC<AsyncBoundaryProps> = ({
   onRetry,
   loadingFallback,
   errorFallback,
+  emptyFallback,
   emptyIcon = Inbox,
   emptyMessage,
   emptyChildren,
@@ -121,6 +124,10 @@ export const AsyncBoundary: FC<AsyncBoundaryProps> = ({
   }
 
   if (isEmpty) {
+    if (emptyFallback) {
+      return <>{emptyFallback}</>;
+    }
+
     return (
       <EmptyState icon={emptyIcon} message={emptyMessage}>
         {emptyChildren}

--- a/Clients/src/presentation/components/AsyncBoundary/index.tsx
+++ b/Clients/src/presentation/components/AsyncBoundary/index.tsx
@@ -76,9 +76,7 @@ export const AsyncBoundary: FC<AsyncBoundaryProps> = ({
           px: 3,
           border: `1px dashed ${theme.palette.error.main}`,
           borderRadius: "4px",
-          backgroundColor: theme.palette.error.light
-            ? `${theme.palette.error.light}14`
-            : undefined,
+          backgroundColor: theme.palette.error.light ? `${theme.palette.error.light}14` : undefined,
         }}
         role="alert"
         aria-live="assertive"

--- a/Clients/src/presentation/components/AsyncBoundary/index.tsx
+++ b/Clients/src/presentation/components/AsyncBoundary/index.tsx
@@ -1,0 +1,134 @@
+import type { FC, ReactNode } from "react";
+import { Box, Button, Stack, Typography, useTheme } from "@mui/material";
+import type { LucideIcon } from "lucide-react";
+import { AlertCircle, Inbox } from "lucide-react";
+import { EmptyState } from "../EmptyState";
+import CustomizableSkeleton from "../Skeletons";
+
+export interface AsyncBoundaryProps {
+  /** When true, a loading fallback is rendered. */
+  isLoading: boolean;
+  /** Error object or message. Takes precedence over loading/empty states. */
+  error?: Error | string | unknown | null;
+  /** When true (and not loading or errored), the empty state is rendered. */
+  isEmpty?: boolean;
+  /** Content rendered when data is available. */
+  children: ReactNode;
+  /** Called when the user presses the Retry button in the error state. */
+  onRetry?: () => void;
+  /** Custom loading UI. Defaults to a full-width rectangular skeleton. */
+  loadingFallback?: ReactNode;
+  /** Custom error UI. Defaults to the standard error card. */
+  errorFallback?: ReactNode;
+  /** Icon for the empty state. Defaults to Inbox. */
+  emptyIcon?: LucideIcon;
+  /** Message for the empty state. */
+  emptyMessage?: string;
+  /** Additional content below the empty-state message (e.g. EmptyStateTip). */
+  emptyChildren?: ReactNode;
+}
+
+/**
+ * Reusable async-state boundary.
+ *
+ * Combines loading, error, and empty-state handling in one component while
+ * reusing the StyleGuide-approved EmptyState and skeleton patterns.
+ *
+ * State precedence: error > loading > empty > children.
+ */
+export const AsyncBoundary: FC<AsyncBoundaryProps> = ({
+  isLoading,
+  error,
+  isEmpty,
+  children,
+  onRetry,
+  loadingFallback,
+  errorFallback,
+  emptyIcon = Inbox,
+  emptyMessage,
+  emptyChildren,
+}) => {
+  const theme = useTheme();
+
+  if (error) {
+    if (errorFallback) {
+      return <>{errorFallback}</>;
+    }
+
+    const message =
+      typeof error === "string"
+        ? error
+        : error instanceof Error
+          ? error.message
+          : "Something went wrong. Please try again.";
+
+    return (
+      <Stack
+        alignItems="center"
+        justifyContent="center"
+        spacing={2}
+        sx={{
+          width: "100%",
+          py: 6,
+          px: 3,
+          border: `1px dashed ${theme.palette.error.main}`,
+          borderRadius: "4px",
+          backgroundColor: theme.palette.error.light
+            ? `${theme.palette.error.light}14`
+            : undefined,
+        }}
+        role="alert"
+        aria-live="assertive"
+      >
+        <AlertCircle size={40} color={theme.palette.error.main} strokeWidth={1.5} />
+        <Typography
+          sx={{
+            fontSize: 13,
+            color: theme.palette.error.main,
+            fontWeight: 500,
+            textAlign: "center",
+            maxWidth: 400,
+            lineHeight: 1.5,
+          }}
+        >
+          {message}
+        </Typography>
+        {onRetry && (
+          <Button
+            variant="outlined"
+            size="small"
+            onClick={onRetry}
+            sx={{ mt: 1 }}
+            aria-label="Retry loading data"
+          >
+            Retry
+          </Button>
+        )}
+      </Stack>
+    );
+  }
+
+  if (isLoading) {
+    if (loadingFallback) {
+      return <>{loadingFallback}</>;
+    }
+
+    return (
+      <Box sx={{ width: "100%" }} role="status" aria-label="Loading">
+        <CustomizableSkeleton variant="rectangular" width="100%" height={200} />
+      </Box>
+    );
+  }
+
+  if (isEmpty) {
+    return (
+      <EmptyState icon={emptyIcon} message={emptyMessage}>
+        {emptyChildren}
+      </EmptyState>
+    );
+  }
+
+  return <>{children}</>;
+};
+
+export default AsyncBoundary;

--- a/Clients/src/presentation/pages/EvalsDashboard/ModelsPage.tsx
+++ b/Clients/src/presentation/pages/EvalsDashboard/ModelsPage.tsx
@@ -26,6 +26,7 @@ import {
   type LLMProvider,
 } from "../../../application/repository/deepEval.repository";
 import Alert from "../../components/Alert";
+import AsyncBoundary from "../../components/AsyncBoundary";
 import StandardModal from "../../components/Modals/StandardModal";
 import ModelsTable, { type ModelRow } from "../../components/Table/ModelsTable";
 import { PageHeader } from "../../components/Layout/PageHeader";
@@ -100,6 +101,7 @@ interface NewModelConfig {
 export default function ModelsPage({ orgId, openAddModal, onAddModalConsumed }: ModelsPageProps) {
   const [models, setModels] = useState<SavedModel[]>([]);
   const [loading, setLoading] = useState(false);
+  const [loadError, setLoadError] = useState<Error | string | unknown>(null);
   const [searchTerm, setSearchTerm] = useState("");
   const [alert, setAlert] = useState<AlertState | null>(null);
 
@@ -170,7 +172,8 @@ export default function ModelsPage({ orgId, openAddModal, onAddModalConsumed }: 
         if (!cancelled) {
           setGatewayModels(models.map((m) => ({ id: m.id, name: m.name })));
         }
-      } catch {
+      } catch (err) {
+        console.warn("Failed to fetch gateway models:", err);
         if (!cancelled) setGatewayModels([]);
       } finally {
         if (!cancelled) setLoadingGatewayModels(false);
@@ -195,14 +198,13 @@ export default function ModelsPage({ orgId, openAddModal, onAddModalConsumed }: 
   }, []);
 
   const loadModels = useCallback(async () => {
+    setLoading(true);
+    setLoadError(null);
     try {
-      setLoading(true);
       const allModels = await evalModelsService.listModels(orgId);
       setModels(allModels);
     } catch (err) {
-      console.error("Failed to load models", err);
-      setAlert({ variant: "error", body: "Failed to load models" });
-      setTimeout(() => setAlert(null), 4000);
+      setLoadError(err);
     } finally {
       setLoading(false);
     }
@@ -266,16 +268,12 @@ export default function ModelsPage({ orgId, openAddModal, onAddModalConsumed }: 
     if (!modelToDelete) return;
     setIsDeleting(true);
     try {
-      const success = await evalModelsService.deleteModel(modelToDelete.id);
-      if (success) {
-        setAlert({ variant: "success", body: "Model deleted successfully" });
-        setTimeout(() => setAlert(null), 3000);
-        setDeleteModalOpen(false);
-        setModelToDelete(null);
-        void loadModels();
-      } else {
-        throw new Error("Delete failed");
-      }
+      await evalModelsService.deleteModel(modelToDelete.id);
+      setAlert({ variant: "success", body: "Model deleted successfully" });
+      setTimeout(() => setAlert(null), 3000);
+      setDeleteModalOpen(false);
+      setModelToDelete(null);
+      void loadModels();
     } catch (err) {
       console.error("Failed to delete model", err);
       setAlert({ variant: "error", body: "Failed to delete model" });
@@ -330,21 +328,17 @@ export default function ModelsPage({ orgId, openAddModal, onAddModalConsumed }: 
       }
 
       // Create model using the new API
-      const created = await evalModelsService.createModel({
+      await evalModelsService.createModel({
         orgId: orgId,
         name: newModel.modelName,
         provider: newModel.accessMethod,
         endpointUrl: newModel.endpointUrl || undefined,
       });
 
-      if (created) {
-        setAlert({ variant: "success", body: "Model added successfully" });
-        setTimeout(() => setAlert(null), 3000);
-        setAddModalOpen(false);
-        void loadModels();
-      } else {
-        throw new Error("Save failed");
-      }
+      setAlert({ variant: "success", body: "Model added successfully" });
+      setTimeout(() => setAlert(null), 3000);
+      setAddModalOpen(false);
+      void loadModels();
     } catch (err) {
       console.error("Failed to add model", err);
       setAlert({ variant: "error", body: "Failed to add model" });
@@ -418,11 +412,25 @@ export default function ModelsPage({ orgId, openAddModal, onAddModalConsumed }: 
 
       {/* Models table */}
       <Box mb={4}>
-        <ModelsTable
-          rows={modelRows}
-          onDelete={canDeleteModel ? handleDelete : undefined}
-          loading={loading}
-        />
+        <AsyncBoundary
+          isLoading={loading}
+          error={loadError}
+          isEmpty={!modelRows.length}
+          onRetry={loadModels}
+          emptyFallback={
+            <ModelsTable
+              rows={[]}
+              onDelete={canDeleteModel ? handleDelete : undefined}
+              loading={false}
+            />
+          }
+        >
+          <ModelsTable
+            rows={modelRows}
+            onDelete={canDeleteModel ? handleDelete : undefined}
+            loading={false}
+          />
+        </AsyncBoundary>
       </Box>
 
       {/* Delete Confirmation Modal */}

--- a/Clients/src/presentation/pages/EvalsDashboard/ProjectOverview.tsx
+++ b/Clients/src/presentation/pages/EvalsDashboard/ProjectOverview.tsx
@@ -27,6 +27,7 @@ import type { DeepEvalProject } from "./types";
 import { useNavigate } from "react-router-dom";
 import { PageHeader } from "../../components/Layout/PageHeader";
 import HelperIcon from "../../components/HelperIcon";
+import AsyncBoundary from "../../components/AsyncBoundary";
 import TipBox from "../../components/TipBox";
 import { useAuth } from "../../../application/hooks/useAuth";
 import allowedRoles from "../../../application/constants/permissions";
@@ -157,6 +158,7 @@ export default function ProjectOverview({
 }: ProjectOverviewProps) {
   const navigate = useNavigate();
   const [loading, setLoading] = useState(true);
+  const [loadError, setLoadError] = useState<Error | string | unknown>(null);
   const [experiments, setExperiments] = useState<Experiment[]>([]);
   const [evaluationLogs, setEvaluationLogs] = useState<EvaluationLog[]>([]);
   const [dashboardData, setDashboardData] = useState<MonitorDashboard | null>(null);
@@ -168,9 +170,9 @@ export default function ProjectOverview({
     allowedRoles.evals.createExperiment.includes(userRoleName) && !isSuperAdmin;
 
   const loadOverviewData = useCallback(async () => {
+    setLoading(true);
+    setLoadError(null);
     try {
-      setLoading(true);
-
       // Load project if not provided
       if (!project) {
         const projectData = await getProject(projectId);
@@ -180,15 +182,15 @@ export default function ProjectOverview({
       // Load experiments, logs, and dashboard data in parallel
       const [experimentsData, logsData, dashboardResponse] = await Promise.all([
         getExperiments({ project_id: projectId, limit: 100 }),
-        getLogs({ project_id: projectId, limit: 1000 }).catch(() => ({ logs: [] })),
-        getMonitorDashboard(projectId).catch(() => ({ data: null })),
+        getLogs({ project_id: projectId, limit: 1000 }),
+        getMonitorDashboard(projectId),
       ]);
 
       setExperiments(experimentsData.experiments || []);
       setEvaluationLogs(logsData.logs || []);
       setDashboardData(dashboardResponse.data);
     } catch (err) {
-      console.error("Failed to load overview data:", err);
+      setLoadError(err);
     } finally {
       setLoading(false);
     }
@@ -225,14 +227,6 @@ export default function ProjectOverview({
     if (score === undefined || score === null || isNaN(score)) return "-";
     return score.toFixed(2);
   };
-
-  if (loading) {
-    return (
-      <Box display="flex" justifyContent="center" py={8}>
-        <CircularProgress />
-      </Box>
-    );
-  }
 
   const hasExperiments = experiments.length > 0;
 
@@ -395,151 +389,162 @@ export default function ProjectOverview({
   };
 
   return (
-    <Stack sx={{ width: "100%", overflow: "hidden" }}>
-      <PageHeader
-        title="Overview"
-        description="Monitor your project's evaluation performance, track key metrics, and view recent experiments at a glance."
-        rightContent={<HelperIcon articlePath="llm-evals/llm-evals-overview" />}
-      />
-      <Box sx={{ mt: "18px" }}>
-        <TipBox entityName="evals-overview" />
-      </Box>
-
-      {/* Header with New Experiment button */}
-      <Box display="flex" justifyContent="flex-end" alignItems="center" mb={3}>
-        <CustomizableButton
-          onClick={handleNewExperiment}
-          variant="contained"
-          text="New experiment"
-          icon={<Play size={16} />}
-          isDisabled={!canCreateExperiment}
-          sx={{
-            "backgroundColor": palette.brand.primary,
-            "border": `1px solid ${palette.brand.primary}`,
-            "gap": 2,
-            "&:hover": {
-              backgroundColor: palette.brand.primaryHover,
-            },
-          }}
+    <AsyncBoundary
+      isLoading={loading}
+      error={loadError}
+      onRetry={loadOverviewData}
+      loadingFallback={
+        <Box display="flex" justifyContent="center" py={8}>
+          <CircularProgress />
+        </Box>
+      }
+    >
+      <Stack sx={{ width: "100%", overflow: "hidden" }}>
+        <PageHeader
+          title="Overview"
+          description="Monitor your project's evaluation performance, track key metrics, and view recent experiments at a glance."
+          rightContent={<HelperIcon articlePath="llm-evals/llm-evals-overview" />}
         />
-      </Box>
-
-      {/* Stat cards: 3x2 grid */}
-      <Box
-        sx={{
-          display: "grid",
-          gridTemplateColumns: { xs: "repeat(2, 1fr)", sm: "repeat(3, 1fr)" },
-          gap: "16px",
-          mb: "24px",
-        }}
-      >
-        <StatCard
-          title="Experiments"
-          value={formatNumber(totalExperiments)}
-          Icon={Beaker}
-          subtitle={`${completedExperiments} completed`}
-        />
-        <StatCard
-          title="Success rate"
-          value={successRate}
-          Icon={CheckCircle}
-          subtitle={successRateSubtitle}
-        />
-        <StatCard
-          title="Avg latency"
-          value={avgLatency}
-          Icon={Clock}
-          subtitle={avgLatencySubtitle}
-        />
-        <StatCard title="Avg score" value={avgScore} Icon={Star} subtitle={avgScoreSubtitle} />
-        <StatCard
-          title="Total tokens"
-          value={totalTokens}
-          Icon={Coins}
-          subtitle={totalTokensSubtitle}
-        />
-        <StatCard
-          title="Running"
-          value={experiments.filter((e) => e.status === "running").length}
-          Icon={Activity}
-          subtitle="Experiments in progress"
-        />
-      </Box>
-
-      {/* Recent experiments table */}
-      <Box>
-        <Box display="flex" alignItems="center" justifyContent="space-between" sx={{ mb: 2 }}>
-          <Typography variant="subtitle1" sx={{ fontWeight: 600, fontSize: "14px" }}>
-            Recent experiments
-          </Typography>
+        <Box sx={{ mt: "18px" }}>
+          <TipBox entityName="evals-overview" />
         </Box>
 
-        {!hasExperiments ? (
-          <Box
+        {/* Header with New Experiment button */}
+        <Box display="flex" justifyContent="flex-end" alignItems="center" mb={3}>
+          <CustomizableButton
+            onClick={handleNewExperiment}
+            variant="contained"
+            text="New experiment"
+            icon={<Play size={16} />}
+            isDisabled={!canCreateExperiment}
             sx={{
-              border: `1px solid ${palette.border.dark}`,
-              borderRadius: "4px",
-              backgroundColor: palette.background.main,
-              textAlign: "center",
-              py: 4,
-              px: 2,
+              "backgroundColor": palette.brand.primary,
+              "border": `1px solid ${palette.brand.primary}`,
+              "gap": 2,
+              "&:hover": {
+                backgroundColor: palette.brand.primaryHover,
+              },
             }}
-          >
-            <Box sx={{ mb: 2 }}>
-              <Beaker size={32} color={palette.text.disabled} strokeWidth={1} />
-            </Box>
-            <Typography variant="subtitle2" sx={{ fontWeight: 600, mb: 1, fontSize: "13px" }}>
-              No experiments yet
+          />
+        </Box>
+
+        {/* Stat cards: 3x2 grid */}
+        <Box
+          sx={{
+            display: "grid",
+            gridTemplateColumns: { xs: "repeat(2, 1fr)", sm: "repeat(3, 1fr)" },
+            gap: "16px",
+            mb: "24px",
+          }}
+        >
+          <StatCard
+            title="Experiments"
+            value={formatNumber(totalExperiments)}
+            Icon={Beaker}
+            subtitle={`${completedExperiments} completed`}
+          />
+          <StatCard
+            title="Success rate"
+            value={successRate}
+            Icon={CheckCircle}
+            subtitle={successRateSubtitle}
+          />
+          <StatCard
+            title="Avg latency"
+            value={avgLatency}
+            Icon={Clock}
+            subtitle={avgLatencySubtitle}
+          />
+          <StatCard title="Avg score" value={avgScore} Icon={Star} subtitle={avgScoreSubtitle} />
+          <StatCard
+            title="Total tokens"
+            value={totalTokens}
+            Icon={Coins}
+            subtitle={totalTokensSubtitle}
+          />
+          <StatCard
+            title="Running"
+            value={experiments.filter((e) => e.status === "running").length}
+            Icon={Activity}
+            subtitle="Experiments in progress"
+          />
+        </Box>
+
+        {/* Recent experiments table */}
+        <Box>
+          <Box display="flex" alignItems="center" justifyContent="space-between" sx={{ mb: 2 }}>
+            <Typography variant="subtitle1" sx={{ fontWeight: 600, fontSize: "14px" }}>
+              Recent experiments
             </Typography>
-            <Typography
-              variant="body2"
-              color="text.secondary"
-              sx={{ mb: 2, fontSize: "12px", maxWidth: 320, mx: "auto", lineHeight: 1.5 }}
-            >
-              Run your first experiment to start evaluating your LLM.
-            </Typography>
-            <CustomizableButton
-              onClick={handleNewExperiment}
-              variant="contained"
-              text="Run first experiment"
-              icon={<Play size={14} />}
-              isDisabled={!canCreateExperiment}
-              sx={{
-                "backgroundColor": palette.brand.primary,
-                "border": `1px solid ${palette.brand.primary}`,
-                "gap": 1,
-                "fontSize": "12px",
-                "height": "32px",
-                "&:hover": {
-                  backgroundColor: palette.brand.primaryHover,
-                },
-              }}
-            />
           </Box>
-        ) : (
-          <ExperimentTable
-            rows={recentExperimentsRows}
-            onRowClick={handleViewExperiment}
-            hidePagination
-            compact
+
+          {!hasExperiments ? (
+            <Box
+              sx={{
+                border: `1px solid ${palette.border.dark}`,
+                borderRadius: "4px",
+                backgroundColor: palette.background.main,
+                textAlign: "center",
+                py: 4,
+                px: 2,
+              }}
+            >
+              <Box sx={{ mb: 2 }}>
+                <Beaker size={32} color={palette.text.disabled} strokeWidth={1} />
+              </Box>
+              <Typography variant="subtitle2" sx={{ fontWeight: 600, mb: 1, fontSize: "13px" }}>
+                No experiments yet
+              </Typography>
+              <Typography
+                variant="body2"
+                color="text.secondary"
+                sx={{ mb: 2, fontSize: "12px", maxWidth: 320, mx: "auto", lineHeight: 1.5 }}
+              >
+                Run your first experiment to start evaluating your LLM.
+              </Typography>
+              <CustomizableButton
+                onClick={handleNewExperiment}
+                variant="contained"
+                text="Run first experiment"
+                icon={<Play size={14} />}
+                isDisabled={!canCreateExperiment}
+                sx={{
+                  "backgroundColor": palette.brand.primary,
+                  "border": `1px solid ${palette.brand.primary}`,
+                  "gap": 1,
+                  "fontSize": "12px",
+                  "height": "32px",
+                  "&:hover": {
+                    backgroundColor: palette.brand.primaryHover,
+                  },
+                }}
+              />
+            </Box>
+          ) : (
+            <ExperimentTable
+              rows={recentExperimentsRows}
+              onRowClick={handleViewExperiment}
+              hidePagination
+              compact
+            />
+          )}
+        </Box>
+
+        {/* New Experiment Modal - only render when project useCase is available */}
+        {project?.useCase && (
+          <NewExperimentModal
+            isOpen={newExperimentModalOpen}
+            onClose={() => setNewExperimentModalOpen(false)}
+            projectId={projectId}
+            orgId={orgId}
+            existingExperimentNames={experiments
+              .map((e) => e.name)
+              .filter((n): n is string => Boolean(n))}
+            onSuccess={handleExperimentSuccess}
+            useCase={project.useCase as "chatbot" | "rag" | "agent"}
           />
         )}
-      </Box>
-
-      {/* New Experiment Modal - only render when project useCase is available */}
-      {project?.useCase && (
-        <NewExperimentModal
-          isOpen={newExperimentModalOpen}
-          onClose={() => setNewExperimentModalOpen(false)}
-          projectId={projectId}
-          orgId={orgId}
-          existingExperimentNames={experiments
-            .map((e) => e.name)
-            .filter((n): n is string => Boolean(n))}
-          onSuccess={handleExperimentSuccess}
-          useCase={project.useCase as "chatbot" | "rag" | "agent"}
-        />
-      )}
-    </Stack>
+      </Stack>
+    </AsyncBoundary>
   );
 }

--- a/Clients/src/presentation/pages/EvalsDashboard/__tests__/ProjectOverview.test.tsx
+++ b/Clients/src/presentation/pages/EvalsDashboard/__tests__/ProjectOverview.test.tsx
@@ -331,7 +331,7 @@ describe("ProjectOverview", () => {
     expect(mockGetProject).not.toHaveBeenCalled();
   });
 
-  it("handles API errors gracefully", async () => {
+  it("shows error state with retry when API calls fail", async () => {
     mockGetExperiments.mockRejectedValue(new Error("API error"));
     mockGetLogs.mockRejectedValue(new Error("API error"));
     mockGetMonitorDashboard.mockRejectedValue(new Error("API error"));
@@ -339,10 +339,12 @@ describe("ProjectOverview", () => {
     renderWithProviders(<ProjectOverview {...defaultProps} />);
 
     await waitFor(() => {
-      expect(screen.getByText("Overview")).toBeInTheDocument();
+      expect(screen.getByRole("alert")).toBeInTheDocument();
     });
 
-    expect(screen.getByText("No experiments yet")).toBeInTheDocument();
+    expect(screen.getByText("API error")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Retry loading data" })).toBeInTheDocument();
+    expect(screen.queryByText("Overview")).not.toBeInTheDocument();
   });
 
   it("opens new experiment modal when button clicked", async () => {

--- a/Clients/src/presentation/pages/ModelInventory/ModelEvaluationsTab.tsx
+++ b/Clients/src/presentation/pages/ModelInventory/ModelEvaluationsTab.tsx
@@ -3,6 +3,7 @@ import { Box, Stack, Typography, Alert as MuiAlert } from "@mui/material";
 import { FlaskConical, AlertTriangle } from "lucide-react";
 import Chip from "../../components/Chip";
 import CustomizableSkeleton from "../../components/Skeletons";
+import AsyncBoundary from "../../components/AsyncBoundary";
 import { palette } from "../../themes/palette";
 import {
   getAllModelEvaluations,
@@ -74,13 +75,23 @@ function getKeyResult(eval_: ModelEvaluation): string {
 export default function ModelEvaluationsTab() {
   const [data, setData] = useState<ModelEvaluationsResponse | null>(null);
   const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<Error | string | unknown>(null);
+
+  const loadEvaluations = async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const evaluations = await getAllModelEvaluations();
+      setData(evaluations);
+    } catch (err) {
+      setError(err);
+    } finally {
+      setLoading(false);
+    }
+  };
 
   useEffect(() => {
-    setLoading(true);
-    getAllModelEvaluations()
-      .then(setData)
-      .catch(() => setData({ experiments: [], biasAudits: [] }))
-      .finally(() => setLoading(false));
+    loadEvaluations();
   }, []);
 
   const allEvals = useMemo(() => {
@@ -92,38 +103,37 @@ export default function ModelEvaluationsTab() {
 
   const flaggedCount = useMemo(() => allEvals.filter(hasFailedMetrics).length, [allEvals]);
 
-  if (loading) {
-    return (
-      <Stack spacing={2} sx={{ p: "24px" }}>
-        <CustomizableSkeleton variant="rectangular" width="100%" height={400} />
-      </Stack>
-    );
-  }
-
   return (
-    <Box sx={{ p: "16px" }}>
-      {flaggedCount > 0 && (
-        <MuiAlert
-          severity="warning"
-          icon={<AlertTriangle size={16} strokeWidth={1.5} />}
-          sx={{ mb: "16px", fontSize: "13px", borderRadius: "4px" }}
-        >
-          {flaggedCount} evaluation{flaggedCount !== 1 ? "s" : ""} flagged a potential risk.
-          Consider adding {flaggedCount !== 1 ? "these" : "this"} to the risk register.
-        </MuiAlert>
-      )}
+    <AsyncBoundary
+      isLoading={loading}
+      error={error}
+      isEmpty={!allEvals.length}
+      onRetry={loadEvaluations}
+      loadingFallback={
+        <Stack spacing={2} sx={{ p: "24px" }}>
+          <CustomizableSkeleton variant="rectangular" width="100%" height={400} />
+        </Stack>
+      }
+      emptyIcon={FlaskConical}
+      emptyMessage="No evaluations linked to any model yet"
+      emptyChildren={
+        <Typography sx={{ fontSize: "12px", color: palette.text.secondary }}>
+          Link evaluations to models when creating experiments or bias audits in LLM Evals
+        </Typography>
+      }
+    >
+      <Box sx={{ p: "16px" }}>
+        {flaggedCount > 0 && (
+          <MuiAlert
+            severity="warning"
+            icon={<AlertTriangle size={16} strokeWidth={1.5} />}
+            sx={{ mb: "16px", fontSize: "13px", borderRadius: "4px" }}
+          >
+            {flaggedCount} evaluation{flaggedCount !== 1 ? "s" : ""} flagged a potential risk.
+            Consider adding {flaggedCount !== 1 ? "these" : "this"} to the risk register.
+          </MuiAlert>
+        )}
 
-      {allEvals.length === 0 ? (
-        <Box sx={{ textAlign: "center", py: "48px" }}>
-          <FlaskConical size={32} color={palette.text.secondary} strokeWidth={1.5} />
-          <Typography sx={{ mt: "8px", fontSize: "13px", color: palette.text.secondary }}>
-            No evaluations linked to any model yet
-          </Typography>
-          <Typography sx={{ mt: "4px", fontSize: "12px", color: palette.text.secondary }}>
-            Link evaluations to models when creating experiments or bias audits in LLM Evals
-          </Typography>
-        </Box>
-      ) : (
         <Box
           component="table"
           sx={{
@@ -184,7 +194,7 @@ export default function ModelEvaluationsTab() {
             ))}
           </tbody>
         </Box>
-      )}
-    </Box>
+      </Box>
+    </AsyncBoundary>
   );
 }

--- a/Clients/src/presentation/pages/ModelInventory/index.tsx
+++ b/Clients/src/presentation/pages/ModelInventory/index.tsx
@@ -152,6 +152,7 @@ const ModelInventory: React.FC = () => {
   const hasProcessedUrlParam = useRef(false);
   const [modelInventoryData, setModelInventoryData] = useState<IModelInventory[]>([]);
   const [isLoading, setIsLoading] = useState(true);
+  const [modelInventoryError, setModelInventoryError] = useState<Error | string | unknown>(null);
   const [isNewModelInventoryModalOpen, setIsNewModelInventoryModalOpen] = useState(false);
   // Note: Lifecycle config is now provided by the model-lifecycle plugin via plugin slots
 
@@ -820,6 +821,7 @@ const ModelInventory: React.FC = () => {
     if (showLoading) {
       setIsLoading(true);
     }
+    setModelInventoryError(null);
     try {
       const response = await getAllEntities({ routeUrl: "/modelInventory" });
       if (response?.data) {
@@ -835,11 +837,7 @@ const ModelInventory: React.FC = () => {
         type: "error",
         message: `Failed to fetch model inventory data: ${error}`,
       });
-      setAlert({
-        variant: "error",
-        body: "Failed to load model inventory data. Please try again later.",
-      });
-      setShowAlert(true);
+      setModelInventoryError(error);
     } finally {
       if (showLoading) {
         setIsLoading(false);
@@ -2283,6 +2281,8 @@ const ModelInventory: React.FC = () => {
                   key={tableKey}
                   data={data}
                   isLoading={isLoading}
+                  error={modelInventoryError}
+                  onRetry={() => fetchModelInventoryData()}
                   onEdit={handleEditModelInventory}
                   onDelete={handleDeleteModelInventory}
                   onCheckModelHasRisks={handleCheckModelHasRisks}

--- a/Clients/src/presentation/pages/ModelInventory/modelInventoryTable.tsx
+++ b/Clients/src/presentation/pages/ModelInventory/modelInventoryTable.tsx
@@ -21,6 +21,7 @@ import { Cpu, Layers, BarChart3, Link2 } from "lucide-react";
 import { EmptyState } from "../../components/EmptyState";
 import CustomizableSkeleton from "../../components/Skeletons";
 import EmptyStateTip from "../../components/EmptyState/EmptyStateTip";
+import AsyncBoundary from "../../components/AsyncBoundary";
 import {
   ModelInventoryTableProps,
   IModelInventory,
@@ -83,6 +84,8 @@ const SecurityAssessmentBadge: React.FC<{ assessment: boolean }> = ({ assessment
 const ModelInventoryTable: React.FC<ModelInventoryTableProps> = ({
   data,
   isLoading,
+  error,
+  onRetry,
   onEdit,
   onDelete,
   onCheckModelHasRisks,
@@ -530,51 +533,50 @@ const ModelInventoryTable: React.FC<ModelInventoryTableProps> = ({
     ],
   );
 
-  if (isLoading) {
-    return (
-      <Stack spacing={2}>
-        <CustomizableSkeleton variant="rectangular" width="100%" height={400} />
-      </Stack>
-    );
-  }
-
-  if (!data || data.length === 0) {
-    return (
-      <TableEmptyStateLayout
-        header={
-          <StandardTableHead
-            columns={visibleTableColumns}
-            sortConfig={sortConfig}
-            onSort={handleSort}
-          />
-        }
-      >
-        <EmptyState
-          icon={Cpu}
-          message="No models registered yet. Maintain a complete inventory of all AI models your organization uses."
-        >
-          <EmptyStateTip
-            icon={Layers}
-            title="What counts as a model?"
-            description="Any machine learning model, large language model, computer vision system, or automated decision-making tool. Include both internal and third-party models."
-          />
-          <EmptyStateTip
-            icon={BarChart3}
-            title="Track model status"
-            description="Record each model's status: approved, restricted, pending, blocked, or rejected. This gives auditors visibility into your governance coverage."
-          />
-          <EmptyStateTip
-            icon={Link2}
-            title="Link to vendors and risks"
-            description="Connect each model to its provider and associated risks. This creates a full traceability map for your audit."
-          />
-        </EmptyState>
-      </TableEmptyStateLayout>
-    );
-  }
-
   return (
-    <>
+    <AsyncBoundary
+      isLoading={!!isLoading}
+      error={error}
+      isEmpty={!data || data.length === 0}
+      onRetry={onRetry}
+      loadingFallback={
+        <Stack spacing={2}>
+          <CustomizableSkeleton variant="rectangular" width="100%" height={400} />
+        </Stack>
+      }
+      emptyFallback={
+        <TableEmptyStateLayout
+          header={
+            <StandardTableHead
+              columns={visibleTableColumns}
+              sortConfig={sortConfig}
+              onSort={handleSort}
+            />
+          }
+        >
+          <EmptyState
+            icon={Cpu}
+            message="No models registered yet. Maintain a complete inventory of all AI models your organization uses."
+          >
+            <EmptyStateTip
+              icon={Layers}
+              title="What counts as a model?"
+              description="Any machine learning model, large language model, computer vision system, or automated decision-making tool. Include both internal and third-party models."
+            />
+            <EmptyStateTip
+              icon={BarChart3}
+              title="Track model status"
+              description="Record each model's status: approved, restricted, pending, blocked, or rejected. This gives auditors visibility into your governance coverage."
+            />
+            <EmptyStateTip
+              icon={Link2}
+              title="Link to vendors and risks"
+              description="Connect each model to its provider and associated risks. This creates a full traceability map for your audit."
+            />
+          </EmptyState>
+        </TableEmptyStateLayout>
+      }
+    >
       <TableContainer sx={{ overflowX: "auto" }}>
         <Table sx={singleTheme.tableStyles.primary.frame}>
           <StandardTableHead
@@ -607,7 +609,7 @@ const ModelInventoryTable: React.FC<ModelInventoryTableProps> = ({
           modelName={selectedModel.name}
         />
       )}
-    </>
+    </AsyncBoundary>
   );
 };
 

--- a/Clients/vite.config.ts
+++ b/Clients/vite.config.ts
@@ -92,6 +92,7 @@ export default defineConfig({
     environment: "jsdom",
     setupFiles: "./src/test/setup.ts",
     globals: true,
+    pool: "forks",
     exclude: ["e2e/**", "**/node_modules/**"],
     env: {
       VITE_APP_API_BASE_URL: "http://localhost:3000",

--- a/Servers/controllers/modelEvaluations.ctrl.ts
+++ b/Servers/controllers/modelEvaluations.ctrl.ts
@@ -32,7 +32,7 @@ export async function getAllModelEvaluations(req: Request, res: Response): Promi
       organizationId,
     });
 
-    return res.status(200).json(data);
+    return res.status(200).json(STATUS_CODE[200](data));
   } catch (error) {
     await logFailure({
       description: "getAllModelEvaluations failed",
@@ -78,7 +78,7 @@ export async function getModelEvaluations(req: Request, res: Response): Promise<
       organizationId,
     });
 
-    return res.status(200).json(data);
+    return res.status(200).json(STATUS_CODE[200](data));
   } catch (error) {
     await logFailure({
       description: "getModelEvaluations failed",

--- a/Servers/controllers/modelInventory.ctrl.ts
+++ b/Servers/controllers/modelInventory.ctrl.ts
@@ -320,7 +320,7 @@ export async function createNewModelInventory(req: Request, res: Response) {
         {
           description: modelDetails || undefined,
         },
-      ).catch((err) => console.error("Failed to send approver notification:", err));
+      ).catch((err) => logger.error("Failed to send approver notification:", err));
     }
 
     logStructured(
@@ -529,7 +529,7 @@ export async function updateModelInventoryById(req: Request, res: Response) {
         {
           description: modelDetails || undefined,
         },
-      ).catch((err) => console.error("Failed to send approver notification:", err));
+      ).catch((err) => logger.error("Failed to send approver notification:", err));
     }
 
     logStructured(

--- a/Servers/utils/modelInventory.utils.ts
+++ b/Servers/utils/modelInventory.utils.ts
@@ -277,12 +277,7 @@ export const createNewModelInventoryQuery = async (
     }
 
     // Record history snapshot for status changes
-    try {
-      await recordSnapshotIfChanged("status", organizationId, undefined, transaction);
-    } catch (historyError) {
-      console.error("Error recording history snapshot:", historyError);
-      // Don't throw - history recording failure shouldn't block model creation
-    }
+    await recordSnapshotIfChanged("status", organizationId, undefined, transaction);
 
     return createdModel;
   } catch (error) {
@@ -462,13 +457,8 @@ export const updateModelInventoryByIdQuery = async (
     }
 
     // Record history snapshot if status changed
-    try {
-      if (oldModel && oldModel.status !== updatedModel.status) {
-        await recordSnapshotIfChanged("status", organizationId, undefined, transaction);
-      }
-    } catch (historyError) {
-      console.error("Error recording history snapshot:", historyError);
-      // Don't throw - history recording failure shouldn't block model update
+    if (oldModel && oldModel.status !== updatedModel.status) {
+      await recordSnapshotIfChanged("status", organizationId, undefined, transaction);
     }
 
     return updatedModel;
@@ -554,12 +544,7 @@ export const deleteModelInventoryByIdQuery = async (
     }
 
     // Record history snapshot after deletion
-    try {
-      await recordSnapshotIfChanged("status", organizationId, undefined, transaction);
-    } catch (historyError) {
-      console.error("Error recording history snapshot:", historyError);
-      // Don't throw - history recording failure shouldn't block model deletion
-    }
+    await recordSnapshotIfChanged("status", organizationId, undefined, transaction);
 
     return deletedModel;
   } catch (error) {


### PR DESCRIPTION
## Describe your changes

1. Introduces a reusable `AsyncBoundary` component and applies it to `ModelInventory` (table + evaluations tab) and `EvalsDashboard` (`ModelsPage` + `ProjectOverview`) for consistent loading, empty, and error states with retry support.
2. Standardizes backend `modelEvaluations` success responses to the `{ message, data }` envelope via `STATUS_CODE`, and stops silent error swallowing in `evalModelsService` and `modelInventory` history-snapshot utilities so failures propagate to the UI.

Fixes No. 1 of  #4150 

## Please ensure all items are checked off before requesting a review:

- [x] I deployed the code locally.
- [x] I have performed a self-review of my code.
- [x] I have included the issue # in the PR.
- [x] I have labelled the PR correctly.
- [x] The issue I am working on is assigned to me.
- [x] I have avoided using hardcoded values to ensure scalability and maintain consistency across the application.
- [x] I have ensured that font sizes, color choices, and other UI elements are referenced from the theme.
- [x] My pull request is focused and addresses a single, specific feature.
- [x] If there are UI changes, I have attached a screenshot or video to this PR.
- [ ] If I added or modified an API endpoint, the change is reflected in the generated OpenAPI spec (`npm run generate:swagger`).
- [ ] If the endpoint requires authentication, it uses `authenticateJWT` and the generated spec declares `bearerAuth` security.
- [ ] I ran `npm run check:api-drift` and committed the regenerated `swagger.yaml` and `endpoints.ts`.
- [ ] If this PR adds or modifies an organization-scoped table, the [tenant isolation registry](Servers/tests/integration/tenant-isolation/tenantIsolation.registry.ts) and [test matrix](Servers/tests/integration/tenant-isolation) are updated. See the [tenant isolation runbook](docs/technical/security/tenant-isolation.md) for details.

<img width="1140" height="431" alt="Screenshot 2026-07-07 at 16 55 21" src="https://github.com/user-attachments/assets/3ba2fdbd-fcde-4fc5-928d-d8c8b31ad259" />
