### PR TITLE
feat(advisor): cross-fade the copy button icon

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,6 @@
 # VerifyWise - Development Guide
 
-> **Last Updated:** 2026-07-03
+> **Last Updated:** 2026-07-05
 
 This document contains cross-cutting rules for the VerifyWise codebase. Directory-scoped guides load automatically when working in each area:
 
@@ -176,6 +176,7 @@ Read the relevant file BEFORE implementing changes in that area:
 | Agent Control integrator/developer docs (connect an agent, Claude Code + Cursor, generic contract, API ref) | `shared/user-guide-content/content/developers/` |
 | AI Trust Index | `docs/technical/domains/ai-trust-index.md` |
 | Model Risk Management (MRM: bank model-risk governance — tiering, validation, findings, monitoring/ingestion, threshold eval, revalidation triggers, attestation; SR 26-2 / SS1/23 / OSFI E-23) | `docs/technical/domains/mrm.md` |
+| MRM metric simulator (dev-only CLI in `tools/mrm-simulator/`: real Python compute of PSI/AUC/gini/fairness from bundled datasets, config-driven fleet, ingestion, gap-finder, live web dashboard — for demoing/exercising MRM) | `docs/technical/domains/mrm-simulator.md` |
 | AI Detection | `docs/technical/domains/ai-detection.md` |
 | Risk management | `docs/technical/domains/risk-management.md` |
 | Vendors | `docs/technical/domains/vendors.md` |

--- a/Clients/src/index.css
+++ b/Clients/src/index.css
@@ -128,3 +128,47 @@ html.dark-mode .gs-card {
 html.dark-mode .feature-video-player {
   filter: invert(1) hue-rotate(180deg);
 }
+
+/* ─────────────────────────────────────────────────────────────
+   Icon swap (transitions.dev) — cross-fade two icons in one slot.
+   Both icons stay stacked in the same grid cell; toggle data-state
+   on .t-icon-swap and the matching .t-icon fades in while the other
+   fades out with blur + scale. Used by the advisor copy button.
+   ───────────────────────────────────────────────────────────── */
+:root {
+  --icon-swap-dur: 250ms;
+  --icon-swap-blur: 2px;
+  --icon-swap-start-scale: 0.25;
+  --icon-swap-ease: ease-in-out;
+}
+
+.t-icon-swap {
+  position: relative;
+  display: inline-grid;
+}
+.t-icon-swap .t-icon {
+  grid-area: 1 / 1;
+  transition:
+    opacity var(--icon-swap-dur) var(--icon-swap-ease),
+    filter var(--icon-swap-dur) var(--icon-swap-ease),
+    transform var(--icon-swap-dur) var(--icon-swap-ease);
+  will-change: opacity, filter, transform;
+}
+.t-icon-swap[data-state="a"] .t-icon[data-icon="a"],
+.t-icon-swap[data-state="b"] .t-icon[data-icon="b"] {
+  opacity: 1;
+  filter: blur(0);
+  transform: scale(1);
+}
+.t-icon-swap[data-state="a"] .t-icon[data-icon="b"],
+.t-icon-swap[data-state="b"] .t-icon[data-icon="a"] {
+  opacity: 0;
+  filter: blur(var(--icon-swap-blur));
+  transform: scale(var(--icon-swap-start-scale));
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .t-icon-swap .t-icon {
+    transition: none !important;
+  }
+}

--- a/Clients/src/presentation/components/AdvisorChat/CustomMessage.tsx
+++ b/Clients/src/presentation/components/AdvisorChat/CustomMessage.tsx
@@ -313,7 +313,22 @@ const CopyButton: FC<{ bubbleRef: React.RefObject<HTMLDivElement | null> }> = ({
       aria-label="Copy response"
       title={copied ? "Copied!" : "Copy"}
     >
-      {copied ? <Check size={12} strokeWidth={1.5} /> : <Copy size={12} strokeWidth={1.5} />}
+      {/* icon-swap (transitions.dev): both icons stacked in one grid
+          cell; data-state cross-fades check ↔ copy on the `copied`
+          toggle. See .t-icon-swap in index.css. */}
+      <Box
+        component="span"
+        className="t-icon-swap"
+        data-state={copied ? "b" : "a"}
+        sx={{ lineHeight: 0 }}
+      >
+        <Box component="span" className="t-icon" data-icon="a" sx={{ lineHeight: 0 }}>
+          <Copy size={12} strokeWidth={1.5} />
+        </Box>
+        <Box component="span" className="t-icon" data-icon="b" sx={{ lineHeight: 0 }}>
+          <Check size={12} strokeWidth={1.5} />
+        </Box>
+      </Box>
       <Typography
         component="span"
         sx={{

--- a/docs/session-handover-2026-07-05.md
+++ b/docs/session-handover-2026-07-05.md
@@ -1,0 +1,107 @@
+# Session handover — 2026-07-05
+
+Context for resuming after `/clear`. This session ran a long MRM (Model Risk
+Management) push: shipped the feature's follow-on fixes, then built a three-phase
+metric **simulator** that found and fixed several real production bugs.
+
+## TL;DR state
+
+- **11 PRs this session; 10 merged, 1 open.** Only **#4229** (auth 401 hardening)
+  is still open.
+- The **MRM metric simulator** (`tools/mrm-simulator/`) is fully built and merged
+  to develop: v1 (scenario CLI + gap-finder), v2a (real Python compute + config
+  fleet), v2b (live web dashboard).
+- The simulator found and fixed **three real production MRM bugs** (see below).
+- A parked "in-app demo ingest" idea was **evaluated and dropped** (the simulator
+  covers demos better than static seeding). See
+  `memory/idea-in-app-demo-ingest.md`.
+
+## What shipped (merged to develop)
+
+| PR | What |
+|----|------|
+| #4228 | MRM feature itself (tiering, validation, findings, monitoring/ingestion, revalidation, attestation) — merged early in the session. |
+| #4230 | fix(mrm): attestation summary `ANY(:array)` → `IN(:array)` (was a 500). |
+| #4231 | docs(mrm): in-app user-guide article (help panel). |
+| #4232 | feat(mrm): route the six MRM sub-tabs + settings sections; new reusable `components/SectionNav`. Also fixed a pre-existing infinite render loop in the settings Roles section. |
+| #4233 | fix(mrm): persist `external_key` on model **update** (PATCH silently dropped it → ingestion 404'd). |
+| #4234 | feat: MRM simulator v1 (scenario-driven scripted metrics, gap-finder). |
+| #4235 | feat: make `external_key` settable at model **create** + UI field + 409 on duplicate. |
+| #4236 | feat: simulator v2a — real Python metric compute + config-driven fleet. |
+| #4237 | fix(mrm): batch metric ingestion SAVEPOINT (500 on any re-run with a duplicate point). |
+| #4238 | feat: simulator v2b — live web dashboard. |
+
+## Still open
+
+- **PR #4229** — `fix(auth): return 401 when a valid token references a missing
+  user`. Branch `fix/auth-401-missing-user`. Real hardening: `auth.middleware.ts`
+  threw a 500 (dereferencing `user.role_id` when `getUserByIdQuery` returned
+  undefined) — now returns 401. Assigned MuhammadKhalilzadeh. Reviewed clean,
+  gates green. **Just needs merge.**
+
+## The three production bugs the simulator found
+
+1. **`external_key` not persisted on update** (#4233) — the model PATCH accepted
+   the field but dropped it (missing from the controller allow-list, the model
+   method, and the UPDATE SQL). Ingestion resolves models by `external_key`, so
+   MRM monitoring was unusable. Fixed across all three layers.
+2. **`external_key` not settable on create / not returned by serializers**
+   (#4235) — same class on the create path + `toSafeJSON`/`toJSON` omitted it +
+   no UI field. Fixed; added a 409 on duplicate keys.
+3. **Batch ingestion SAVEPOINT bug** (#4237) — `ingestPointQuery` caught the
+   idempotency 23505 in JS but a failed INSERT aborts the whole Postgres
+   transaction, so a duplicate point poisoned the rest of a batch → 500 on every
+   re-run. Fixed by wrapping the insert in a SAVEPOINT (RELEASE on success,
+   ROLLBACK TO on 23505).
+
+## The simulator (now on develop)
+
+`tools/mrm-simulator/` — a **dev-only CLI** that impersonates a model-monitoring
+platform (Evidently/Arize style) feeding VerifyWise MRM. See the full reference:
+`docs/technical/domains/mrm-simulator.md`.
+
+- **v2a compute:** a Python module (`compute/`, pandas/numpy/sklearn/scipy)
+  computes real PSI/AUC/gini/KS/fairness from four bundled CSV datasets with
+  embedded drift. The TS engine shells out to it per model/period.
+- **Config-driven:** `config.yaml` defines the fleet.
+- **v2b dashboard:** `sim dashboard` starts a local HTTP+WebSocket server that
+  drives the sim and streams computed metrics/breaches/pushes to a
+  VerifyWise-styled four-panel page.
+
+**Gotchas to remember (documented in the simulator README + doc):**
+- Needs a Python venv: `cd tools/mrm-simulator/compute && python3 -m venv venv &&
+  ./venv/bin/pip install -r requirements.txt`.
+- Datasets are fixed-date (2026-06-01 onward) → backfill/dashboard need
+  `--start-date 2026-06-01`.
+- `npm run sim` strips flags → use `npm run sim -- <cmd> --flags` or
+  `npx tsx src/cli.ts <cmd>`.
+- The Python compute CLI is invoked as `python __main__.py` from `compute/`
+  (not `python -m compute`).
+
+## Local dev environment notes
+
+- Backend was run via `cd Servers && npm run watch` (tsc-watch + nodemon). A
+  recurring friction: running `npm run build` in `Servers/` kills the watch
+  process on :3000 — restart it after any manual build.
+- Dev auto-bootstrap is enabled in `Servers/.env` (`DEV_AUTO_BOOTSTRAP=true`,
+  admin `gorkem.cetin@verifywise.ai` / `Verifywise#1`, org "Acme Dev"). The
+  password is quoted in `.env` because the `#` would otherwise be treated as an
+  inline comment.
+- Sim models occupy model_inventory ids ~5-8 with external_keys
+  `credit-scoring-v3`, `fraud-detector-v2`, `loan-approval-v1`,
+  `churn-propensity-v1`.
+
+## Suggested next steps
+
+1. **Merge #4229** (the last open PR) when ready.
+2. Optionally run the dashboard for a demo:
+   `cd tools/mrm-simulator && npx tsx src/cli.ts dashboard --start-date 2026-06-01 --days 30`.
+3. The in-app demo-ingest feature is **dropped** — revive only if *customer*
+   self-serve (no terminal) becomes a real need.
+
+## Working state at handover
+
+- On branch `docs/mrm-simulator-handover` (this doc + the simulator technical doc
+  + a CLAUDE.md update). Everything else is merged.
+- Working tree otherwise clean apart from long-standing untracked scratch files
+  (screenshots, `.json` snapshots) in the repo root — not part of any work.

--- a/docs/technical/domains/mrm-simulator.md
+++ b/docs/technical/domains/mrm-simulator.md
@@ -1,0 +1,129 @@
+# MRM metric simulator
+
+> **Last Updated:** 2026-07-05
+> **Location:** `tools/mrm-simulator/` — a **dev-only** CLI. Not shipped to users.
+
+A tool that impersonates a push-based model-monitoring platform (Evidently /
+Arize style) and feeds realistic metrics into VerifyWise's MRM ingestion API. It
+computes real metrics from bundled datasets, pushes them through the real
+pipeline, checks that the governance loop closes, and can visualize the whole run
+live. It exists to demo MRM end-to-end and to exercise the ingestion/evaluation
+path the way a real customer would — which is how it found three production bugs
+(see the MRM doc and the 2026-07-05 handover).
+
+## What it is (and is not)
+
+- **Is:** a local TypeScript CLI (compute in Python) that drives setup → metric
+  compute → ingestion → verification, with an optional live web dashboard.
+- **Is not:** a product feature. It is developer/demo tooling. It refuses
+  non-localhost targets unless `--i-know-what-im-doing` is passed; its token
+  cache, venv, datasets cache, and gaps report are git-ignored.
+
+## Architecture
+
+```
+config.yaml (fleet: models, tier, dataset, metrics, thresholds)
+      │  configLoader (TS) → FleetModel[]
+      ▼
+TS CLI (setup / backfill / live / verify / dashboard)
+      │  per model, per period:
+      │    computeMetrics ── shells out ──► python __main__.py  (compute/)
+      │                                      pandas/numpy/sklearn/scipy
+      │                                      real PSI/AUC/gini/KS/fairness
+      │    ingestClient.pushBatch ──────────► POST /api/mrm/models/:key/metrics
+      ▼
+  verify → reads MRM back, checks governance loop → gaps-report.md
+```
+
+### File map
+
+| Path | Responsibility |
+|------|----------------|
+| `config.yaml` | The fleet definition (models, tiers, dataset mapping, metrics, thresholds). |
+| `src/configLoader.ts` | Parse + validate config into `FleetModel[]`. Rejects bad op/metric/tier and path-traversal in the dataset field. |
+| `compute/metrics.py` | Pure metric functions: `psi`, `auc`, `gini`, `ks`, `fairness`. |
+| `compute/__main__.py` | CLI: read CSV, slice reference vs. period, compute, print JSON. |
+| `datasets/*.csv` + `generate.py` | Four bundled datasets with embedded drift + a deterministic generator (committed static). |
+| `src/computeClient.ts` | TS wrapper that shells out to the Python compute module. |
+| `src/engine.ts` | Builds metric points per model/period from the compute result. |
+| `src/setup.ts` | Idempotent fleet + thresholds + ingestion-token creation via the JWT API. |
+| `src/ingestClient.ts` | Token-authed batched POST to the ingestion endpoint. |
+| `src/verify.ts` + `src/report.ts` | Read MRM back, run contract/workflow gap checks, render `gaps-report.md`. |
+| `src/config.ts` | Base URL, creds, the localhost safety guard, token cache. |
+| `src/dashboard/{events,runner,server}.ts` + `public/` | The live web dashboard (v2b). |
+
+## The four scenario models
+
+Defined in `config.yaml`, backed by `datasets/`:
+
+| Model (`external_key`) | Tier | Behavior (real, from the data) |
+|---|---|---|
+| `credit-scoring-v3` | 1 | PSI drifts across 0.20 mid-window (breach → revalidation); AUC sags. |
+| `fraud-detector-v2` | 1 | Stable — healthy control, no false breach. |
+| `loan-approval-v1` | 2 | `subprime` segment gini collapses below the band (fairness breach). |
+| `churn-propensity-v1` | 3 | PSI breaches then recovers. |
+
+Metrics are **computed**, not scripted; the datasets are tuned so breaches land
+in the right place, and tests assert both direction and realistic ranges (AUC
+never 1.0, bounded PSI, a visible fairness gap).
+
+## Compute engine (Python)
+
+- Invoked as `python __main__.py --dataset <path> --period <date> --metrics
+  psi,auc,gini,ks --feature-col feature [--segment-col segment]`, run from the
+  `compute/` directory. Prints a JSON object of metric values (+ a `fairness`
+  block per segment when `--segment-col` is given).
+- **Reference window:** each dataset's first 7 days (fixed baseline) unless
+  `--reference start:end` is passed. Drift is measured against that baseline.
+- Stack: pandas, numpy, scikit-learn, scipy (ranges in `compute/requirements.txt`;
+  works on Python 3.11). One venv under `compute/venv/`.
+
+## Commands
+
+```bash
+npm run sim -- setup                                        # create fleet + thresholds + token (idempotent)
+npm run sim -- backfill --days 30 --start-date 2026-06-01   # push computed history over the dataset window
+npm run sim -- live --interval 5s                           # keep pushing forward
+npm run sim -- verify                                       # read MRM back, write gaps-report.md
+npm run sim -- dashboard --start-date 2026-06-01 --days 30  # live web dashboard (default :4000)
+```
+
+Add `--dry-run` to `backfill`/`live` to compute without POSTing.
+
+## Live dashboard (v2b)
+
+`sim dashboard` starts a local Node HTTP + WebSocket server (loopback only) that
+drives the simulation itself and streams typed events to a VerifyWise-styled
+vanilla-JS page. Four panels: fleet overview (status chips), per-model metric
+charts (with threshold lines and marked breaches), a live breach/event feed, and
+ingestion totals. Chart.js is pinned with Subresource Integrity; DOM writes from
+event data use `textContent` (no HTML injection). The server buffers events and
+replays them so a browser connecting mid-run sees history.
+
+- `src/dashboard/runner.ts` is pure orchestration (injected deps, emits typed
+  events) — unit-tested. `server.ts` is thin transport. `public/` is presentation.
+
+## Gotchas
+
+- **Python venv required** before any command that computes (see Architecture).
+- **Datasets are fixed-date** (2026-06-01 onward) → always pass
+  `--start-date 2026-06-01` to `backfill`/`dashboard`; otherwise it asks for
+  today-relative dates the datasets don't contain and gets "no rows for period".
+- **`npm run` strips flags** → use `npm run sim -- <cmd> --flags` or
+  `npx tsx src/cli.ts <cmd> --flags`.
+- **Compute CLI is `python __main__.py`** run from `compute/` (a flat module),
+  NOT `python -m compute`.
+- The tool refuses non-localhost base URLs unless `--i-know-what-im-doing`.
+
+## Prerequisites
+
+- A running VerifyWise backend (default `http://localhost:3000`) with an admin
+  login (dev auto-bootstrap: `gorkem.cetin@verifywise.ai` / `Verifywise#1`).
+- Node 22+, Python 3.11+, and `npm install` in `tools/mrm-simulator/`.
+
+## Spec / plan history
+
+Design specs and implementation plans live under `docs/superpowers/`:
+`2026-07-04-mrm-model-eval-simulator-*` (v1),
+`2026-07-04-mrm-simulator-v2a-compute-*` (v2a),
+`2026-07-04-mrm-simulator-v2b-dashboard-*` (v2b).


### PR DESCRIPTION
## Changes
- Added reusable icon-swap motion tokens and a `.t-icon-swap` CSS block to the global stylesheet (`Clients/src/index.css`), including a `prefers-reduced-motion` guard.
- Wired the advisor copy button in `CustomMessage.tsx` to stack the copy and check icons in a single grid cell, cross-fading between them via `data-state` on the `copied` toggle instead of a hard swap.

## Benefits
- Smoother, more polished copy interaction in the AI Advisor chat.
- Shared, tokenised motion primitive that any future icon toggle can reuse.
- Fully accessible: honours reduced-motion preferences; no behaviour or clipboard logic changed.

## Notes
- Two files changed (+60/-1). Typecheck, format-check, and build all pass locally.