### PR TITLE
feat(themes): add color primitive pools and derive semantic palette

### DIFF
--- a/Clients/src/presentation/pages/StyleGuide/sections/ColorsSection.tsx
+++ b/Clients/src/presentation/pages/StyleGuide/sections/ColorsSection.tsx
@@ -1,7 +1,7 @@
 import React, { useState } from "react";
 import { Box, Stack, Typography, useTheme, Divider, Snackbar } from "@mui/material";
 import { Copy } from "lucide-react";
-import { grey, green, red } from "../../../themes/primitives";
+import { grey, green, red, amber } from "../../../themes/primitives";
 
 const ColorsSection: React.FC = () => {
   const theme = useTheme();
@@ -115,6 +115,21 @@ const ColorsSection: React.FC = () => {
               Red
             </Typography>
             <PrimitiveScale name="Red" scale={red} tokenPrefix="red" onCopy={handleCopy} />
+          </Box>
+          <Box>
+            <Typography
+              sx={{
+                fontSize: 12,
+                fontWeight: 600,
+                color: theme.palette.text.secondary,
+                mb: "12px",
+                textTransform: "uppercase",
+                letterSpacing: "0.5px",
+              }}
+            >
+              Amber
+            </Typography>
+            <PrimitiveScale name="Amber" scale={amber} tokenPrefix="amber" onCopy={handleCopy} />
           </Box>
         </Box>
       </SpecSection>
@@ -693,7 +708,8 @@ const ColorsSection: React.FC = () => {
             "Define hex values only in themes/primitives.ts — use palette.ts semantics in components",
             "Grey primitives power text, border, and background tokens",
             "Green primitives power brand, success, and accent tokens",
-            "Red primitives power error, critical, and risk tokens",
+            "Red primitives power error and critical risk tokens",
+            "Amber primitives power warning, medium risk, and accent.amber tokens",
             "Access semantics via theme.palette.* — never hardcode hex in components",
             "Border color theme.palette.border.dark should be used for input borders",
             "Text hierarchy: primary > secondary > tertiary > accent",

--- a/Clients/src/presentation/pages/StyleGuide/sections/ColorsSection.tsx
+++ b/Clients/src/presentation/pages/StyleGuide/sections/ColorsSection.tsx
@@ -1,7 +1,7 @@
 import React, { useState } from "react";
 import { Box, Stack, Typography, useTheme, Divider, Snackbar } from "@mui/material";
 import { Copy } from "lucide-react";
-import { grey, green, red, amber, orange, blue, indigo } from "../../../themes/primitives";
+import { grey, green, red, amber, orange, blue, indigo, purple } from "../../../themes/primitives";
 
 const ColorsSection: React.FC = () => {
   const theme = useTheme();
@@ -67,7 +67,7 @@ const ColorsSection: React.FC = () => {
           sx={{
             display: "flex",
             flexWrap: "wrap",
-            gap: "48px",
+            gap: "40px",
             alignItems: "flex-start",
           }}
         >
@@ -175,6 +175,21 @@ const ColorsSection: React.FC = () => {
               Indigo
             </Typography>
             <PrimitiveScale name="Indigo" scale={indigo} tokenPrefix="indigo" onCopy={handleCopy} />
+          </Box>
+          <Box>
+            <Typography
+              sx={{
+                fontSize: 12,
+                fontWeight: 600,
+                color: theme.palette.text.secondary,
+                mb: "12px",
+                textTransform: "uppercase",
+                letterSpacing: "0.5px",
+              }}
+            >
+              Purple
+            </Typography>
+            <PrimitiveScale name="Purple" scale={purple} tokenPrefix="purple" onCopy={handleCopy} />
           </Box>
         </Box>
       </SpecSection>
@@ -758,6 +773,7 @@ const ColorsSection: React.FC = () => {
             "Amber primitives power warning, medium risk, and accent.amber tokens",
             "Blue primitives power info and accent.blue tokens",
             "Indigo primitives power accent.indigo tokens",
+            "Purple primitives power accent.purple tokens",
             "Access semantics via theme.palette.* — never hardcode hex in components",
             "Border color theme.palette.border.dark should be used for input borders",
             "Text hierarchy: primary > secondary > tertiary > accent",
@@ -805,7 +821,7 @@ const PrimitiveScale: React.FC<{
     .sort((a, b) => a - b);
 
   return (
-    <Stack spacing="6px" sx={{ width: 240 }}>
+    <Stack spacing="8px" sx={{ width: 164 }}>
       {steps.map((step) => {
         const color = scale[step as keyof typeof scale];
 
@@ -844,7 +860,8 @@ const PrimitiveScale: React.FC<{
                   (step === 50 && tokenPrefix === "grey") ||
                   (step === 50 && tokenPrefix === "orange") ||
                   (step === 50 && tokenPrefix === "blue") ||
-                  (step === 50 && tokenPrefix === "indigo")
+                  (step === 50 && tokenPrefix === "indigo") ||
+                  (step === 50 && tokenPrefix === "purple")
                     ? `1px solid ${theme.palette.border.light}`
                     : "none",
               }}

--- a/Clients/src/presentation/pages/StyleGuide/sections/ColorsSection.tsx
+++ b/Clients/src/presentation/pages/StyleGuide/sections/ColorsSection.tsx
@@ -1,7 +1,18 @@
 import React, { useState } from "react";
 import { Box, Stack, Typography, useTheme, Divider, Snackbar } from "@mui/material";
 import { Copy } from "lucide-react";
-import { grey, green, red, amber, orange, blue, indigo, purple } from "../../../themes/primitives";
+import {
+  grey,
+  green,
+  red,
+  amber,
+  orange,
+  blue,
+  indigo,
+  purple,
+  teal,
+  pink,
+} from "../../../themes/primitives";
 
 const ColorsSection: React.FC = () => {
   const theme = useTheme();
@@ -190,6 +201,36 @@ const ColorsSection: React.FC = () => {
               Purple
             </Typography>
             <PrimitiveScale name="Purple" scale={purple} tokenPrefix="purple" onCopy={handleCopy} />
+          </Box>
+          <Box>
+            <Typography
+              sx={{
+                fontSize: 12,
+                fontWeight: 600,
+                color: theme.palette.text.secondary,
+                mb: "12px",
+                textTransform: "uppercase",
+                letterSpacing: "0.5px",
+              }}
+            >
+              Teal
+            </Typography>
+            <PrimitiveScale name="Teal" scale={teal} tokenPrefix="teal" onCopy={handleCopy} />
+          </Box>
+          <Box>
+            <Typography
+              sx={{
+                fontSize: 12,
+                fontWeight: 600,
+                color: theme.palette.text.secondary,
+                mb: "12px",
+                textTransform: "uppercase",
+                letterSpacing: "0.5px",
+              }}
+            >
+              Pink
+            </Typography>
+            <PrimitiveScale name="Pink" scale={pink} tokenPrefix="pink" onCopy={handleCopy} />
           </Box>
         </Box>
       </SpecSection>
@@ -774,6 +815,8 @@ const ColorsSection: React.FC = () => {
             "Blue primitives power info and accent.blue tokens",
             "Indigo primitives power accent.indigo tokens",
             "Purple primitives power accent.purple tokens",
+            "Teal primitives power accent.teal tokens",
+            "Pink primitives power accent.pink tokens",
             "Access semantics via theme.palette.* — never hardcode hex in components",
             "Border color theme.palette.border.dark should be used for input borders",
             "Text hierarchy: primary > secondary > tertiary > accent",
@@ -861,7 +904,9 @@ const PrimitiveScale: React.FC<{
                   (step === 50 && tokenPrefix === "orange") ||
                   (step === 50 && tokenPrefix === "blue") ||
                   (step === 50 && tokenPrefix === "indigo") ||
-                  (step === 50 && tokenPrefix === "purple")
+                  (step === 50 && tokenPrefix === "purple") ||
+                  (step === 50 && tokenPrefix === "teal") ||
+                  (step === 50 && tokenPrefix === "pink")
                     ? `1px solid ${theme.palette.border.light}`
                     : "none",
               }}

--- a/Clients/src/presentation/pages/StyleGuide/sections/ColorsSection.tsx
+++ b/Clients/src/presentation/pages/StyleGuide/sections/ColorsSection.tsx
@@ -1,7 +1,7 @@
 import React, { useState } from "react";
 import { Box, Stack, Typography, useTheme, Divider, Snackbar } from "@mui/material";
 import { Copy } from "lucide-react";
-import { grey, green } from "../../../themes/primitives";
+import { grey, green, red } from "../../../themes/primitives";
 
 const ColorsSection: React.FC = () => {
   const theme = useTheme();
@@ -100,6 +100,21 @@ const ColorsSection: React.FC = () => {
               Green
             </Typography>
             <PrimitiveScale name="Green" scale={green} tokenPrefix="green" onCopy={handleCopy} />
+          </Box>
+          <Box>
+            <Typography
+              sx={{
+                fontSize: 12,
+                fontWeight: 600,
+                color: theme.palette.text.secondary,
+                mb: "12px",
+                textTransform: "uppercase",
+                letterSpacing: "0.5px",
+              }}
+            >
+              Red
+            </Typography>
+            <PrimitiveScale name="Red" scale={red} tokenPrefix="red" onCopy={handleCopy} />
           </Box>
         </Box>
       </SpecSection>
@@ -678,6 +693,7 @@ const ColorsSection: React.FC = () => {
             "Define hex values only in themes/primitives.ts — use palette.ts semantics in components",
             "Grey primitives power text, border, and background tokens",
             "Green primitives power brand, success, and accent tokens",
+            "Red primitives power error, critical, and risk tokens",
             "Access semantics via theme.palette.* — never hardcode hex in components",
             "Border color theme.palette.border.dark should be used for input borders",
             "Text hierarchy: primary > secondary > tertiary > accent",

--- a/Clients/src/presentation/pages/StyleGuide/sections/ColorsSection.tsx
+++ b/Clients/src/presentation/pages/StyleGuide/sections/ColorsSection.tsx
@@ -1,7 +1,7 @@
 import React, { useState } from "react";
 import { Box, Stack, Typography, useTheme, Divider, Snackbar } from "@mui/material";
 import { Copy } from "lucide-react";
-import { grey, green, red, amber, deepOrange } from "../../../themes/primitives";
+import { grey, green, red, amber, orange } from "../../../themes/primitives";
 
 const ColorsSection: React.FC = () => {
   const theme = useTheme();
@@ -127,14 +127,9 @@ const ColorsSection: React.FC = () => {
                 letterSpacing: "0.5px",
               }}
             >
-              Deep orange
+              Orange
             </Typography>
-            <PrimitiveScale
-              name="Deep orange"
-              scale={deepOrange}
-              tokenPrefix="deepOrange"
-              onCopy={handleCopy}
-            />
+            <PrimitiveScale name="Orange" scale={orange} tokenPrefix="orange" onCopy={handleCopy} />
           </Box>
           <Box>
             <Typography
@@ -729,7 +724,7 @@ const ColorsSection: React.FC = () => {
             "Grey primitives power text, border, and background tokens",
             "Green primitives power brand, success, and accent tokens",
             "Red primitives power error and critical risk tokens",
-            "Deep orange primitives power high risk and major severity tokens",
+            "Orange primitives power high risk, major severity, and accent.orange tokens",
             "Amber primitives power warning, medium risk, and accent.amber tokens",
             "Access semantics via theme.palette.* — never hardcode hex in components",
             "Border color theme.palette.border.dark should be used for input borders",
@@ -814,7 +809,8 @@ const PrimitiveScale: React.FC<{
                 borderRadius: "4px",
                 backgroundColor: color,
                 border:
-                  step === 50 && tokenPrefix === "grey"
+                  (step === 50 && tokenPrefix === "grey") ||
+                  (step === 50 && tokenPrefix === "orange")
                     ? `1px solid ${theme.palette.border.light}`
                     : "none",
               }}

--- a/Clients/src/presentation/pages/StyleGuide/sections/ColorsSection.tsx
+++ b/Clients/src/presentation/pages/StyleGuide/sections/ColorsSection.tsx
@@ -1,7 +1,7 @@
 import React, { useState } from "react";
 import { Box, Stack, Typography, useTheme, Divider, Snackbar } from "@mui/material";
 import { Copy } from "lucide-react";
-import { grey, green, red, amber, orange } from "../../../themes/primitives";
+import { grey, green, red, amber, orange, blue, indigo } from "../../../themes/primitives";
 
 const ColorsSection: React.FC = () => {
   const theme = useTheme();
@@ -145,6 +145,36 @@ const ColorsSection: React.FC = () => {
               Amber
             </Typography>
             <PrimitiveScale name="Amber" scale={amber} tokenPrefix="amber" onCopy={handleCopy} />
+          </Box>
+          <Box>
+            <Typography
+              sx={{
+                fontSize: 12,
+                fontWeight: 600,
+                color: theme.palette.text.secondary,
+                mb: "12px",
+                textTransform: "uppercase",
+                letterSpacing: "0.5px",
+              }}
+            >
+              Blue
+            </Typography>
+            <PrimitiveScale name="Blue" scale={blue} tokenPrefix="blue" onCopy={handleCopy} />
+          </Box>
+          <Box>
+            <Typography
+              sx={{
+                fontSize: 12,
+                fontWeight: 600,
+                color: theme.palette.text.secondary,
+                mb: "12px",
+                textTransform: "uppercase",
+                letterSpacing: "0.5px",
+              }}
+            >
+              Indigo
+            </Typography>
+            <PrimitiveScale name="Indigo" scale={indigo} tokenPrefix="indigo" onCopy={handleCopy} />
           </Box>
         </Box>
       </SpecSection>
@@ -726,6 +756,8 @@ const ColorsSection: React.FC = () => {
             "Red primitives power error and critical risk tokens",
             "Orange primitives power high risk, major severity, and accent.orange tokens",
             "Amber primitives power warning, medium risk, and accent.amber tokens",
+            "Blue primitives power info and accent.blue tokens",
+            "Indigo primitives power accent.indigo tokens",
             "Access semantics via theme.palette.* — never hardcode hex in components",
             "Border color theme.palette.border.dark should be used for input borders",
             "Text hierarchy: primary > secondary > tertiary > accent",
@@ -810,7 +842,9 @@ const PrimitiveScale: React.FC<{
                 backgroundColor: color,
                 border:
                   (step === 50 && tokenPrefix === "grey") ||
-                  (step === 50 && tokenPrefix === "orange")
+                  (step === 50 && tokenPrefix === "orange") ||
+                  (step === 50 && tokenPrefix === "blue") ||
+                  (step === 50 && tokenPrefix === "indigo")
                     ? `1px solid ${theme.palette.border.light}`
                     : "none",
               }}

--- a/Clients/src/presentation/pages/StyleGuide/sections/ColorsSection.tsx
+++ b/Clients/src/presentation/pages/StyleGuide/sections/ColorsSection.tsx
@@ -1,7 +1,7 @@
 import React, { useState } from "react";
 import { Box, Stack, Typography, useTheme, Divider, Snackbar } from "@mui/material";
 import { Copy } from "lucide-react";
-import { grey, green, red, amber } from "../../../themes/primitives";
+import { grey, green, red, amber, deepOrange } from "../../../themes/primitives";
 
 const ColorsSection: React.FC = () => {
   const theme = useTheme();
@@ -115,6 +115,26 @@ const ColorsSection: React.FC = () => {
               Red
             </Typography>
             <PrimitiveScale name="Red" scale={red} tokenPrefix="red" onCopy={handleCopy} />
+          </Box>
+          <Box>
+            <Typography
+              sx={{
+                fontSize: 12,
+                fontWeight: 600,
+                color: theme.palette.text.secondary,
+                mb: "12px",
+                textTransform: "uppercase",
+                letterSpacing: "0.5px",
+              }}
+            >
+              Deep orange
+            </Typography>
+            <PrimitiveScale
+              name="Deep orange"
+              scale={deepOrange}
+              tokenPrefix="deepOrange"
+              onCopy={handleCopy}
+            />
           </Box>
           <Box>
             <Typography
@@ -709,6 +729,7 @@ const ColorsSection: React.FC = () => {
             "Grey primitives power text, border, and background tokens",
             "Green primitives power brand, success, and accent tokens",
             "Red primitives power error and critical risk tokens",
+            "Deep orange primitives power high risk and major severity tokens",
             "Amber primitives power warning, medium risk, and accent.amber tokens",
             "Access semantics via theme.palette.* — never hardcode hex in components",
             "Border color theme.palette.border.dark should be used for input borders",

--- a/Clients/src/presentation/pages/StyleGuide/sections/ColorsSection.tsx
+++ b/Clients/src/presentation/pages/StyleGuide/sections/ColorsSection.tsx
@@ -1,6 +1,7 @@
 import React, { useState } from "react";
 import { Box, Stack, Typography, useTheme, Divider, Snackbar } from "@mui/material";
 import { Copy } from "lucide-react";
+import { grey, green } from "../../../themes/primitives";
 
 const ColorsSection: React.FC = () => {
   const theme = useTheme();
@@ -41,12 +42,69 @@ const ColorsSection: React.FC = () => {
             maxWidth: 600,
           }}
         >
-          The VerifyWise color palette. All colors are defined in the theme and should be accessed
-          via theme.palette. Click any color to copy its hex value.
+          The VerifyWise color system: primitive ramps in{" "}
+          <Box component="span" sx={{ fontFamily: "monospace", fontSize: 13 }}>
+            themes/primitives.ts
+          </Box>
+          , semantic tokens in{" "}
+          <Box component="span" sx={{ fontFamily: "monospace", fontSize: 13 }}>
+            themes/palette.ts
+          </Box>
+          . Click any swatch to copy its hex value.
         </Typography>
       </Box>
 
-      {/* Primary Colors */}
+      {/* Color primitives */}
+      <SpecSection title="Color primitives">
+        <Typography sx={{ fontSize: 13, color: theme.palette.text.tertiary, mb: "24px" }}>
+          Source-of-truth ramps from{" "}
+          <Box component="span" sx={{ fontFamily: "monospace", fontSize: 13 }}>
+            themes/primitives.ts
+          </Box>
+          . Semantic tokens in palette.ts reference these steps.
+        </Typography>
+        <Box
+          sx={{
+            display: "flex",
+            flexWrap: "wrap",
+            gap: "48px",
+            alignItems: "flex-start",
+          }}
+        >
+          <Box>
+            <Typography
+              sx={{
+                fontSize: 12,
+                fontWeight: 600,
+                color: theme.palette.text.secondary,
+                mb: "12px",
+                textTransform: "uppercase",
+                letterSpacing: "0.5px",
+              }}
+            >
+              Grey
+            </Typography>
+            <PrimitiveScale name="Grey" scale={grey} tokenPrefix="grey" onCopy={handleCopy} />
+          </Box>
+          <Box>
+            <Typography
+              sx={{
+                fontSize: 12,
+                fontWeight: 600,
+                color: theme.palette.text.secondary,
+                mb: "12px",
+                textTransform: "uppercase",
+                letterSpacing: "0.5px",
+              }}
+            >
+              Green
+            </Typography>
+            <PrimitiveScale name="Green" scale={green} tokenPrefix="green" onCopy={handleCopy} />
+          </Box>
+        </Box>
+      </SpecSection>
+
+      <Divider sx={{ my: "32px" }} />
       <SpecSection title="Primary colors">
         <Typography sx={{ fontSize: 13, color: theme.palette.text.tertiary, mb: "24px" }}>
           Main brand colors used for primary actions and key UI elements.
@@ -617,11 +675,11 @@ const ColorsSection: React.FC = () => {
         </Typography>
         <Stack spacing="8px">
           {[
-            "Always use theme.palette.* for colors - never hardcode hex values",
-            "Primary green #13715B is the main brand color",
-            "Border color #d0d5dd should be used for all input borders",
-            "Use status colors for feedback (success, error, warning)",
-            "Background colors have semantic meanings - use appropriately",
+            "Define hex values only in themes/primitives.ts — use palette.ts semantics in components",
+            "Grey primitives power text, border, and background tokens",
+            "Green primitives power brand, success, and accent tokens",
+            "Access semantics via theme.palette.* — never hardcode hex in components",
+            "Border color theme.palette.border.dark should be used for input borders",
             "Text hierarchy: primary > secondary > tertiary > accent",
           ].map((item, index) => (
             <Box
@@ -654,6 +712,109 @@ const ColorsSection: React.FC = () => {
 };
 
 // Helper Components
+
+const PrimitiveScale: React.FC<{
+  name: string;
+  scale: Record<number, string>;
+  tokenPrefix: string;
+  onCopy: (text: string) => void;
+}> = ({ name, scale, tokenPrefix, onCopy }) => {
+  const theme = useTheme();
+  const steps = Object.keys(scale)
+    .map(Number)
+    .sort((a, b) => a - b);
+
+  return (
+    <Stack spacing="6px" sx={{ width: 240 }}>
+      {steps.map((step) => {
+        const color = scale[step as keyof typeof scale];
+
+        return (
+          <Box
+            key={step}
+            onClick={() => onCopy(color)}
+            sx={{
+              "display": "flex",
+              "alignItems": "center",
+              "gap": "10px",
+              "px": "8px",
+              "py": "6px",
+              "borderRadius": "4px",
+              "border": `1px solid ${theme.palette.background.hover}`,
+              "cursor": "pointer",
+              "backgroundColor": theme.palette.background.main,
+              "transition": "border-color 150ms ease, background-color 150ms ease",
+              "&:hover": {
+                borderColor: theme.palette.border.light,
+                backgroundColor: theme.palette.background.alt,
+              },
+              "&:hover .primitive-copy-icon": {
+                opacity: 1,
+              },
+            }}
+          >
+            <Box
+              sx={{
+                width: 32,
+                height: 32,
+                flexShrink: 0,
+                borderRadius: "4px",
+                backgroundColor: color,
+                border:
+                  step === 50 && tokenPrefix === "grey"
+                    ? `1px solid ${theme.palette.border.light}`
+                    : "none",
+              }}
+            />
+            <Box sx={{ minWidth: 0, flex: 1 }}>
+              <Typography
+                sx={{
+                  fontSize: 12,
+                  fontWeight: 600,
+                  color: theme.palette.text.primary,
+                  lineHeight: 1.2,
+                }}
+              >
+                {name} {step}
+              </Typography>
+              <Typography
+                sx={{
+                  fontSize: 11,
+                  fontFamily: "monospace",
+                  color: theme.palette.text.accent,
+                  lineHeight: 1.3,
+                }}
+              >
+                {color}
+              </Typography>
+              <Typography
+                sx={{
+                  fontSize: 10,
+                  fontFamily: "monospace",
+                  color: theme.palette.text.tertiary,
+                  lineHeight: 1.3,
+                }}
+              >
+                {tokenPrefix}[{step}]
+              </Typography>
+            </Box>
+            <Box
+              className="primitive-copy-icon"
+              sx={{
+                color: theme.palette.text.secondary,
+                opacity: 0,
+                transition: "opacity 150ms ease",
+                flexShrink: 0,
+              }}
+            >
+              <Copy size={14} />
+            </Box>
+          </Box>
+        );
+      })}
+    </Stack>
+  );
+};
 
 const SpecSection: React.FC<{ title: string; children: React.ReactNode }> = ({
   title,

--- a/Clients/src/presentation/themes/index.ts
+++ b/Clients/src/presentation/themes/index.ts
@@ -9,7 +9,7 @@ export { default as singleTheme } from "./v1SingleTheme";
 export { alertStyles } from "./alerts";
 export { tableStyles } from "./tables";
 export { palette, default as colorPalette } from "./palette";
-export { grey, green, red, default as grayScale } from "./primitives";
+export { grey, green, red, amber, default as grayScale } from "./primitives";
 
 export * from "./mixins";
 export * from "./components";

--- a/Clients/src/presentation/themes/index.ts
+++ b/Clients/src/presentation/themes/index.ts
@@ -9,7 +9,7 @@ export { default as singleTheme } from "./v1SingleTheme";
 export { alertStyles } from "./alerts";
 export { tableStyles } from "./tables";
 export { palette, default as colorPalette } from "./palette";
-export { grey, default as grayScale } from "./primitives";
+export { grey, green, default as grayScale } from "./primitives";
 
 export * from "./mixins";
 export * from "./components";

--- a/Clients/src/presentation/themes/index.ts
+++ b/Clients/src/presentation/themes/index.ts
@@ -9,7 +9,7 @@ export { default as singleTheme } from "./v1SingleTheme";
 export { alertStyles } from "./alerts";
 export { tableStyles } from "./tables";
 export { palette, default as colorPalette } from "./palette";
-export { grey, green, default as grayScale } from "./primitives";
+export { grey, green, red, default as grayScale } from "./primitives";
 
 export * from "./mixins";
 export * from "./components";

--- a/Clients/src/presentation/themes/index.ts
+++ b/Clients/src/presentation/themes/index.ts
@@ -9,7 +9,7 @@ export { default as singleTheme } from "./v1SingleTheme";
 export { alertStyles } from "./alerts";
 export { tableStyles } from "./tables";
 export { palette, default as colorPalette } from "./palette";
-export { grey, green, red, amber, deepOrange, default as grayScale } from "./primitives";
+export { grey, green, red, amber, orange, default as grayScale } from "./primitives";
 
 export * from "./mixins";
 export * from "./components";

--- a/Clients/src/presentation/themes/index.ts
+++ b/Clients/src/presentation/themes/index.ts
@@ -18,6 +18,8 @@ export {
   blue,
   indigo,
   purple,
+  teal,
+  pink,
   default as grayScale,
 } from "./primitives";
 

--- a/Clients/src/presentation/themes/index.ts
+++ b/Clients/src/presentation/themes/index.ts
@@ -9,7 +9,7 @@ export { default as singleTheme } from "./v1SingleTheme";
 export { alertStyles } from "./alerts";
 export { tableStyles } from "./tables";
 export { palette, default as colorPalette } from "./palette";
-export { grey, green, red, amber, orange, default as grayScale } from "./primitives";
+export { grey, green, red, amber, orange, blue, indigo, default as grayScale } from "./primitives";
 
 export * from "./mixins";
 export * from "./components";

--- a/Clients/src/presentation/themes/index.ts
+++ b/Clients/src/presentation/themes/index.ts
@@ -9,7 +9,17 @@ export { default as singleTheme } from "./v1SingleTheme";
 export { alertStyles } from "./alerts";
 export { tableStyles } from "./tables";
 export { palette, default as colorPalette } from "./palette";
-export { grey, green, red, amber, orange, blue, indigo, default as grayScale } from "./primitives";
+export {
+  grey,
+  green,
+  red,
+  amber,
+  orange,
+  blue,
+  indigo,
+  purple,
+  default as grayScale,
+} from "./primitives";
 
 export * from "./mixins";
 export * from "./components";

--- a/Clients/src/presentation/themes/index.ts
+++ b/Clients/src/presentation/themes/index.ts
@@ -9,6 +9,7 @@ export { default as singleTheme } from "./v1SingleTheme";
 export { alertStyles } from "./alerts";
 export { tableStyles } from "./tables";
 export { palette, default as colorPalette } from "./palette";
+export { grey, default as grayScale } from "./primitives";
 
 export * from "./mixins";
 export * from "./components";

--- a/Clients/src/presentation/themes/index.ts
+++ b/Clients/src/presentation/themes/index.ts
@@ -9,7 +9,7 @@ export { default as singleTheme } from "./v1SingleTheme";
 export { alertStyles } from "./alerts";
 export { tableStyles } from "./tables";
 export { palette, default as colorPalette } from "./palette";
-export { grey, green, red, amber, default as grayScale } from "./primitives";
+export { grey, green, red, amber, deepOrange, default as grayScale } from "./primitives";
 
 export * from "./mixins";
 export * from "./components";

--- a/Clients/src/presentation/themes/palette.ts
+++ b/Clients/src/presentation/themes/palette.ts
@@ -4,10 +4,8 @@
  * Single source of truth for ALL colors across every module:
  * Governance, LLM Evals, AI Detection, Shadow AI, Model Inventory.
  *
- * Design philosophy: calm, pastel backgrounds with muted text —
- * derived from the Chip component's proven palette. All status,
- * risk, chart, and accent colors live here so every module stays
- * visually coherent.
+ * Grey tokens derive from primitives.ts.
+ * Status, risk, accent, brand, and chart hues remain here until their scales are defined.
  *
  * Usage:
  *   import { palette } from '@/presentation/themes/palette';
@@ -15,6 +13,8 @@
  *
  * Migration guide: see /docs/COLOR_MIGRATION.md
  */
+
+import { grey } from "./primitives";
 
 // ---------------------------------------------------------------------------
 // 1. Semantic status colors (success / error / warning / info / default)
@@ -26,7 +26,7 @@ export const status = {
   error: { bg: "#FFD6D6", text: "#D32F2F", border: "#F5B8B8" },
   warning: { bg: "#FFF8E1", text: "#795548", border: "#F5E6B8" },
   info: { bg: "#E3F2FD", text: "#1565C0", border: "#BBDEFB" },
-  default: { bg: "#F3F4F6", text: "#6B7280", border: "#E5E7EB" },
+  default: { bg: grey[100], text: grey[500], border: grey[200] },
 } as const;
 
 // ---------------------------------------------------------------------------
@@ -88,19 +88,19 @@ export const chart = [
 ] as const;
 
 // ---------------------------------------------------------------------------
-// 6. Text hierarchy (from theme — repeated here for palette completeness)
+// 6. Text hierarchy (Figma grey scale)
 // ---------------------------------------------------------------------------
 
 export const text = {
-  primary: "#1c2130",
-  secondary: "#344054",
-  tertiary: "#475467",
-  accent: "#838c99",
-  disabled: "#9CA3AF",
-  black: "#000000",
-  icon: "#667085",
-  muted: "#98A2B3",
-  subdued: "#616161",
+  primary: grey[900],
+  secondary: grey[700],
+  tertiary: grey[600],
+  accent: grey[400],
+  disabled: grey[350],
+  black: grey[950],
+  icon: grey[450],
+  muted: grey[600],
+  subdued: grey[450],
 } as const;
 
 // ---------------------------------------------------------------------------
@@ -108,24 +108,24 @@ export const text = {
 // ---------------------------------------------------------------------------
 
 export const background = {
-  main: "#FFFFFF",
-  alt: "#FCFCFD",
-  modal: "#FCFCFD",
+  main: grey[50],
+  alt: grey[100],
+  modal: grey[100],
   fill: "#E6F0EC",
-  accent: "#f9fafb",
-  hover: "#F3F4F6",
+  accent: grey[100],
+  hover: grey[150],
   selected: "#E6F0EC",
-  surface: "#f5f5f5",
+  surface: grey[150],
   gradientStop: "#f8fafc",
 } as const;
 
 // ---------------------------------------------------------------------------
-// 8. Borders
+// 8. Borders (Figma grey scale)
 // ---------------------------------------------------------------------------
 
 export const border = {
-  light: "#eaecf0",
-  dark: "#d0d5dd",
+  light: grey[200],
+  dark: grey[300],
 } as const;
 
 // ---------------------------------------------------------------------------

--- a/Clients/src/presentation/themes/palette.ts
+++ b/Clients/src/presentation/themes/palette.ts
@@ -4,7 +4,7 @@
  * Single source of truth for ALL colors across every module:
  * Governance, LLM Evals, AI Detection, Shadow AI, Model Inventory.
  *
- * Grey and green tokens derive from primitives.ts.
+ * Grey, green, and red tokens derive from primitives.ts.
  * Other status, risk, accent, and chart hues remain here until their scales are defined.
  *
  * Usage:
@@ -14,7 +14,7 @@
  * Migration guide: see /docs/COLOR_MIGRATION.md
  */
 
-import { grey, green } from "./primitives";
+import { grey, green, red } from "./primitives";
 
 // ---------------------------------------------------------------------------
 // 1. Semantic status colors (success / error / warning / info / default)
@@ -23,7 +23,7 @@ import { grey, green } from "./primitives";
 
 export const status = {
   success: { bg: green[200], text: green[600], border: green[300] },
-  error: { bg: "#FFD6D6", text: "#D32F2F", border: "#F5B8B8" },
+  error: { bg: red[200], text: red[500], border: red[300] },
   warning: { bg: "#FFF8E1", text: "#795548", border: "#F5E6B8" },
   info: { bg: "#E3F2FD", text: "#1565C0", border: "#BBDEFB" },
   default: { bg: grey[100], text: grey[500], border: grey[200] },
@@ -35,7 +35,7 @@ export const status = {
 // ---------------------------------------------------------------------------
 
 export const risk = {
-  critical: { bg: "#FFD6D6", text: "#D32F2F", border: "#F5B8B8" },
+  critical: { bg: red[200], text: red[500], border: red[300] },
   high: { bg: "#FFE5D0", text: "#E64A19", border: "#F5CDB0" },
   medium: { bg: "#FFF8E1", text: "#795548", border: "#F5E6B8" },
   low: { bg: green[200], text: green[600], border: green[300] },

--- a/Clients/src/presentation/themes/palette.ts
+++ b/Clients/src/presentation/themes/palette.ts
@@ -4,7 +4,7 @@
  * Single source of truth for ALL colors across every module:
  * Governance, LLM Evals, AI Detection, Shadow AI, Model Inventory.
  *
- * Grey, green, and red tokens derive from primitives.ts.
+ * Grey, green, red, and amber tokens derive from primitives.ts.
  * Other status, risk, accent, and chart hues remain here until their scales are defined.
  *
  * Usage:
@@ -14,7 +14,7 @@
  * Migration guide: see /docs/COLOR_MIGRATION.md
  */
 
-import { grey, green, red } from "./primitives";
+import { grey, green, red, amber } from "./primitives";
 
 // ---------------------------------------------------------------------------
 // 1. Semantic status colors (success / error / warning / info / default)
@@ -24,7 +24,7 @@ import { grey, green, red } from "./primitives";
 export const status = {
   success: { bg: green[200], text: green[600], border: green[300] },
   error: { bg: red[200], text: red[500], border: red[300] },
-  warning: { bg: "#FFF8E1", text: "#795548", border: "#F5E6B8" },
+  warning: { bg: amber[100], text: amber[600], border: amber[200] },
   info: { bg: "#E3F2FD", text: "#1565C0", border: "#BBDEFB" },
   default: { bg: grey[100], text: grey[500], border: grey[200] },
 } as const;
@@ -37,7 +37,7 @@ export const status = {
 export const risk = {
   critical: { bg: red[200], text: red[500], border: red[300] },
   high: { bg: "#FFE5D0", text: "#E64A19", border: "#F5CDB0" },
-  medium: { bg: "#FFF8E1", text: "#795548", border: "#F5E6B8" },
+  medium: { bg: amber[100], text: amber[600], border: amber[200] },
   low: { bg: green[200], text: green[600], border: green[300] },
   veryLow: { bg: "#E0F7FA", text: "#00695C", border: "#B2EBF2" },
 } as const;
@@ -67,7 +67,7 @@ export const accent = {
   teal: { bg: "#E0F2F1", text: "#00695C", border: "#B2DFDB" },
   blue: { bg: "#E3F2FD", text: "#1565C0", border: "#BBDEFB" },
   pink: { bg: "#FCE4EC", text: "#AD1457", border: "#F8BBD0" },
-  amber: { bg: "#FFF8E1", text: "#FF8F00", border: "#FFECB3" },
+  amber: { bg: amber[100], text: amber[700], border: amber[200] },
 } as const;
 
 // ---------------------------------------------------------------------------

--- a/Clients/src/presentation/themes/palette.ts
+++ b/Clients/src/presentation/themes/palette.ts
@@ -4,7 +4,7 @@
  * Single source of truth for ALL colors across every module:
  * Governance, LLM Evals, AI Detection, Shadow AI, Model Inventory.
  *
- * Grey, green, red, and amber tokens derive from primitives.ts.
+ * Grey, green, red, amber, and deepOrange tokens derive from primitives.ts.
  * Other status, risk, accent, and chart hues remain here until their scales are defined.
  *
  * Usage:
@@ -14,7 +14,7 @@
  * Migration guide: see /docs/COLOR_MIGRATION.md
  */
 
-import { grey, green, red, amber } from "./primitives";
+import { grey, green, red, amber, deepOrange } from "./primitives";
 
 // ---------------------------------------------------------------------------
 // 1. Semantic status colors (success / error / warning / info / default)
@@ -36,7 +36,7 @@ export const status = {
 
 export const risk = {
   critical: { bg: red[200], text: red[500], border: red[300] },
-  high: { bg: "#FFE5D0", text: "#E64A19", border: "#F5CDB0" },
+  high: { bg: deepOrange[100], text: deepOrange[600], border: deepOrange[200] },
   medium: { bg: amber[100], text: amber[600], border: amber[200] },
   low: { bg: green[200], text: green[600], border: green[300] },
   veryLow: { bg: "#E0F7FA", text: "#00695C", border: "#B2EBF2" },

--- a/Clients/src/presentation/themes/palette.ts
+++ b/Clients/src/presentation/themes/palette.ts
@@ -4,7 +4,8 @@
  * Single source of truth for ALL colors across every module:
  * Governance, LLM Evals, AI Detection, Shadow AI, Model Inventory.
  *
- * Grey, green, red, amber, orange, blue, indigo, and purple tokens derive from primitives.ts.
+ * Grey, green, red, amber, orange, blue, indigo, purple, teal, and pink tokens
+ * derive from primitives.ts.
  * Other status, risk, accent, and chart hues remain here until their scales are defined.
  *
  * Usage:
@@ -14,7 +15,7 @@
  * Migration guide: see /docs/COLOR_MIGRATION.md
  */
 
-import { grey, green, red, amber, orange, blue, indigo, purple } from "./primitives";
+import { grey, green, red, amber, orange, blue, indigo, purple, teal, pink } from "./primitives";
 
 // ---------------------------------------------------------------------------
 // 1. Semantic status colors (success / error / warning / info / default)
@@ -64,9 +65,9 @@ export const accent = {
   indigo: { bg: indigo[50], text: indigo[600], border: indigo[100] },
   purple: { bg: purple[50], text: purple[600], border: purple[100] },
   orange: { bg: orange[50], text: orange[600], border: orange[200] },
-  teal: { bg: "#E0F2F1", text: "#00695C", border: "#B2DFDB" },
+  teal: { bg: teal[50], text: teal[800], border: teal[100] },
   blue: { bg: blue[50], text: blue[800], border: blue[100] },
-  pink: { bg: "#FCE4EC", text: "#AD1457", border: "#F8BBD0" },
+  pink: { bg: pink[50], text: pink[800], border: pink[100] },
   amber: { bg: amber[100], text: amber[700], border: amber[200] },
 } as const;
 

--- a/Clients/src/presentation/themes/palette.ts
+++ b/Clients/src/presentation/themes/palette.ts
@@ -4,7 +4,7 @@
  * Single source of truth for ALL colors across every module:
  * Governance, LLM Evals, AI Detection, Shadow AI, Model Inventory.
  *
- * Grey, green, red, amber, and orange tokens derive from primitives.ts.
+ * Grey, green, red, amber, orange, blue, and indigo tokens derive from primitives.ts.
  * Other status, risk, accent, and chart hues remain here until their scales are defined.
  *
  * Usage:
@@ -14,7 +14,7 @@
  * Migration guide: see /docs/COLOR_MIGRATION.md
  */
 
-import { grey, green, red, amber, orange } from "./primitives";
+import { grey, green, red, amber, orange, blue, indigo } from "./primitives";
 
 // ---------------------------------------------------------------------------
 // 1. Semantic status colors (success / error / warning / info / default)
@@ -25,7 +25,7 @@ export const status = {
   success: { bg: green[200], text: green[600], border: green[300] },
   error: { bg: red[200], text: red[500], border: red[300] },
   warning: { bg: amber[100], text: amber[600], border: amber[200] },
-  info: { bg: "#E3F2FD", text: "#1565C0", border: "#BBDEFB" },
+  info: { bg: blue[50], text: blue[800], border: blue[100] },
   default: { bg: grey[100], text: grey[500], border: grey[200] },
 } as const;
 
@@ -61,11 +61,11 @@ export const severity = {
 
 export const accent = {
   primary: { bg: green[100], text: green[700], border: green[400] },
-  indigo: { bg: "#E8EAF6", text: "#3949AB", border: "#C5CAE9" },
+  indigo: { bg: indigo[50], text: indigo[600], border: indigo[100] },
   purple: { bg: "#EDE7F6", text: "#5E35B1", border: "#D1C4E9" },
   orange: { bg: orange[50], text: orange[600], border: orange[200] },
   teal: { bg: "#E0F2F1", text: "#00695C", border: "#B2DFDB" },
-  blue: { bg: "#E3F2FD", text: "#1565C0", border: "#BBDEFB" },
+  blue: { bg: blue[50], text: blue[800], border: blue[100] },
   pink: { bg: "#FCE4EC", text: "#AD1457", border: "#F8BBD0" },
   amber: { bg: amber[100], text: amber[700], border: amber[200] },
 } as const;

--- a/Clients/src/presentation/themes/palette.ts
+++ b/Clients/src/presentation/themes/palette.ts
@@ -4,7 +4,7 @@
  * Single source of truth for ALL colors across every module:
  * Governance, LLM Evals, AI Detection, Shadow AI, Model Inventory.
  *
- * Grey, green, red, amber, orange, blue, and indigo tokens derive from primitives.ts.
+ * Grey, green, red, amber, orange, blue, indigo, and purple tokens derive from primitives.ts.
  * Other status, risk, accent, and chart hues remain here until their scales are defined.
  *
  * Usage:
@@ -14,7 +14,7 @@
  * Migration guide: see /docs/COLOR_MIGRATION.md
  */
 
-import { grey, green, red, amber, orange, blue, indigo } from "./primitives";
+import { grey, green, red, amber, orange, blue, indigo, purple } from "./primitives";
 
 // ---------------------------------------------------------------------------
 // 1. Semantic status colors (success / error / warning / info / default)
@@ -62,7 +62,7 @@ export const severity = {
 export const accent = {
   primary: { bg: green[100], text: green[700], border: green[400] },
   indigo: { bg: indigo[50], text: indigo[600], border: indigo[100] },
-  purple: { bg: "#EDE7F6", text: "#5E35B1", border: "#D1C4E9" },
+  purple: { bg: purple[50], text: purple[600], border: purple[100] },
   orange: { bg: orange[50], text: orange[600], border: orange[200] },
   teal: { bg: "#E0F2F1", text: "#00695C", border: "#B2DFDB" },
   blue: { bg: blue[50], text: blue[800], border: blue[100] },

--- a/Clients/src/presentation/themes/palette.ts
+++ b/Clients/src/presentation/themes/palette.ts
@@ -4,8 +4,8 @@
  * Single source of truth for ALL colors across every module:
  * Governance, LLM Evals, AI Detection, Shadow AI, Model Inventory.
  *
- * Grey tokens derive from primitives.ts.
- * Status, risk, accent, brand, and chart hues remain here until their scales are defined.
+ * Grey and green tokens derive from primitives.ts.
+ * Other status, risk, accent, and chart hues remain here until their scales are defined.
  *
  * Usage:
  *   import { palette } from '@/presentation/themes/palette';
@@ -14,7 +14,7 @@
  * Migration guide: see /docs/COLOR_MIGRATION.md
  */
 
-import { grey } from "./primitives";
+import { grey, green } from "./primitives";
 
 // ---------------------------------------------------------------------------
 // 1. Semantic status colors (success / error / warning / info / default)
@@ -22,7 +22,7 @@ import { grey } from "./primitives";
 // ---------------------------------------------------------------------------
 
 export const status = {
-  success: { bg: "#E6F4EA", text: "#138A5E", border: "#C8E6D0" },
+  success: { bg: green[200], text: green[600], border: green[300] },
   error: { bg: "#FFD6D6", text: "#D32F2F", border: "#F5B8B8" },
   warning: { bg: "#FFF8E1", text: "#795548", border: "#F5E6B8" },
   info: { bg: "#E3F2FD", text: "#1565C0", border: "#BBDEFB" },
@@ -38,7 +38,7 @@ export const risk = {
   critical: { bg: "#FFD6D6", text: "#D32F2F", border: "#F5B8B8" },
   high: { bg: "#FFE5D0", text: "#E64A19", border: "#F5CDB0" },
   medium: { bg: "#FFF8E1", text: "#795548", border: "#F5E6B8" },
-  low: { bg: "#E6F4EA", text: "#138A5E", border: "#C8E6D0" },
+  low: { bg: green[200], text: green[600], border: green[300] },
   veryLow: { bg: "#E0F7FA", text: "#00695C", border: "#B2EBF2" },
 } as const;
 
@@ -60,7 +60,7 @@ export const severity = {
 // ---------------------------------------------------------------------------
 
 export const accent = {
-  primary: { bg: "#E6F0EC", text: "#13715B", border: "#C2DDD3" },
+  primary: { bg: green[100], text: green[700], border: green[400] },
   indigo: { bg: "#E8EAF6", text: "#3949AB", border: "#C5CAE9" },
   purple: { bg: "#EDE7F6", text: "#5E35B1", border: "#D1C4E9" },
   orange: { bg: "#FFF3E0", text: "#E65100", border: "#FFE0B2" },
@@ -111,10 +111,10 @@ export const background = {
   main: grey[50],
   alt: grey[100],
   modal: grey[100],
-  fill: "#E6F0EC",
+  fill: green[100],
   accent: grey[100],
   hover: grey[150],
-  selected: "#E6F0EC",
+  selected: green[100],
   surface: grey[150],
   gradientStop: "#f8fafc",
 } as const;
@@ -133,10 +133,10 @@ export const border = {
 // ---------------------------------------------------------------------------
 
 export const brand = {
-  primary: "#13715B",
-  primaryHover: "#0F5A47",
-  primaryLight: "#E6F0EC",
-  primaryDark: "#10614d",
+  primary: green[700],
+  primaryHover: green[900],
+  primaryLight: green[100],
+  primaryDark: green[800],
 } as const;
 
 // ---------------------------------------------------------------------------

--- a/Clients/src/presentation/themes/palette.ts
+++ b/Clients/src/presentation/themes/palette.ts
@@ -4,7 +4,7 @@
  * Single source of truth for ALL colors across every module:
  * Governance, LLM Evals, AI Detection, Shadow AI, Model Inventory.
  *
- * Grey, green, red, amber, and deepOrange tokens derive from primitives.ts.
+ * Grey, green, red, amber, and orange tokens derive from primitives.ts.
  * Other status, risk, accent, and chart hues remain here until their scales are defined.
  *
  * Usage:
@@ -14,7 +14,7 @@
  * Migration guide: see /docs/COLOR_MIGRATION.md
  */
 
-import { grey, green, red, amber, deepOrange } from "./primitives";
+import { grey, green, red, amber, orange } from "./primitives";
 
 // ---------------------------------------------------------------------------
 // 1. Semantic status colors (success / error / warning / info / default)
@@ -36,7 +36,7 @@ export const status = {
 
 export const risk = {
   critical: { bg: red[200], text: red[500], border: red[300] },
-  high: { bg: deepOrange[100], text: deepOrange[600], border: deepOrange[200] },
+  high: { bg: orange[100], text: orange[600], border: orange[200] },
   medium: { bg: amber[100], text: amber[600], border: amber[200] },
   low: { bg: green[200], text: green[600], border: green[300] },
   veryLow: { bg: "#E0F7FA", text: "#00695C", border: "#B2EBF2" },
@@ -63,7 +63,7 @@ export const accent = {
   primary: { bg: green[100], text: green[700], border: green[400] },
   indigo: { bg: "#E8EAF6", text: "#3949AB", border: "#C5CAE9" },
   purple: { bg: "#EDE7F6", text: "#5E35B1", border: "#D1C4E9" },
-  orange: { bg: "#FFF3E0", text: "#E65100", border: "#FFE0B2" },
+  orange: { bg: orange[50], text: orange[600], border: orange[200] },
   teal: { bg: "#E0F2F1", text: "#00695C", border: "#B2DFDB" },
   blue: { bg: "#E3F2FD", text: "#1565C0", border: "#BBDEFB" },
   pink: { bg: "#FCE4EC", text: "#AD1457", border: "#F8BBD0" },

--- a/Clients/src/presentation/themes/primitives.ts
+++ b/Clients/src/presentation/themes/primitives.ts
@@ -41,4 +41,16 @@ export const green = {
 
 export type GreenStep = keyof typeof green;
 
+/**
+ * Error red ramp (partial): 50 (subtle tint) → 500 (main).
+ */
+export const red = {
+  50: "#FEF2F2",
+  200: "#FFD6D6",
+  300: "#F5B8B8",
+  500: "#D32F2F",
+} as const;
+
+export type RedStep = keyof typeof red;
+
 export default grey;

--- a/Clients/src/presentation/themes/primitives.ts
+++ b/Clients/src/presentation/themes/primitives.ts
@@ -91,4 +91,13 @@ export const indigo = {
 
 export type IndigoStep = keyof typeof indigo;
 
+/** Accent purple ramp */
+export const purple = {
+  50: "#EDE7F6",
+  100: "#D1C4E9",
+  600: "#5E35B1",
+} as const;
+
+export type PurpleStep = keyof typeof purple;
+
 export default grey;

--- a/Clients/src/presentation/themes/primitives.ts
+++ b/Clients/src/presentation/themes/primitives.ts
@@ -63,4 +63,13 @@ export const amber = {
 
 export type AmberStep = keyof typeof amber;
 
+/** High risk — peach / deep orange */
+export const deepOrange = {
+  100: "#FFE5D0",
+  200: "#F5CDB0",
+  600: "#E64A19",
+} as const;
+
+export type DeepOrangeStep = keyof typeof deepOrange;
+
 export default grey;

--- a/Clients/src/presentation/themes/primitives.ts
+++ b/Clients/src/presentation/themes/primitives.ts
@@ -100,4 +100,22 @@ export const purple = {
 
 export type PurpleStep = keyof typeof purple;
 
+/** Accent teal ramp */
+export const teal = {
+  50: "#E0F2F1",
+  100: "#B2DFDB",
+  800: "#00695C",
+} as const;
+
+export type TealStep = keyof typeof teal;
+
+/** Accent pink ramp */
+export const pink = {
+  50: "#FCE4EC",
+  100: "#F8BBD0",
+  800: "#AD1457",
+} as const;
+
+export type PinkStep = keyof typeof pink;
+
 export default grey;

--- a/Clients/src/presentation/themes/primitives.ts
+++ b/Clients/src/presentation/themes/primitives.ts
@@ -73,4 +73,22 @@ export const orange = {
 
 export type OrangeStep = keyof typeof orange;
 
+/** Info and accent.blue — blue ramp */
+export const blue = {
+  50: "#E3F2FD",
+  100: "#BBDEFB",
+  800: "#1565C0",
+} as const;
+
+export type BlueStep = keyof typeof blue;
+
+/** Accent indigo ramp */
+export const indigo = {
+  50: "#E8EAF6",
+  100: "#C5CAE9",
+  600: "#3949AB",
+} as const;
+
+export type IndigoStep = keyof typeof indigo;
+
 export default grey;

--- a/Clients/src/presentation/themes/primitives.ts
+++ b/Clients/src/presentation/themes/primitives.ts
@@ -1,0 +1,28 @@
+/**
+ * VerifyWise grey scale primitives
+ *
+ * Hex literals for the grey ramp live here only.
+ * Status, brand, and accent hues remain in palette.ts until their scales are defined.
+ */
+
+/** Grey ramp: 50 (lightest) → 950 (black) */
+export const grey = {
+  50: "#FFFFFF",
+  100: "#F9FAFB",
+  150: "#F3F4F6",
+  200: "#E5E7EB",
+  300: "#D0D5DD",
+  350: "#9CA3AF",
+  400: "#838C99",
+  450: "#667085",
+  500: "#6B7280",
+  600: "#475467",
+  700: "#344054",
+  800: "#1F2937",
+  900: "#1C2130",
+  950: "#000000",
+} as const;
+
+export type GreyStep = keyof typeof grey;
+
+export default grey;

--- a/Clients/src/presentation/themes/primitives.ts
+++ b/Clients/src/presentation/themes/primitives.ts
@@ -63,13 +63,14 @@ export const amber = {
 
 export type AmberStep = keyof typeof amber;
 
-/** High risk — peach / deep orange */
-export const deepOrange = {
+/** High risk and accent.orange — orange ramp */
+export const orange = {
+  50: "#FFF4EB",
   100: "#FFE5D0",
   200: "#F5CDB0",
   600: "#E64A19",
 } as const;
 
-export type DeepOrangeStep = keyof typeof deepOrange;
+export type OrangeStep = keyof typeof orange;
 
 export default grey;

--- a/Clients/src/presentation/themes/primitives.ts
+++ b/Clients/src/presentation/themes/primitives.ts
@@ -1,8 +1,8 @@
 /**
- * VerifyWise grey scale primitives
+ * VerifyWise color primitives.
  *
- * Hex literals for the grey ramp live here only.
- * Status, brand, and accent hues remain in palette.ts until their scales are defined.
+ * Hex literals for color ramps live here only.
+ * Semantic tokens in palette.ts derive from these values.
  */
 
 /** Grey ramp: 50 (lightest) → 950 (black) */
@@ -24,5 +24,21 @@ export const grey = {
 } as const;
 
 export type GreyStep = keyof typeof grey;
+
+/** Brand green ramp: 50 (lightest) → 900 (darkest) */
+export const green = {
+  50: "#F0FDF4",
+  100: "#E6F0EC",
+  200: "#E6F4EA",
+  300: "#C8E6D0",
+  400: "#C2DDD3",
+  500: "#10B981",
+  600: "#138A5E",
+  700: "#13715B",
+  800: "#10614D",
+  900: "#0F5A47",
+} as const;
+
+export type GreenStep = keyof typeof green;
 
 export default grey;

--- a/Clients/src/presentation/themes/primitives.ts
+++ b/Clients/src/presentation/themes/primitives.ts
@@ -53,4 +53,14 @@ export const red = {
 
 export type RedStep = keyof typeof red;
 
+/** Warning / medium — amber surfaces with brown-toned text */
+export const amber = {
+  100: "#FFF8E1",
+  200: "#F5E6B8",
+  600: "#795548",
+  700: "#92400E",
+} as const;
+
+export type AmberStep = keyof typeof amber;
+
 export default grey;

--- a/docs/technical/guides/token-audit-orphan-map.md
+++ b/docs/technical/guides/token-audit-orphan-map.md
@@ -1,0 +1,53 @@
+# Token Audit — Orphan Map (Phase 1: Colors)
+
+> **Branch:** `feature/design-token-foundation`  
+> **Last updated:** 2026-07-09
+
+## Figma neutral scale (primitives)
+
+Source of truth: [`Clients/src/presentation/themes/primitives.ts`](../../Clients/src/presentation/themes/primitives.ts) (`grey` export)
+
+| Step | Hex | Semantic usage |
+|------|-----|----------------|
+| 50 | `#f9fafb` | `background.accent` |
+| 100 | `#F3F4F6` | `background.hover`, `status.default.bg` |
+| 200 | `#E5E7EB` | `border.light`, `status.default.border` |
+| 300 | `#d0d5dd` | `border.dark` |
+| 400 | `#99A1AF` | `text.muted`, `text.disabled` |
+| 500 | `#6B7280` | `text.icon`, `status.default.text` |
+| 600 | `#4b5563` | `text.tertiary`, `text.subdued` |
+| 700 | `#374151` | `text.secondary` |
+| 800 | `#1f2937` | — (available for emphasis) |
+| 900 | `#111827` | `text.primary` |
+| 950 | `#000000` | `text.black` |
+
+Status, risk, accent, brand, and chart hues are unchanged in `palette.ts` until their Figma scales are added.
+
+## Top orphan hex → token mapping
+
+Use **`palette.*`** in components (not raw hex or `neutral[n]` unless in theme files).
+
+| Orphan | Count (approx) | Primitive | Semantic token |
+|--------|----------------|-----------|----------------|
+| `#d0d5dd` | 117 | `neutral.300` | `palette.border.dark` |
+| `#666` / `#666666` | 106 | `neutral.600` | `palette.text.subdued` |
+| `#dc2626` | 57 | `red.500` | `palette.risk.critical.text` |
+| `#13715b` | 50 | `green.500` | `palette.brand.primary` |
+| `#fafafa` / `#f9fafb` | 50+ | `neutral.50` | `palette.background.accent` |
+| `#10b981` | 42 | `mint.500` | `palette.risk.low.text` |
+| `#ef4444` | 39 | `orange.500` | `palette.risk.high.text` |
+| `#f59e0b` | 38 | `brown.500` | `palette.risk.medium.text` |
+| `#eaecf0` / `#e0e4e9` | 64 | `neutral.200` | `palette.border.light` |
+| `#374151` / `#1f2937` / `#111827` | 80+ | `neutral.700–900` | `palette.text.secondary` / `primary` |
+| `#3b82f6` / `#4c7bf4` | 52 | `blue.500` | `palette.status.info.text` |
+| `#8b5cf6` | 21 | `purple.500` | `palette.accent.purple.text` |
+| `#92400e` | 31 | `brown.500` | `palette.status.warning.text` |
+| `#d32f2f` | 21 | `red.500` | `palette.status.error.text` |
+
+
+
+## Policy
+
+- No new hex greys or status colors in `presentation/` components.
+- New colors only via `primitives.ts` + design review.
+- Fonts, spacing, and border radius: deferred to Phases 2–4.


### PR DESCRIPTION
## Describe your changes

- Introduce closed color primitive ramps in `Clients/src/presentation/themes/primitives.ts` (`grey`, `green`, `red`, `amber`, `orange`, `blue`, `indigo`, `purple`, `teal`, `pink`).
- Refactor `palette.ts` so status, risk, accent, text, background, border, and brand tokens derive from those primitives instead of duplicated hex.
- Add Phase 1 orphan map (`docs/technical/guides/token-audit-orphan-map.md`) and StyleGuide color ramp display for the new primitives.

This is the **foundation PR only** — no chip/badge or page-level hex migration yet. Follow-up will migrate hardcoded colors to `palette.*`.


## Write your issue number after "Fixes "

Fixes #4268 

## Please ensure all items are checked off before requesting a review:

- [ ] I deployed the code locally.
- [ ] I have performed a self-review of my code.
- [ ] I have included the issue # in the PR.
- [ ] I have labelled the PR correctly.
- [ ] The issue I am working on is assigned to me.
- [ ] I have avoided using hardcoded values to ensure scalability and maintain consistency across the application.
- [ ] I have ensured that font sizes, color choices, and other UI elements are referenced from the theme.
- [ ] My pull request is focused and addresses a single, specific feature.
- [ ] If there are UI changes, I have attached a screenshot or video to this PR.
- [ ] If I added or modified an API endpoint, the change is reflected in the generated OpenAPI spec (`npm run generate:swagger`).
- [ ] If the endpoint requires authentication, it uses `authenticateJWT` and the generated spec declares `bearerAuth` security.
- [ ] I ran `npm run check:api-drift` and committed the regenerated `swagger.yaml` and `endpoints.ts`.
- [ ] If this PR adds or modifies an organization-scoped table, the [tenant isolation registry](Servers/tests/integration/tenant-isolation/tenantIsolation.registry.ts) and [test matrix](Servers/tests/integration/tenant-isolation) are updated. See the [tenant isolation runbook](docs/technical/security/tenant-isolation.md) for details.

<img width="2521" height="1224" alt="Screenshot 2026-07-14 at 12 34 58 PM" src="https://github.com/user-attachments/assets/87d68405-cafd-45d4-9cfc-6715b0bf6f2e" />
