### PR TITLE
fix(mrm): review follow-ups — sweep read caching, role query reuse, alert copy/logging

### DIFF
--- a/Clients/src/presentation/pages/ModelInventory/mrm/RetentionSection.tsx
+++ b/Clients/src/presentation/pages/ModelInventory/mrm/RetentionSection.tsx
@@ -3,15 +3,13 @@ import { Box, Typography } from "@mui/material";
 import { CustomizableButton } from "../../../components/button/customizable-button";
 import Field from "../../../components/Inputs/Field";
 import { useMrmSettings, useUpdateMrmSettings } from "../../../../application/hooks/useMrm";
-import { mrmErrorMessage } from "./constants";
+import { MIN_RETENTION_MONTHS, mrmErrorMessage } from "./constants";
 import { mrmSectionIntroStyle } from "./mrmStyles";
 
 interface RetentionSectionProps {
   onError: (message: string) => void;
   onSuccess: (message: string) => void;
 }
-
-const MIN_RETENTION_MONTHS = 13;
 
 const RetentionSection = ({ onError, onSuccess }: RetentionSectionProps) => {
   const { data: settings } = useMrmSettings();

--- a/Clients/src/presentation/pages/ModelInventory/mrm/constants.ts
+++ b/Clients/src/presentation/pages/ModelInventory/mrm/constants.ts
@@ -24,6 +24,9 @@ import {
 } from "../../../../domain/enums/mrm.enum";
 import { IMrmThreshold } from "../../../../domain/interfaces/i.mrm";
 
+/** Retention floor (months) — mirrors the server-enforced minimum (SR 26-2 / SS1/23 / OSFI E-23 examiner cycle + margin). */
+export const MIN_RETENTION_MONTHS = 13;
+
 // ---- Tier ----
 
 export const TIER_OPTIONS: { value: MrmTier; label: string }[] = [

--- a/Servers/controllers/__tests__/mrmMonitoring.breachAlerts.test.ts
+++ b/Servers/controllers/__tests__/mrmMonitoring.breachAlerts.test.ts
@@ -104,7 +104,7 @@ describe("handleBreaches alert dispatch", () => {
     expect(notification.title).toBe("Metric warning: psi");
     expect(emailEnabled).toBe(true);
     expect(email.template).toBe("mrm-breach-alert.mjml");
-    expect(email.variables.severity).toBe("warn");
+    expect(email.variables.severity).toBe("warning");
     expect(mockDispatch.mock.calls[1][2].title).toBe("Metric breach: auc");
   });
 
@@ -137,5 +137,14 @@ describe("handleBreaches alert dispatch", () => {
     await expect(
       handleBreaches(1, 7, [outcome("psi", MrmEvalStatus.BREACH, MrmThresholdSeverity.HIGH)]),
     ).resolves.toBeUndefined();
+  });
+
+  it("skips breach alerts and auto-findings when the settings read fails", async () => {
+    mockSettings.mockRejectedValue(new Error("db down"));
+    await expect(
+      handleBreaches(1, 7, [outcome("psi", MrmEvalStatus.BREACH, MrmThresholdSeverity.HIGH)]),
+    ).resolves.toBeUndefined();
+    expect(mockAutoFinding).not.toHaveBeenCalled();
+    expect(mockDispatch).not.toHaveBeenCalled();
   });
 });

--- a/Servers/controllers/mrmMonitoring.ctrl.ts
+++ b/Servers/controllers/mrmMonitoring.ctrl.ts
@@ -429,9 +429,18 @@ export async function handleBreaches(
   // Alert side effects: auto-open findings (hard breaches, org toggle), then
   // notify the model's MRM stakeholders (roles ∪ org-wide extra recipients),
   // in-app always and by email when the org enabled it.
+  let settings;
   try {
-    const settings = await getMrmOrgSettings(organizationId);
+    settings = await getMrmOrgSettings(organizationId);
+  } catch (error) {
+    logger.error(
+      "❌ Failed to read MRM alert settings — skipping breach alerts and auto-findings:",
+      error,
+    );
+    return;
+  }
 
+  try {
     // Auto-findings run BEFORE recipient resolution and regardless of it —
     // and AFTER the triggerRevalidation block above, so a just-opened
     // validation is available for the finding to link to.
@@ -461,6 +470,9 @@ export async function handleBreaches(
         ? `Metric breach: ${breach.point.metric}`
         : `Metric warning: ${breach.point.metric}`;
       const message = `${label} — "${breach.point.metric}" = ${breach.point.value} breached its monitoring threshold.`;
+      const thresholdSeverity = breach.evaluation!.threshold?.severity ?? MrmThresholdSeverity.HIGH;
+      const displaySeverity =
+        thresholdSeverity === MrmThresholdSeverity.WARN ? "warning" : thresholdSeverity;
       await dispatchAlerts(
         organizationId,
         recipients,
@@ -480,7 +492,7 @@ export async function handleBreaches(
             model_label: label,
             metric: breach.point.metric,
             value: String(breach.point.value),
-            severity: breach.evaluation!.threshold?.severity ?? "high",
+            severity: displaySeverity,
             model_url: `${baseUrl}/model-inventory/models/${modelInventoryId}`,
           },
         },

--- a/Servers/services/automations/actions/__tests__/mrmRevalidationSweep.test.ts
+++ b/Servers/services/automations/actions/__tests__/mrmRevalidationSweep.test.ts
@@ -12,6 +12,7 @@ jest.mock("../../../../utils/mrmRevalidation.utils", () => ({
 }));
 jest.mock("../../../../utils/mrmAlerts.utils", () => ({
   notifyRevalidationDue: jest.fn(),
+  loadMrmAlertContext: jest.fn(),
 }));
 jest.mock("../../../../utils/organization.utils", () => ({
   getAllOrganizationsQuery: jest.fn(),
@@ -46,8 +47,8 @@ describe("runRevalidationSweep overdue alerts", () => {
 
     expect(summary).toEqual({ organization_id: 1, due: 2, opened: 1, annotated: 1 });
     expect(mockNotify).toHaveBeenCalledTimes(2);
-    expect(mockNotify).toHaveBeenCalledWith(1, 7, 71, NEXT_DUE);
-    expect(mockNotify).toHaveBeenCalledWith(1, 8, 81, NEXT_DUE);
+    expect(mockNotify).toHaveBeenCalledWith(1, 7, 71, NEXT_DUE, expect.any(Function));
+    expect(mockNotify).toHaveBeenCalledWith(1, 8, 81, NEXT_DUE, expect.any(Function));
   });
 
   it("a notify failure never fails the sweep or skews the counters", async () => {

--- a/Servers/services/automations/actions/mrmRevalidationSweep.ts
+++ b/Servers/services/automations/actions/mrmRevalidationSweep.ts
@@ -3,7 +3,11 @@ import {
   getDueRevalidationsQuery,
   triggerRevalidation,
 } from "../../../utils/mrmRevalidation.utils";
-import { notifyRevalidationDue } from "../../../utils/mrmAlerts.utils";
+import {
+  loadMrmAlertContext,
+  MrmAlertContext,
+  notifyRevalidationDue,
+} from "../../../utils/mrmAlerts.utils";
 import { MrmRevalidationTriggerSource } from "../../../domain.layer/enums/mrmMonitoring.enum";
 import logger from "../../../utils/logger/fileLogger";
 
@@ -34,6 +38,11 @@ export async function runRevalidationSweep(
   let opened = 0;
   let annotated = 0;
 
+  // Org-constant alert inputs (settings + extra recipients) load at most once
+  // per sweep run, and only when a row actually wins the overdue claim.
+  let alertContext: Promise<MrmAlertContext> | null = null;
+  const loadAlertContext = () => (alertContext ??= loadMrmAlertContext(organizationId));
+
   for (const row of due) {
     try {
       const result = await triggerRevalidation(
@@ -58,6 +67,7 @@ export async function runRevalidationSweep(
             row.model_inventory_id,
             result.validation_id,
             row.next_due,
+            loadAlertContext,
           );
         } catch (error) {
           logger.error(

--- a/Servers/utils/__tests__/mrmAlerts.utils.test.ts
+++ b/Servers/utils/__tests__/mrmAlerts.utils.test.ts
@@ -21,6 +21,7 @@ jest.mock("../../services/inAppNotification.service", () => ({
 jest.mock("../../utils/mrmMonitoring.utils", () => ({
   getBreachNotificationRecipientsQuery: jest.fn(),
   getModelLabelQuery: jest.fn(),
+  getModelRoleUserIdQuery: jest.fn(),
 }));
 jest.mock("../../utils/mrmRevalidation.utils", () => ({
   getOpenValidationForModelQuery: jest.fn(),

--- a/Servers/utils/mrmAlerts.utils.ts
+++ b/Servers/utils/mrmAlerts.utils.ts
@@ -1,10 +1,14 @@
 import { QueryTypes, Transaction } from "sequelize";
 import { sequelize } from "../database/db";
-import { getBreachNotificationRecipientsQuery, getModelLabelQuery } from "./mrmMonitoring.utils";
+import {
+  getBreachNotificationRecipientsQuery,
+  getModelLabelQuery,
+  getModelRoleUserIdQuery,
+} from "./mrmMonitoring.utils";
 import { getOpenValidationForModelQuery } from "./mrmRevalidation.utils";
-import { getMrmOrgSettings } from "./mrmSettings.utils";
+import { getMrmOrgSettings, MrmOrgSettings } from "./mrmSettings.utils";
 import { MrmEvalStatus, MrmThresholdSeverity } from "../domain.layer/enums/mrmMonitoring.enum";
-import { MrmFindingSeverity } from "../domain.layer/enums/mrm.enum";
+import { MrmFindingSeverity, MrmModelRole } from "../domain.layer/enums/mrm.enum";
 import { sendInAppNotification } from "../services/inAppNotification.service";
 import { EMAIL_TEMPLATES } from "../constants/emailTemplates";
 import {
@@ -85,6 +89,20 @@ export const getAlertRecipientsUnion = async (
   return unionRecipients(roleRecipients, extraRecipients);
 };
 
+export interface MrmAlertContext {
+  settings: MrmOrgSettings;
+  extraRecipients: number[];
+}
+
+/** Org-constant inputs for alert dispatch, loadable once per run. */
+export const loadMrmAlertContext = async (organizationId: number): Promise<MrmAlertContext> => {
+  const [settings, extraRecipients] = await Promise.all([
+    getMrmOrgSettings(organizationId),
+    getAlertExtraRecipientsQuery(organizationId),
+  ]);
+  return { settings, extraRecipients };
+};
+
 /** Threshold severity → finding severity. warn never opens a finding. */
 export const severityToFindingSeverity = (
   severity: MrmThresholdSeverity,
@@ -97,29 +115,6 @@ export const severityToFindingSeverity = (
 /** Auto-finding trigger predicate: hard breaches only, and only when enabled. */
 export const isAutoFindingEligible = (status: MrmEvalStatus, autoOpenEnabled: boolean): boolean =>
   autoOpenEnabled && status === MrmEvalStatus.BREACH;
-
-/** The model's assigned owner role user, or null. Lowest id wins if duplicated. */
-const getModelOwnerUserIdQuery = async (
-  organizationId: number,
-  modelInventoryId: number,
-  transaction?: Transaction,
-): Promise<number | null> => {
-  const rows = (await sequelize.query(
-    `SELECT user_id FROM mrm_model_roles
-      WHERE organization_id = :organizationId
-        AND model_inventory_id = :modelInventoryId
-        AND role = 'owner'
-        AND user_id IS NOT NULL
-      ORDER BY id ASC
-      LIMIT 1`,
-    {
-      replacements: { organizationId, modelInventoryId },
-      type: QueryTypes.SELECT,
-      transaction,
-    },
-  )) as { user_id: number }[];
-  return rows[0]?.user_id ?? null;
-};
 
 /**
  * Auto-open a finding for a hard metric breach, once per (model, metric) while
@@ -187,7 +182,12 @@ export const maybeAutoOpenFindingForBreach = async (
       modelInventoryId,
       transaction,
     );
-    const ownerId = await getModelOwnerUserIdQuery(organizationId, modelInventoryId, transaction);
+    const ownerId = await getModelRoleUserIdQuery(
+      organizationId,
+      modelInventoryId,
+      MrmModelRole.OWNER,
+      transaction,
+    );
 
     const rows = (await sequelize.query(
       `INSERT INTO mrm_findings
@@ -211,6 +211,10 @@ export const maybeAutoOpenFindingForBreach = async (
         transaction,
       },
     )) as { id: number }[];
+
+    if (!rows[0]) {
+      throw new Error("mrm_findings INSERT returned no row");
+    }
 
     await transaction.commit();
     return rows[0].id;
@@ -284,14 +288,19 @@ export const notifyRevalidationDue = async (
   modelInventoryId: number,
   validationId: number,
   nextDue: Date | null,
+  loadContext: () => Promise<MrmAlertContext> = () => loadMrmAlertContext(organizationId),
 ): Promise<void> => {
   const claimed = await claimOverdueNotificationQuery(organizationId, validationId);
   if (!claimed) return;
 
-  const recipients = await getAlertRecipientsUnion(organizationId, modelInventoryId);
+  const ctx = await loadContext();
+  const roleRecipients = await getBreachNotificationRecipientsQuery(
+    organizationId,
+    modelInventoryId,
+  );
+  const recipients = unionRecipients(roleRecipients, ctx.extraRecipients);
   if (recipients.length === 0) return;
 
-  const settings = await getMrmOrgSettings(organizationId);
   const label = (await getModelLabelQuery(organizationId, modelInventoryId)) ?? "a model";
   const dueDate = nextDue ? new Date(nextDue).toISOString().slice(0, 10) : "unknown";
   const baseUrl = process.env.FRONTEND_URL || "http://localhost:5173";
@@ -309,7 +318,7 @@ export const notifyRevalidationDue = async (
       entity_name: label,
       action_url: validationPath,
     },
-    settings.alert_email_enabled,
+    ctx.settings.alert_email_enabled,
     {
       template: EMAIL_TEMPLATES.MRM_REVALIDATION_DUE,
       subject: `Validation overdue: ${label}`,

--- a/Servers/utils/mrmMonitoring.utils.ts
+++ b/Servers/utils/mrmMonitoring.utils.ts
@@ -7,6 +7,7 @@ import {
   MrmThresholdOp,
   MrmThresholdSeverity,
 } from "../domain.layer/enums/mrmMonitoring.enum";
+import { MrmModelRole } from "../domain.layer/enums/mrm.enum";
 import { MrmThresholdModel } from "../domain.layer/models/mrm/mrmThreshold.model";
 import { MrmMetricKeyModel } from "../domain.layer/models/mrm/mrmMetricKey.model";
 import { MrmThresholdSnapshot } from "../domain.layer/interfaces/i.mrmMetricEvaluation";
@@ -535,6 +536,33 @@ export const flagModelForRevalidationQuery = async (
       transaction,
     },
   );
+};
+
+/**
+ * The user id assigned to one of the model's MRM roles, or null when
+ * unassigned. Deterministic: lowest id wins if somehow duplicated.
+ */
+export const getModelRoleUserIdQuery = async (
+  organizationId: number,
+  modelInventoryId: number,
+  role: MrmModelRole,
+  transaction?: Transaction,
+): Promise<number | null> => {
+  const rows = (await sequelize.query(
+    `SELECT user_id FROM mrm_model_roles
+      WHERE organization_id = :organizationId
+        AND model_inventory_id = :modelInventoryId
+        AND role = :role
+        AND user_id IS NOT NULL
+      ORDER BY id ASC
+      LIMIT 1`,
+    {
+      replacements: { organizationId, modelInventoryId, role },
+      type: QueryTypes.SELECT,
+      transaction,
+    },
+  )) as { user_id: number }[];
+  return rows[0]?.user_id ?? null;
 };
 
 /**

--- a/Servers/utils/mrmRevalidation.utils.ts
+++ b/Servers/utils/mrmRevalidation.utils.ts
@@ -8,6 +8,7 @@ import {
 } from "../domain.layer/enums/mrm.enum";
 import { MrmRevalidationTriggerSource } from "../domain.layer/enums/mrmMonitoring.enum";
 import { createValidationQuery } from "./mrm.utils";
+import { getModelRoleUserIdQuery } from "./mrmMonitoring.utils";
 import { ConflictException } from "../domain.layer/exceptions/custom.exception";
 
 /**
@@ -103,25 +104,12 @@ export const getModelValidatorIdQuery = async (
   modelInventoryId: number,
   transaction?: Transaction,
 ): Promise<number | null> => {
-  const rows = (await sequelize.query(
-    `SELECT user_id FROM mrm_model_roles
-      WHERE organization_id = :organizationId
-        AND model_inventory_id = :modelInventoryId
-        AND role = :role
-        AND user_id IS NOT NULL
-      ORDER BY id ASC
-      LIMIT 1`,
-    {
-      replacements: {
-        organizationId,
-        modelInventoryId,
-        role: MrmModelRole.VALIDATOR,
-      },
-      type: QueryTypes.SELECT,
-      transaction,
-    },
-  )) as { user_id: number | null }[];
-  return rows[0]?.user_id ?? null;
+  return getModelRoleUserIdQuery(
+    organizationId,
+    modelInventoryId,
+    MrmModelRole.VALIDATOR,
+    transaction,
+  );
 };
 
 /**


### PR DESCRIPTION
## Changes

- **Sweep read caching.** Memoize org-constant alert-context reads (settings + extra recipients) per sweep run via a lazy-loaded, per-run cache. A day where every validation is already claimed does zero extra reads; a day with N newly-overdue rows in one org reads each value at most once instead of N times.
- **Role query reuse.** Extract `getModelRoleUserIdQuery` (parameterized by `MrmModelRole`) into `mrmMonitoring.utils.ts` and delegate the owner lookup in `mrmAlerts.utils.ts` and the validator lookup in `mrmRevalidation.utils.ts` to it, removing the duplicated query.
- **Shared constant.** Move `MIN_RETENTION_MONTHS` into the shared `mrm/constants.ts` module instead of a local duplicate in `RetentionSection.tsx`.
- **Alert copy.** Fix the breach-alert email's severity variable so a warn-level breach reads "warning" instead of the raw enum value "warn"; the auto-finding call still receives the raw threshold severity.
- **Logging.** Split the settings read out of `handleBreaches`' single try/catch so a `getMrmOrgSettings` failure logs distinctly from a downstream dispatch failure, instead of being swallowed under one generic log line.
- **Guard.** Add an explicit guard against an empty `INSERT ... RETURNING` result in `maybeAutoOpenFindingForBreach` so a would-be TypeError becomes a readable error message.

## Notes

Cleanup refinements to already-shipped MRM code (retention #4252, alerts #4264). No schema changes, no new user-facing features. The org-scoped tables these paths touch (`mrm_org_settings`, `mrm_alert_recipients`) are already registered in the tenant-isolation registry.

## Verification

- `cd Servers && npm run build` — passes
- `cd Servers && npm run format-check` — passes
- `cd Clients && npm run typecheck` — passes