### PR TITLE
4028 add contract tests for raw sql list endpoints

### DIFF
--- a/Servers/tests/contract/aiDetection.contract.test.ts
+++ b/Servers/tests/contract/aiDetection.contract.test.ts
@@ -1,0 +1,102 @@
+import { describe, it, expect, jest, beforeEach } from "@jest/globals";
+
+jest.mock("../../database/db", () => ({
+  sequelize: { query: jest.fn() },
+}));
+
+import { sequelize } from "../../database/db";
+import { getScansListQuery, getFindingsForScanQuery } from "../../utils/aiDetection.utils";
+
+const mockQuery = sequelize.query as jest.MockedFunction<typeof sequelize.query>;
+
+describe("aiDetection contract", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe("getScansListQuery", () => {
+    const ORG_ID = 42;
+    const LIMIT = 10;
+
+    beforeEach(() => {
+      // Two queries via Promise.all: count then data
+      mockQuery
+        .mockResolvedValueOnce([[{ total: "3" }], 0] as any)
+        .mockResolvedValueOnce([[{ id: 1, organization_id: ORG_ID }], 0] as any);
+    });
+
+    it("includes LIMIT and OFFSET in SQL", async () => {
+      await getScansListQuery(ORG_ID, 1, LIMIT);
+
+      const calls = mockQuery.mock.calls;
+      const dataSql = calls[1][0] as string;
+      expect(dataSql).toContain("LIMIT :limit");
+      expect(dataSql).toContain("OFFSET :offset");
+    });
+
+    it("includes ORDER BY in SQL", async () => {
+      await getScansListQuery(ORG_ID, 1, LIMIT);
+
+      const dataSql = mockQuery.mock.calls[1][0] as string;
+      expect(dataSql).toContain("ORDER BY");
+      expect(dataSql).toContain("s.created_at DESC");
+    });
+
+    it("filters by organization_id", async () => {
+      await getScansListQuery(ORG_ID, 1, LIMIT);
+
+      const dataSql = mockQuery.mock.calls[1][0] as string;
+      expect(dataSql).toContain("s.organization_id = :organizationId");
+
+      const dataReplacements = (mockQuery.mock.calls[1][1] as any).replacements;
+      expect(dataReplacements.organizationId).toBe(ORG_ID);
+    });
+
+    it("passes correct limit and offset values", async () => {
+      await getScansListQuery(ORG_ID, 3, LIMIT);
+
+      const dataReplacements = (mockQuery.mock.calls[1][1] as any).replacements;
+      expect(dataReplacements.limit).toBe(LIMIT);
+      expect(dataReplacements.offset).toBe(20); // (page 3 - 1) * 10
+    });
+  });
+
+  describe("getFindingsForScanQuery", () => {
+    const ORG_ID = 42;
+    const SCAN_ID = 7;
+    const LIMIT = 25;
+
+    beforeEach(() => {
+      mockQuery
+        .mockResolvedValueOnce([[{ total: "1" }], 0] as any)
+        .mockResolvedValueOnce([[{ id: 1, organization_id: ORG_ID }], 0] as any);
+    });
+
+    it("includes LIMIT and OFFSET in SQL", async () => {
+      await getFindingsForScanQuery(SCAN_ID, ORG_ID, 1, LIMIT);
+
+      const dataSql = mockQuery.mock.calls[1][0] as string;
+      expect(dataSql).toContain("LIMIT :limit");
+      expect(dataSql).toContain("OFFSET :offset");
+    });
+
+    it("includes ORDER BY in SQL", async () => {
+      await getFindingsForScanQuery(SCAN_ID, ORG_ID, 1, LIMIT);
+
+      const dataSql = mockQuery.mock.calls[1][0] as string;
+      expect(dataSql).toContain("ORDER BY");
+    });
+
+    it("filters by organization_id and scan_id", async () => {
+      await getFindingsForScanQuery(SCAN_ID, ORG_ID, 1, LIMIT);
+
+      const dataSql = mockQuery.mock.calls[1][0] as string;
+      expect(dataSql).toContain("f.scan_id = :scanId");
+      expect(dataSql).toContain("f.organization_id = :organizationId");
+
+      const dataReplacements = (mockQuery.mock.calls[1][1] as any).replacements;
+      expect(dataReplacements.organizationId).toBe(ORG_ID);
+      expect(dataReplacements.scanId).toBe(SCAN_ID);
+    });
+  });
+});

--- a/Servers/tests/contract/file.contract.test.ts
+++ b/Servers/tests/contract/file.contract.test.ts
@@ -1,0 +1,83 @@
+import { describe, it, expect, jest, beforeEach } from "@jest/globals";
+
+jest.mock("../../database/db", () => ({
+  sequelize: { query: jest.fn() },
+}));
+
+jest.mock("../../utils/files/attachLinkProjections", () => ({
+  attachLinkProjections: jest.fn(),
+}));
+
+import { sequelize } from "../../database/db";
+import { getOrganizationFiles } from "../../repositories/file.repository";
+import { attachLinkProjections } from "../../utils/files/attachLinkProjections";
+
+const mockQuery = sequelize.query as jest.MockedFunction<typeof sequelize.query>;
+const mockAttachLinkProjections = attachLinkProjections as jest.MockedFunction<
+  typeof attachLinkProjections
+>;
+
+describe("file contract", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe("getOrganizationFiles", () => {
+    const ORG_ID = 33;
+
+    beforeEach(() => {
+      // Sequential: main query first, then count query
+      mockQuery
+        .mockResolvedValueOnce([[{ id: 1, filename: "doc.pdf" }], 0] as any)
+        .mockResolvedValueOnce([[{ count: "2" }], 0] as any);
+      mockAttachLinkProjections.mockResolvedValue(undefined);
+    });
+
+    it("includes LIMIT in SQL", async () => {
+      await getOrganizationFiles(ORG_ID, { limit: 10 });
+
+      const dataSql = mockQuery.mock.calls[0][0] as string;
+      expect(dataSql).toContain("LIMIT :limit");
+    });
+
+    it("includes ORDER BY in SQL", async () => {
+      await getOrganizationFiles(ORG_ID);
+
+      const dataSql = mockQuery.mock.calls[0][0] as string;
+      expect(dataSql).toContain("ORDER BY f.uploaded_time DESC, f.id DESC");
+    });
+
+    it("filters by organization_id", async () => {
+      await getOrganizationFiles(ORG_ID);
+
+      const dataSql = mockQuery.mock.calls[0][0] as string;
+      expect(dataSql).toContain("f.organization_id = :organizationId");
+
+      const dataReplacements = (mockQuery.mock.calls[0][1] as any).replacements;
+      expect(dataReplacements.organizationId).toBe(ORG_ID);
+    });
+
+    it("count query also filters by organization_id", async () => {
+      await getOrganizationFiles(ORG_ID);
+
+      const countSql = mockQuery.mock.calls[1][0] as string;
+      expect(countSql).toContain("organization_id = :organizationId");
+
+      const countReplacements = (mockQuery.mock.calls[1][1] as any).replacements;
+      expect(countReplacements.organizationId).toBe(ORG_ID);
+    });
+
+    it("passes clamped limit to query", async () => {
+      await getOrganizationFiles(ORG_ID, { limit: 50 });
+
+      const dataReplacements = (mockQuery.mock.calls[0][1] as any).replacements;
+      expect(dataReplacements.limit).toBe(50);
+    });
+
+    it("calls attachLinkProjections for link enrichment", async () => {
+      await getOrganizationFiles(ORG_ID);
+
+      expect(mockAttachLinkProjections).toHaveBeenCalledWith(ORG_ID, expect.any(Array));
+    });
+  });
+});

--- a/Servers/tests/contract/search.contract.test.ts
+++ b/Servers/tests/contract/search.contract.test.ts
@@ -1,0 +1,153 @@
+import { describe, it, expect, jest, beforeEach } from "@jest/globals";
+
+jest.mock("../../database/db", () => ({
+  sequelize: { query: jest.fn() },
+}));
+
+import { sequelize } from "../../database/db";
+import { wiseSearch, SEARCH_CONSTANTS } from "../../utils/search.utils";
+
+const mockQuery = sequelize.query as jest.MockedFunction<typeof sequelize.query>;
+
+describe("search contract", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  /**
+   * Mock implementation that routes based on SQL content:
+   * - projects_members → user project IDs
+   * - vendors_projects → user vendor IDs
+   * - SELECT DISTINCT * → entity search results
+   */
+  function setupSearchMocks(rows: Record<string, any>[] = [{ id: 1, name: "test" }]) {
+    mockQuery.mockImplementation(async (sql: any) => {
+      const sqlStr = typeof sql === "string" ? sql : "";
+      if (sqlStr.includes("projects_members")) {
+        return [[{ project_id: 1 }], 0] as any;
+      }
+      if (sqlStr.includes("vendors_projects")) {
+        return [[{ vendor_id: 1 }], 0] as any;
+      }
+      if (sqlStr.includes("DISTINCT *")) {
+        return [rows, 0] as any;
+      }
+      return [[], 0] as any;
+    });
+  }
+
+  /** Entity search queries use "DISTINCT * FROM"; access lookups use "DISTINCT vendor_id" or "project_id" */
+  function getEntityCalls() {
+    return mockQuery.mock.calls.filter(
+      (c) => typeof c[0] === "string" && c[0].includes("DISTINCT *"),
+    );
+  }
+
+  it("each entity query includes LIMIT", async () => {
+    setupSearchMocks();
+
+    await wiseSearch({
+      query: "test search query",
+      organizationId: 42,
+      userId: 1,
+      limit: 15,
+    });
+
+    const entityCalls = getEntityCalls();
+
+    expect(entityCalls.length).toBeGreaterThan(0);
+    for (const call of entityCalls) {
+      const sql = call[0] as string;
+      expect(sql).toContain("LIMIT :limit");
+    }
+  });
+
+  it("each entity query includes ORDER BY", async () => {
+    setupSearchMocks();
+
+    await wiseSearch({
+      query: "test search query",
+      organizationId: 42,
+      userId: 1,
+    });
+
+    const entityCalls = getEntityCalls();
+
+    for (const call of entityCalls) {
+      const sql = call[0] as string;
+      expect(sql).toContain("ORDER BY id ASC");
+    }
+  });
+
+  it("each entity query filters by organization_id", async () => {
+    setupSearchMocks();
+
+    await wiseSearch({
+      query: "test search query",
+      organizationId: 42,
+      userId: 1,
+    });
+
+    const entityCalls = getEntityCalls();
+
+    for (const call of entityCalls) {
+      const sql = call[0] as string;
+      expect(sql).toContain("organization_id = :organizationId");
+
+      const replacements = (call[1] as any).replacements;
+      expect(replacements.organizationId).toBe(42);
+    }
+  });
+
+  it("limits search pattern to MAX_LIMIT", async () => {
+    setupSearchMocks();
+
+    await wiseSearch({
+      query: "test search query",
+      organizationId: 42,
+      userId: 1,
+      limit: 500,
+    });
+
+    const entityCalls = getEntityCalls();
+
+    for (const call of entityCalls) {
+      const replacements = (call[1] as any).replacements;
+      expect(replacements.limit).toBe(SEARCH_CONSTANTS.MAX_LIMIT);
+    }
+  });
+
+  it("includes ILIKE search pattern when query provided", async () => {
+    setupSearchMocks();
+
+    await wiseSearch({
+      query: "test search query",
+      organizationId: 42,
+      userId: 1,
+    });
+
+    const entityCalls = getEntityCalls();
+
+    const hasIlike = entityCalls.some(
+      (c) => typeof c[0] === "string" && c[0].includes("ILIKE :searchPattern"),
+    );
+    expect(hasIlike).toBe(true);
+
+    const firstEntityCall = entityCalls[0];
+    const replacements = (firstEntityCall[1] as any).replacements;
+    expect(replacements.searchPattern).toMatch(/^%.+%$/);
+  });
+
+  it("returns empty for queries shorter than MIN_QUERY_LENGTH", async () => {
+    setupSearchMocks();
+
+    const result = await wiseSearch({
+      query: "ab",
+      organizationId: 42,
+      userId: 1,
+    });
+
+    expect(result).toEqual({});
+    expect(mockQuery).not.toHaveBeenCalled();
+  });
+});

--- a/Servers/tests/contract/shadowAi.contract.test.ts
+++ b/Servers/tests/contract/shadowAi.contract.test.ts
@@ -1,0 +1,107 @@
+import { describe, it, expect, jest, beforeEach } from "@jest/globals";
+
+jest.mock("../../database/db", () => ({
+  sequelize: { query: jest.fn() },
+}));
+
+import { sequelize } from "../../database/db";
+import { getUserActivityQuery } from "../../utils/shadowAiInsights.utils";
+import { getAllToolsQuery } from "../../utils/shadowAiTools.utils";
+
+const mockQuery = sequelize.query as jest.MockedFunction<typeof sequelize.query>;
+
+describe("shadowAi contract", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe("getUserActivityQuery", () => {
+    const ORG_ID = 55;
+
+    beforeEach(() => {
+      // Sequential: data query first, then count query
+      mockQuery
+        .mockResolvedValueOnce([[{ user_email: "a@test.com" }], 0] as any)
+        .mockResolvedValueOnce([[{ total: "1" }], 0] as any);
+    });
+
+    it("includes LIMIT and OFFSET in SQL", async () => {
+      await getUserActivityQuery(ORG_ID, { limit: 10 });
+
+      const dataSql = mockQuery.mock.calls[0][0] as string;
+      expect(dataSql).toContain("LIMIT :limit");
+      expect(dataSql).toContain("OFFSET :offset");
+    });
+
+    it("includes ORDER BY in SQL", async () => {
+      await getUserActivityQuery(ORG_ID);
+
+      const dataSql = mockQuery.mock.calls[0][0] as string;
+      expect(dataSql).toContain("ORDER BY");
+      expect(dataSql).toContain("total_prompts DESC");
+    });
+
+    it("filters by organization_id", async () => {
+      await getUserActivityQuery(ORG_ID);
+
+      const dataSql = mockQuery.mock.calls[0][0] as string;
+      expect(dataSql).toContain("e.organization_id = :organizationId");
+
+      const dataReplacements = (mockQuery.mock.calls[0][1] as any).replacements;
+      expect(dataReplacements.organizationId).toBe(ORG_ID);
+    });
+
+    it("passes correct limit and offset values", async () => {
+      await getUserActivityQuery(ORG_ID, { page: 3, limit: 10 });
+
+      const dataReplacements = (mockQuery.mock.calls[0][1] as any).replacements;
+      expect(dataReplacements.limit).toBe(10);
+      expect(dataReplacements.offset).toBe(20); // (3 - 1) * 10
+    });
+  });
+
+  describe("getAllToolsQuery", () => {
+    const ORG_ID = 55;
+
+    beforeEach(() => {
+      // Sequential: data query first, then count query
+      mockQuery
+        .mockResolvedValueOnce([[{ id: 1, name: "tool1" }], 0] as any)
+        .mockResolvedValueOnce([[{ total: "1" }], 0] as any);
+    });
+
+    it("includes LIMIT and OFFSET in SQL", async () => {
+      await getAllToolsQuery(ORG_ID, { limit: 10 });
+
+      const dataSql = mockQuery.mock.calls[0][0] as string;
+      expect(dataSql).toContain("LIMIT :limit");
+      expect(dataSql).toContain("OFFSET :offset");
+    });
+
+    it("includes ORDER BY in SQL", async () => {
+      await getAllToolsQuery(ORG_ID);
+
+      const dataSql = mockQuery.mock.calls[0][0] as string;
+      expect(dataSql).toContain("ORDER BY");
+      expect(dataSql).toContain("last_seen_at DESC");
+    });
+
+    it("filters by organization_id", async () => {
+      await getAllToolsQuery(ORG_ID);
+
+      const dataSql = mockQuery.mock.calls[0][0] as string;
+      expect(dataSql).toContain("organization_id = :organizationId");
+
+      const dataReplacements = (mockQuery.mock.calls[0][1] as any).replacements;
+      expect(dataReplacements.organizationId).toBe(ORG_ID);
+    });
+
+    it("passes correct limit and offset values", async () => {
+      await getAllToolsQuery(ORG_ID, { page: 2, limit: 15 });
+
+      const dataReplacements = (mockQuery.mock.calls[0][1] as any).replacements;
+      expect(dataReplacements.limit).toBe(15);
+      expect(dataReplacements.offset).toBe(15); // (2 - 1) * 15
+    });
+  });
+});


### PR DESCRIPTION
## Describe your changes

Inspect the generated SQL or run parameterized queries against a known seed dataset.

## Write your issue number after "Fixes "

Fixes #4028 

## Please ensure all items are checked off before requesting a review:

- [x] I deployed the code locally.
- [x] I have performed a self-review of my code.
- [x] I have included the issue # in the PR.
- [x] I have labelled the PR correctly.
- [x] The issue I am working on is assigned to me.
- [x] I have avoided using hardcoded values to ensure scalability and maintain consistency across the application.
- [x] I have ensured that font sizes, color choices, and other UI elements are referenced from the theme.
- [x] My pull request is focused and addresses a single, specific feature.
- [x] If there are UI changes, I have attached a screenshot or video to this PR.
- [x] If I added or modified an API endpoint, the change is reflected in the generated OpenAPI spec (`npm run generate:swagger`).
- [x] If the endpoint requires authentication, it uses `authenticateJWT` and the generated spec declares `bearerAuth` security.
- [x] I ran `npm run check:api-drift` and committed the regenerated `swagger.yaml` and `endpoints.ts`.
- [x] If this PR adds or modifies an organization-scoped table, the [tenant isolation registry](Servers/tests/integration/tenant-isolation/tenantIsolation.registry.ts) and [test matrix](Servers/tests/integration/tenant-isolation) are updated. See the [tenant isolation runbook](docs/technical/security/tenant-isolation.md) for details.
