### PR TITLE
feat(themes): add typography token foundation

### DIFF
--- a/Clients/src/presentation/pages/StyleGuide/sections/TypographySection.tsx
+++ b/Clients/src/presentation/pages/StyleGuide/sections/TypographySection.tsx
@@ -2,6 +2,24 @@ import React, { useState } from "react";
 import { Box, Stack, Typography, useTheme, Divider, Snackbar } from "@mui/material";
 import { Copy } from "lucide-react";
 import { brand, text, background } from "../../../themes/palette";
+import {
+  fontFamily,
+  fontSize,
+  fontWeight,
+  lineHeight,
+  textStyles,
+} from "../../../themes/typography";
+
+/** Format a textStyles entry for StyleGuide display chips */
+const styleMeta = (style: {
+  fontSize: number;
+  fontWeight: number;
+  lineHeight: number | string;
+}) => ({
+  fontSize: `${style.fontSize}px`,
+  fontWeight: String(style.fontWeight),
+  lineHeight: String(style.lineHeight),
+});
 
 const TypographySection: React.FC = () => {
   const theme = useTheme();
@@ -27,8 +45,7 @@ const TypographySection: React.FC = () => {
       <Box sx={{ mb: "32px" }}>
         <Typography
           sx={{
-            fontSize: 24,
-            fontWeight: 600,
+            ...textStyles.pageTitle,
             color: theme.palette.text.primary,
             mb: "8px",
           }}
@@ -37,13 +54,13 @@ const TypographySection: React.FC = () => {
         </Typography>
         <Typography
           sx={{
-            fontSize: 14,
+            ...textStyles.bodyLarge,
             color: theme.palette.text.tertiary,
             maxWidth: 600,
           }}
         >
-          Typography styles and text hierarchy used in VerifyWise. All text uses the Geist font
-          family with Inter as fallback, with consistent sizing and weights.
+          Typography styles and text hierarchy from <code>themes/typography.ts</code>. Primary stack
+          is Geist with system fallbacks (no Inter).
         </Typography>
       </Box>
 
@@ -64,14 +81,14 @@ const TypographySection: React.FC = () => {
           />
           <SpecCard
             title="Font stack"
-            value="'Geist', system-ui, -apple-system, BlinkMacSystemFont, Helvetica, Arial, sans-serif"
-            note="Full fallback chain"
+            value={fontFamily.sans}
+            note="fontFamily.sans"
             onCopy={handleCopy}
           />
           <SpecCard
             title="Monospace"
-            value="'Fira Code', 'Consolas', monospace"
-            note="Code blocks"
+            value={fontFamily.mono}
+            note="fontFamily.mono"
             onCopy={handleCopy}
           />
         </Box>
@@ -81,43 +98,37 @@ const TypographySection: React.FC = () => {
 
       {/* Heading Styles */}
       <SpecSection title="Headings">
-        <Typography sx={{ fontSize: 13, color: theme.palette.text.tertiary, mb: "24px" }}>
-          Page and section headings with consistent sizing and weights.
+        <Typography
+          sx={{ fontSize: fontSize.base, color: theme.palette.text.tertiary, mb: "24px" }}
+        >
+          Semantic styles: textStyles.pageTitle, sectionTitle, cardTitle, subsectionTitle
         </Typography>
 
         <Stack spacing="24px">
           <TypographyExample
-            label="Page title"
-            fontSize="24px"
-            fontWeight="600"
-            lineHeight="1.3"
+            label="Page title (textStyles.pageTitle)"
+            {...styleMeta(textStyles.pageTitle)}
             color="#1c2130"
             example="Dashboard overview"
             onCopy={handleCopy}
           />
           <TypographyExample
-            label="Section title"
-            fontSize="18px"
-            fontWeight="600"
-            lineHeight="1.4"
+            label="Section title (textStyles.sectionTitle)"
+            {...styleMeta(textStyles.sectionTitle)}
             color="#1c2130"
             example="Risk management"
             onCopy={handleCopy}
           />
           <TypographyExample
-            label="Card title"
-            fontSize="16px"
-            fontWeight="600"
-            lineHeight="1.4"
+            label="Card title (textStyles.cardTitle)"
+            {...styleMeta(textStyles.cardTitle)}
             color="#1c2130"
             example="Compliance status"
             onCopy={handleCopy}
           />
           <TypographyExample
-            label="Subsection title"
-            fontSize="14px"
-            fontWeight="600"
-            lineHeight="1.5"
+            label="Subsection title (textStyles.subsectionTitle)"
+            {...styleMeta(textStyles.subsectionTitle)}
             color="#1c2130"
             example="Filter options"
             onCopy={handleCopy}
@@ -129,43 +140,38 @@ const TypographySection: React.FC = () => {
 
       {/* Body Text */}
       <SpecSection title="Body text">
-        <Typography sx={{ fontSize: 13, color: theme.palette.text.tertiary, mb: "24px" }}>
-          Standard text sizes for body content, labels, and supporting text.
+        <Typography
+          sx={{ fontSize: fontSize.base, color: theme.palette.text.tertiary, mb: "24px" }}
+        >
+          Standard text sizes for body content. Modal descriptions and sidebar/tab labels use body
+          (13), not bodySmall.
         </Typography>
 
         <Stack spacing="24px">
           <TypographyExample
-            label="Body large"
-            fontSize="14px"
-            fontWeight="400"
-            lineHeight="1.5"
+            label="Body large (textStyles.bodyLarge)"
+            {...styleMeta(textStyles.bodyLarge)}
             color={text.secondary}
             example="This is body text used for longer form content and descriptions that require more space."
             onCopy={handleCopy}
           />
           <TypographyExample
-            label="Body default"
-            fontSize="13px"
-            fontWeight="400"
-            lineHeight="1.5"
+            label="Body default (textStyles.body)"
+            {...styleMeta(textStyles.body)}
             color={text.secondary}
-            example="Standard body text for most UI content and form labels."
+            example="Standard body text for most UI content, modal descriptions, and tab labels."
             onCopy={handleCopy}
           />
           <TypographyExample
-            label="Body small"
-            fontSize="12px"
-            fontWeight="400"
-            lineHeight="1.5"
+            label="Body small (textStyles.bodySmall)"
+            {...styleMeta(textStyles.bodySmall)}
             color={text.tertiary}
             example="Smaller text for secondary information and metadata."
             onCopy={handleCopy}
           />
           <TypographyExample
-            label="Caption"
-            fontSize="11px"
-            fontWeight="400"
-            lineHeight="1.4"
+            label="Caption (textStyles.caption)"
+            {...styleMeta(textStyles.caption)}
             color="#838c99"
             example="Caption text for hints, timestamps, and footnotes"
             onCopy={handleCopy}
@@ -177,8 +183,10 @@ const TypographySection: React.FC = () => {
 
       {/* Font Weights */}
       <SpecSection title="Font weights">
-        <Typography sx={{ fontSize: 13, color: theme.palette.text.tertiary, mb: "24px" }}>
-          Standard font weights used across the application.
+        <Typography
+          sx={{ fontSize: fontSize.base, color: theme.palette.text.tertiary, mb: "24px" }}
+        >
+          Tokens: fontWeight.regular / medium / semibold / bold
         </Typography>
 
         <Box
@@ -191,10 +199,30 @@ const TypographySection: React.FC = () => {
             },
           }}
         >
-          <WeightCard weight="400" name="Regular" usage="Body text" onCopy={handleCopy} />
-          <WeightCard weight="500" name="Medium" usage="Labels, buttons" onCopy={handleCopy} />
-          <WeightCard weight="600" name="Semibold" usage="Headings, emphasis" onCopy={handleCopy} />
-          <WeightCard weight="700" name="Bold" usage="Strong emphasis" onCopy={handleCopy} />
+          <WeightCard
+            weight={String(fontWeight.regular)}
+            name="Regular"
+            usage="Body text"
+            onCopy={handleCopy}
+          />
+          <WeightCard
+            weight={String(fontWeight.medium)}
+            name="Medium"
+            usage="Labels, buttons"
+            onCopy={handleCopy}
+          />
+          <WeightCard
+            weight={String(fontWeight.semibold)}
+            name="Semibold"
+            usage="Headings, emphasis"
+            onCopy={handleCopy}
+          />
+          <WeightCard
+            weight={String(fontWeight.bold)}
+            name="Bold"
+            usage="Strong emphasis"
+            onCopy={handleCopy}
+          />
         </Box>
       </SpecSection>
 
@@ -202,90 +230,74 @@ const TypographySection: React.FC = () => {
 
       {/* Common UI Text */}
       <SpecSection title="Common UI text styles">
-        <Typography sx={{ fontSize: 13, color: theme.palette.text.tertiary, mb: "24px" }}>
-          Specific text styles used for common UI elements.
+        <Typography
+          sx={{ fontSize: fontSize.base, color: theme.palette.text.tertiary, mb: "24px" }}
+        >
+          Specific text styles used for common UI elements (from textStyles.*).
         </Typography>
 
         <Stack spacing="24px">
           <TypographyExample
-            label="Button text"
-            fontSize="13px"
-            fontWeight="500"
-            lineHeight="1"
+            label="Button text (textStyles.button)"
+            {...styleMeta(textStyles.button)}
             color={background.main}
             example="Save changes"
             onCopy={handleCopy}
             bgColor={brand.primary}
           />
           <TypographyExample
-            label="Form label"
-            fontSize="13px"
-            fontWeight="500"
-            lineHeight="22px"
+            label="Form label (textStyles.formLabel)"
+            {...styleMeta(textStyles.formLabel)}
             color={text.secondary}
             example="Email address"
             onCopy={handleCopy}
           />
           <TypographyExample
-            label="Input text"
-            fontSize="13px"
-            fontWeight="400"
-            lineHeight="1.5"
+            label="Input text (textStyles.input)"
+            {...styleMeta(textStyles.input)}
             color="#1c2130"
             example="user@example.com"
             onCopy={handleCopy}
           />
           <TypographyExample
             label="Placeholder"
-            fontSize="13px"
-            fontWeight="400"
-            lineHeight="1.5"
+            {...styleMeta(textStyles.input)}
             color="#838c99"
             example="Enter your email..."
             onCopy={handleCopy}
           />
           <TypographyExample
-            label="Error message"
-            fontSize="11px"
-            fontWeight="400"
-            lineHeight="1.4"
+            label="Error message (textStyles.error)"
+            {...styleMeta(textStyles.error)}
             color="#f04438"
             example="This field is required"
             onCopy={handleCopy}
           />
           <TypographyExample
-            label="Table header"
-            fontSize="12px"
-            fontWeight="500"
-            lineHeight="1.5"
+            label="Table header (textStyles.tableHeader)"
+            {...styleMeta(textStyles.tableHeader)}
             color={text.tertiary}
             example="NAME"
             textTransform="uppercase"
             onCopy={handleCopy}
           />
           <TypographyExample
-            label="Table cell"
-            fontSize="13px"
-            fontWeight="400"
-            lineHeight="1.5"
+            label="Table cell (textStyles.tableCell)"
+            {...styleMeta(textStyles.tableCell)}
             color={text.secondary}
             example="John Doe"
             onCopy={handleCopy}
           />
           <TypographyExample
-            label="Badge text"
-            fontSize="12px"
-            fontWeight="500"
-            lineHeight="1"
+            label="Badge text (textStyles.badge)"
+            {...styleMeta(textStyles.badge)}
             color="#079455"
             example="Active"
             onCopy={handleCopy}
           />
           <TypographyExample
-            label="Tooltip"
-            fontSize="13px"
-            fontWeight="400"
-            lineHeight="1.4"
+            label="Tooltip (textStyles.tooltip)"
+            {...styleMeta(textStyles.tooltip)}
             color={background.main}
             example="Click to view details"
             onCopy={handleCopy}
@@ -298,24 +310,52 @@ const TypographySection: React.FC = () => {
 
       {/* Line Heights */}
       <SpecSection title="Line heights">
-        <Typography sx={{ fontSize: 13, color: theme.palette.text.tertiary, mb: "24px" }}>
-          Standard line height values for different text contexts.
+        <Typography
+          sx={{ fontSize: fontSize.base, color: theme.palette.text.tertiary, mb: "24px" }}
+        >
+          Tokens from lineHeight.* in typography.ts
         </Typography>
 
         <Box
           sx={{
             "display": "grid",
-            "gridTemplateColumns": "repeat(4, 1fr)",
+            "gridTemplateColumns": "repeat(5, 1fr)",
             "gap": "16px",
             "@media (max-width: 900px)": {
               gridTemplateColumns: "repeat(2, 1fr)",
             },
           }}
         >
-          <SpecCard title="Tight" value="1.2" note="Headings, titles" onCopy={handleCopy} />
-          <SpecCard title="Normal" value="1.4" note="Default for most text" onCopy={handleCopy} />
-          <SpecCard title="Relaxed" value="1.5" note="Body text, paragraphs" onCopy={handleCopy} />
-          <SpecCard title="Loose" value="1.75" note="Long-form content" onCopy={handleCopy} />
+          <SpecCard
+            title="Tight"
+            value={String(lineHeight.tight)}
+            note="lineHeight.tight"
+            onCopy={handleCopy}
+          />
+          <SpecCard
+            title="Snug"
+            value={String(lineHeight.snug)}
+            note="Page titles"
+            onCopy={handleCopy}
+          />
+          <SpecCard
+            title="Normal"
+            value={String(lineHeight.normal)}
+            note="Default for most text"
+            onCopy={handleCopy}
+          />
+          <SpecCard
+            title="Relaxed"
+            value={String(lineHeight.relaxed)}
+            note="Body text, paragraphs"
+            onCopy={handleCopy}
+          />
+          <SpecCard
+            title="Loose"
+            value={String(lineHeight.loose)}
+            note="Long-form content"
+            onCopy={handleCopy}
+          />
         </Box>
       </SpecSection>
 
@@ -331,8 +371,8 @@ const TypographySection: React.FC = () => {
       >
         <Typography
           sx={{
-            fontSize: 14,
-            fontWeight: 600,
+            fontSize: fontSize.md,
+            fontWeight: fontWeight.semibold,
             color: theme.palette.text.primary,
             mb: "16px",
           }}
@@ -341,13 +381,14 @@ const TypographySection: React.FC = () => {
         </Typography>
         <Stack spacing="8px">
           {[
-            "Base font size is 13px for most UI text",
-            "Use fontWeight 500 for labels and buttons, 600 for headings",
-            "Always use Inter font family via theme.typography.fontFamily",
+            "Import tokens from themes/typography.ts (fontSize, textStyles) — do not invent sizes",
+            `Base UI text is fontSize.base (${fontSize.base}px); modal description and sidebar/tab labels use textStyles.body`,
+            "Use fontWeight.medium for labels/buttons, fontWeight.semibold for headings",
+            "Font stack is Geist via fontFamily.sans / theme.typography.fontFamily (no Inter)",
             "Text colors should come from theme.palette.text.*",
-            "Error text: fontSize 11px, color theme.palette.status.error.text",
-            "Never use MUI Typography variants (h1-h6) - use custom fontSize/fontWeight",
-            "Form labels: fontSize 13px, fontWeight 500, color text.secondary",
+            "Error text: textStyles.error + theme.palette.status.error.text",
+            "Never use MUI Typography variants (h1-h6) — use textStyles or fontSize/fontWeight tokens",
+            "Form labels: textStyles.formLabel with color text.secondary",
           ].map((item, index) => (
             <Box
               key={index}

--- a/Clients/src/presentation/themes/components.ts
+++ b/Clients/src/presentation/themes/components.ts
@@ -1,4 +1,5 @@
 import { SxProps, Theme } from "@mui/material";
+import { fontSize, textStyles } from "./typography";
 
 /**
  * Standardized component styles to be used across the application
@@ -8,9 +9,9 @@ import { SxProps, Theme } from "@mui/material";
 // Common sizing constants
 export const COMPONENT_SIZES = {
   button: {
-    small: { height: 28, fontSize: 12 },
-    medium: { height: 34, fontSize: 13 },
-    large: { height: 40, fontSize: 14 },
+    small: { height: 28, fontSize: fontSize.sm },
+    medium: { height: 34, fontSize: fontSize.base },
+    large: { height: 40, fontSize: fontSize.md },
   },
   input: {
     small: { height: 32 },
@@ -103,7 +104,7 @@ export const modalStyles = {
   description: (theme: Theme): SxProps<Theme> => ({
     color: theme.palette.text.tertiary,
     marginBottom: theme.spacing(3),
-    fontSize: 14,
+    fontSize: fontSize.md,
     textAlign: "left",
   }),
 
@@ -259,20 +260,19 @@ export const formStyles = {
 
   label: (theme: Theme): SxProps<Theme> => ({
     color: theme.palette.text.secondary,
-    fontSize: "14px",
-    fontWeight: 500,
+    ...textStyles.formLabel,
     marginBottom: theme.spacing(0.5),
   }),
 
   helperText: (theme: Theme): SxProps<Theme> => ({
     color: theme.palette.text.tertiary,
-    fontSize: "12px",
+    fontSize: fontSize.sm,
     marginTop: theme.spacing(0.5),
   }),
 
   errorText: (theme: Theme): SxProps<Theme> => ({
     color: theme.palette.status?.error?.text || "#f04438",
-    fontSize: "12px",
+    ...textStyles.error,
     marginTop: theme.spacing(0.5),
   }),
 };

--- a/Clients/src/presentation/themes/index.ts
+++ b/Clients/src/presentation/themes/index.ts
@@ -9,6 +9,15 @@ export { default as singleTheme } from "./v1SingleTheme";
 export { alertStyles } from "./alerts";
 export { tableStyles } from "./tables";
 export { palette, default as colorPalette } from "./palette";
+export {
+  typography,
+  fontFamily,
+  fontSize,
+  fontWeight,
+  lineHeight,
+  textStyles,
+  default as typographyTokens,
+} from "./typography";
 
 export * from "./mixins";
 export * from "./components";

--- a/Clients/src/presentation/themes/light.ts
+++ b/Clients/src/presentation/themes/light.ts
@@ -1,5 +1,6 @@
 import { createTheme } from "@mui/material/styles";
 import { text, background, border, status, brand } from "./palette";
+import { fontFamily, fontSize, fontWeight } from "./typography";
 
 declare module "@mui/material/Button" {
   interface ButtonPropsVariantOverrides {
@@ -7,13 +8,10 @@ declare module "@mui/material/Button" {
   }
 }
 
-const fontFamilyDefault =
-  "'Geist', system-ui, -apple-system, BlinkMacSystemFont, Helvetica, Arial, sans-serif";
-
 const shadow = "0px 4px 24px -4px rgba(16, 24, 40, 0.08), 0px 3px 3px -3px rgba(16, 24, 40, 0.03)";
 
 const light = createTheme({
-  typography: { fontFamily: fontFamilyDefault, fontSize: 13 },
+  typography: { fontFamily: fontFamily.sans, fontSize: fontSize.base },
   spacing: 2,
   palette: {
     primary: { main: brand.primary },
@@ -122,7 +120,7 @@ const light = createTheme({
               },
             },
           ],
-          "fontWeight": 400,
+          "fontWeight": fontWeight.regular,
           "borderRadius": 4,
           "boxShadow": "none",
           "textTransform": "none",
@@ -200,7 +198,7 @@ const light = createTheme({
           "backgroundColor": "inherit",
           "padding": "4px 6px",
           "color": text.secondary,
-          "fontSize": 13,
+          "fontSize": fontSize.base,
           "margin": 2,
           "marginBottom": 0,
           "minWidth": 100,
@@ -331,7 +329,7 @@ const light = createTheme({
     MuiTooltip: {
       styleOverrides: {
         tooltip: {
-          fontSize: "13px",
+          fontSize: fontSize.base,
           backgroundColor: "#1F2937",
           padding: "8px 12px",
           borderRadius: "4px",

--- a/Clients/src/presentation/themes/mixins.ts
+++ b/Clients/src/presentation/themes/mixins.ts
@@ -1,4 +1,5 @@
 import { SxProps, Theme } from "@mui/material";
+import { fontSize, fontWeight, textStyles } from "./typography";
 
 /**
  * Common style mixins to prevent duplication across components
@@ -250,28 +251,46 @@ export const iconMixins = {
   }),
 };
 
-// Typography mixins
+// Typography mixins — sizes/weights from typography.ts textStyles
 export const typographyMixins = {
   pageTitle: (theme: Theme): SxProps<Theme> => ({
     color: theme.palette.text.primary,
-    fontSize: "16px",
-    fontWeight: 600,
+    ...textStyles.pageTitle,
+  }),
+
+  sectionTitle: (theme: Theme): SxProps<Theme> => ({
+    color: theme.palette.text.primary,
+    ...textStyles.sectionTitle,
   }),
 
   pageDescription: (theme: Theme): SxProps<Theme> => ({
     color: theme.palette.text.secondary,
-    fontSize: theme.typography.fontSize,
+    ...textStyles.body,
   }),
 
   cardTitle: (theme: Theme): SxProps<Theme> => ({
-    fontWeight: 500,
     color: theme.palette.text.primary,
-    fontSize: "16px",
+    ...textStyles.cardTitle,
   }),
 
   cardDescription: (theme: Theme): SxProps<Theme> => ({
     color: theme.palette.text.tertiary,
-    fontSize: "14px",
+    ...textStyles.bodyLarge,
+  }),
+
+  body: (theme: Theme): SxProps<Theme> => ({
+    color: theme.palette.text.primary,
+    ...textStyles.body,
+  }),
+
+  bodySmall: (theme: Theme): SxProps<Theme> => ({
+    color: theme.palette.text.secondary,
+    ...textStyles.bodySmall,
+  }),
+
+  caption: (theme: Theme): SxProps<Theme> => ({
+    color: theme.palette.text.tertiary,
+    ...textStyles.caption,
   }),
 };
 
@@ -283,8 +302,8 @@ export const statusMixins = {
     border: `1px solid ${theme.palette.status?.success?.main || "#17b26a"}`,
     borderRadius: theme.shape.borderRadius,
     padding: theme.spacing(0.5, 1),
-    fontSize: "12px",
-    fontWeight: 500,
+    fontSize: fontSize.sm,
+    fontWeight: fontWeight.medium,
   }),
 
   error: (theme: Theme): SxProps<Theme> => ({
@@ -293,8 +312,8 @@ export const statusMixins = {
     border: `1px solid ${theme.palette.status?.error?.border || "#f04438"}`,
     borderRadius: theme.shape.borderRadius,
     padding: theme.spacing(0.5, 1),
-    fontSize: "12px",
-    fontWeight: 500,
+    fontSize: fontSize.sm,
+    fontWeight: fontWeight.medium,
   }),
 
   warning: (theme: Theme): SxProps<Theme> => ({
@@ -303,8 +322,8 @@ export const statusMixins = {
     border: `1px solid ${theme.palette.status?.warning?.border || "#fec84b"}`,
     borderRadius: theme.shape.borderRadius,
     padding: theme.spacing(0.5, 1),
-    fontSize: "12px",
-    fontWeight: 500,
+    fontSize: fontSize.sm,
+    fontWeight: fontWeight.medium,
   }),
 
   info: (theme: Theme): SxProps<Theme> => ({
@@ -313,7 +332,7 @@ export const statusMixins = {
     border: `1px solid ${theme.palette.status?.info?.border || "#d0d5dd"}`,
     borderRadius: theme.shape.borderRadius,
     padding: theme.spacing(0.5, 1),
-    fontSize: "12px",
-    fontWeight: 500,
+    fontSize: fontSize.sm,
+    fontWeight: fontWeight.medium,
   }),
 };

--- a/Clients/src/presentation/themes/tables.ts
+++ b/Clients/src/presentation/themes/tables.ts
@@ -1,8 +1,4 @@
-const fontSizes = {
-  small: "11px",
-  medium: "13px",
-  large: "16px",
-};
+import { fontSize, fontWeight } from "./typography";
 
 export const tableStyles = {
   primary: {
@@ -21,9 +17,10 @@ export const tableStyles = {
         background: "linear-gradient(180deg, #f9fafb 0%, #f3f4f6 100%)",
       },
       cell: {
+        // Existing tables use base (13); textStyles.tableHeader is 12 for new work
         "color": "#475467",
-        "fontSize": fontSizes.medium,
-        "fontWeight": 400,
+        "fontSize": fontSize.base,
+        "fontWeight": fontWeight.regular,
         "padding": "14px 12px",
         "whiteSpace": "nowrap",
         "&:not(:lastChild)": {
@@ -53,7 +50,7 @@ export const tableStyles = {
         },
       },
       cell: {
-        "fontSize": fontSizes.medium,
+        "fontSize": fontSize.base,
         "padding": "14px 12px",
         "whiteSpace": "nowrap",
         "&:not(:lastChild)": {
@@ -62,7 +59,7 @@ export const tableStyles = {
         },
       },
       button: {
-        "fontSize": fontSizes.medium,
+        "fontSize": fontSize.base,
         "padding": "2px 8px",
         "textTransform": "none",
         "borderRadius": "4px",
@@ -77,7 +74,7 @@ export const tableStyles = {
     },
     footer: {
       cell: {
-        fontSize: fontSizes.small,
+        fontSize: fontSize.caption,
         whiteSpace: "nowrap",
         opacity: 0.7,
       },

--- a/Clients/src/presentation/themes/typography.ts
+++ b/Clients/src/presentation/themes/typography.ts
@@ -1,0 +1,192 @@
+/**
+ * VerifyWise Typography Tokens
+ *
+ * Single source of truth for font families, sizes, weights, line heights,
+ * and semantic text styles across every module.
+ *
+ * Structure mirrors palette.ts:
+ *   1. Primitives — raw allowed values (fontFamily, fontSize, fontWeight, lineHeight)
+ *   2. Semantic   — role-based text styles composed from primitives
+ *
+ * Allowed sizes only: 11, 12, 13, 14, 16, 18, 24
+ * Source of rules: CodeRules/09-design-system/typography.md
+ *
+ * Usage:
+ *   import { fontSize, textStyles, typography } from '@/presentation/themes/typography';
+ *   <Typography sx={textStyles.pageTitle} />
+ *   <Typography sx={{ fontSize: fontSize.base, fontWeight: fontWeight.regular }} />
+ */
+
+// ---------------------------------------------------------------------------
+// 1. Primitives — raw type scale
+// ---------------------------------------------------------------------------
+
+export const fontFamily = {
+  sans: "'Geist', system-ui, -apple-system, BlinkMacSystemFont, Helvetica, Arial, sans-serif",
+  mono: "'Fira Code', 'Consolas', monospace",
+} as const;
+
+/** Allowed font sizes in px. Do not invent sizes outside this scale. */
+export const fontSize = {
+  "caption": 11,
+  "sm": 12,
+  "base": 13,
+  "md": 14,
+  "lg": 16,
+  "xl": 18,
+  "2xl": 24,
+} as const;
+
+export const fontWeight = {
+  regular: 400,
+  medium: 500,
+  semibold: 600,
+  bold: 700,
+} as const;
+
+export const lineHeight = {
+  tight: 1.2,
+  snug: 1.3,
+  normal: 1.4,
+  relaxed: 1.5,
+  loose: 1.75,
+} as const;
+
+export type FontSizeToken = keyof typeof fontSize;
+export type FontWeightToken = keyof typeof fontWeight;
+export type LineHeightToken = keyof typeof lineHeight;
+
+// ---------------------------------------------------------------------------
+// 2. Semantic text styles — role-based composites
+//
+// Quick pick (common surfaces):
+//   Page H1              → pageTitle
+//   In-page section      → sectionTitle
+//   Card / modal / drawer title → cardTitle
+//   Modal description    → body (13), not bodySmall
+//   Sidebar / tab label  → body (prefer shared Sidebar / TabBar)
+//   Form label / error   → formLabel / error
+// ---------------------------------------------------------------------------
+
+export const textStyles = {
+  // Headings
+  /** Main page heading (e.g. Dashboard, Settings). 24 / 600 */
+  pageTitle: {
+    fontSize: fontSize["2xl"],
+    fontWeight: fontWeight.semibold,
+    lineHeight: lineHeight.snug,
+  },
+  /** In-page section heading below the page title. 18 / 600 */
+  sectionTitle: {
+    fontSize: fontSize.xl,
+    fontWeight: fontWeight.semibold,
+    lineHeight: lineHeight.normal,
+  },
+  /** Card, panel, modal, or drawer title. 16 / 600 */
+  cardTitle: {
+    fontSize: fontSize.lg,
+    fontWeight: fontWeight.semibold,
+    lineHeight: lineHeight.normal,
+  },
+  /** Nested heading under a section or card. 14 / 600 */
+  subsectionTitle: {
+    fontSize: fontSize.md,
+    fontWeight: fontWeight.semibold,
+    lineHeight: lineHeight.relaxed,
+  },
+
+  // Body
+  /** Emphasized body / intro copy. 14 / 400 */
+  bodyLarge: {
+    fontSize: fontSize.md,
+    fontWeight: fontWeight.regular,
+    lineHeight: lineHeight.relaxed,
+  },
+  /**
+   * Default UI text: paragraphs, modal description, sidebar/tab labels.
+   * Prefer this over bodySmall for main readable content. 13 / 400
+   */
+  body: {
+    fontSize: fontSize.base,
+    fontWeight: fontWeight.regular,
+    lineHeight: lineHeight.relaxed,
+  },
+  /** Secondary information; quieter than body. Not for modal descriptions. 12 / 400 */
+  bodySmall: {
+    fontSize: fontSize.sm,
+    fontWeight: fontWeight.regular,
+    lineHeight: lineHeight.relaxed,
+  },
+  /** Hints, timestamps, footnotes, helper text under fields. 11 / 400 */
+  caption: {
+    fontSize: fontSize.caption,
+    fontWeight: fontWeight.regular,
+    lineHeight: lineHeight.normal,
+  },
+
+  // UI
+  /** Button label text (sentence case). 13 / 500 */
+  button: {
+    fontSize: fontSize.base,
+    fontWeight: fontWeight.medium,
+    lineHeight: lineHeight.tight,
+  },
+  /** Label above an input field. 13 / 500 */
+  formLabel: {
+    fontSize: fontSize.base,
+    fontWeight: fontWeight.medium,
+    lineHeight: lineHeight.relaxed,
+  },
+  /** Text inside text fields and selects. 13 / 400 */
+  input: {
+    fontSize: fontSize.base,
+    fontWeight: fontWeight.regular,
+    lineHeight: lineHeight.relaxed,
+  },
+  /** Validation / error message below an input. 11 / 400 */
+  error: {
+    fontSize: fontSize.caption,
+    fontWeight: fontWeight.regular,
+    lineHeight: lineHeight.normal,
+  },
+  /** Table column header (often uppercase in UI). 12 / 500 */
+  tableHeader: {
+    fontSize: fontSize.sm,
+    fontWeight: fontWeight.medium,
+    lineHeight: lineHeight.relaxed,
+  },
+  /** Standard table cell text. 13 / 400 */
+  tableCell: {
+    fontSize: fontSize.base,
+    fontWeight: fontWeight.regular,
+    lineHeight: lineHeight.relaxed,
+  },
+  /** Chip / badge / tag label. 12 / 500 */
+  badge: {
+    fontSize: fontSize.sm,
+    fontWeight: fontWeight.medium,
+    lineHeight: lineHeight.tight,
+  },
+  /** Tooltip content. 13 / 400 */
+  tooltip: {
+    fontSize: fontSize.base,
+    fontWeight: fontWeight.regular,
+    lineHeight: lineHeight.normal,
+  },
+} as const;
+
+export type TextStyleToken = keyof typeof textStyles;
+
+// ---------------------------------------------------------------------------
+// Combined export
+// ---------------------------------------------------------------------------
+
+export const typography = {
+  fontFamily,
+  fontSize,
+  fontWeight,
+  lineHeight,
+  textStyles,
+} as const;
+
+export default typography;

--- a/Clients/src/presentation/themes/v1SingleTheme.ts
+++ b/Clients/src/presentation/themes/v1SingleTheme.ts
@@ -5,6 +5,7 @@
 
 import { alertStyles } from "./alerts";
 import { tableStyles } from "./tables";
+import { fontSize, fontWeight, textStyles as typographyTextStyles } from "./typography";
 
 const textColors = {
   theme: "#0f604d",
@@ -20,29 +21,30 @@ const shadowEffect = {
   primary: "0px 4px 24px -4px rgba(16, 24, 40, 0.08), 0px 3px 3px -3px rgba(16, 24, 40, 0.03)",
 };
 
+/** Legacy size keys — values derived from typography.ts (keep export shape for consumers) */
 const fontSizes = {
-  small: "11px",
-  medium: "13px",
-  large: "16px",
+  small: `${fontSize.caption}px`,
+  medium: `${fontSize.base}px`,
+  large: `${fontSize.lg}px`,
 };
 
 // Standardized button sizes
 const buttonSizes = {
   small: {
     height: 28,
-    fontSize: "12px",
+    fontSize: `${fontSize.sm}px`,
     padding: "6px 12px",
     minHeight: 28,
   },
   medium: {
     height: 32,
-    fontSize: "13px",
+    fontSize: `${fontSize.base}px`,
     padding: "8px 16px",
     minHeight: 32,
   },
   large: {
     height: 40,
-    fontSize: "14px",
+    fontSize: `${fontSize.md}px`,
     padding: "10px 20px",
     minHeight: 40,
   },
@@ -89,7 +91,7 @@ const buttons = {
       "textTransform": "inherit",
       "borderRadius": "4px",
       "border": "none",
-      "fontWeight": 500,
+      "fontWeight": fontWeight.medium,
       "transition": "all 0.2s ease",
       "&:hover": {
         backgroundColor: colors.primaryHover,
@@ -112,7 +114,7 @@ const buttons = {
       "boxShadow": "none",
       "textTransform": "inherit",
       "borderRadius": "4px",
-      "fontWeight": 500,
+      "fontWeight": fontWeight.medium,
       "transition": "all 0.2s ease",
       "&:hover": {
         backgroundColor: `${colors.primary}08`,
@@ -135,7 +137,7 @@ const buttons = {
       "boxShadow": "none",
       "textTransform": "inherit",
       "borderRadius": "4px",
-      "fontWeight": 500,
+      "fontWeight": fontWeight.medium,
       "transition": "all 0.2s ease",
       "&:hover": {
         backgroundColor: `${colors.primary}08`,
@@ -159,7 +161,7 @@ const buttons = {
       "textTransform": "inherit",
       "borderRadius": "4px",
       "border": "none",
-      "fontWeight": 500,
+      "fontWeight": fontWeight.medium,
       "transition": "all 0.2s ease",
       "&:hover": {
         backgroundColor: colors.secondaryHover,
@@ -182,7 +184,7 @@ const buttons = {
       "boxShadow": "none",
       "textTransform": "inherit",
       "borderRadius": "4px",
-      "fontWeight": 500,
+      "fontWeight": fontWeight.medium,
       "transition": "all 0.2s ease",
       "&:hover": {
         backgroundColor: `${colors.secondary}08`,
@@ -200,7 +202,7 @@ const buttons = {
       "boxShadow": "none",
       "textTransform": "inherit",
       "borderRadius": "4px",
-      "fontWeight": 500,
+      "fontWeight": fontWeight.medium,
       "transition": "all 0.2s ease",
       "&:hover": {
         backgroundColor: `${colors.secondary}08`,
@@ -220,7 +222,7 @@ const buttons = {
       "textTransform": "inherit",
       "borderRadius": "4px",
       "border": "none",
-      "fontWeight": 500,
+      "fontWeight": fontWeight.medium,
       "transition": "all 0.2s ease",
       "&:hover": {
         backgroundColor: colors.successHover,
@@ -239,7 +241,7 @@ const buttons = {
       "boxShadow": "none",
       "textTransform": "inherit",
       "borderRadius": "4px",
-      "fontWeight": 500,
+      "fontWeight": fontWeight.medium,
       "transition": "all 0.2s ease",
       "&:hover": {
         backgroundColor: `${colors.success}08`,
@@ -254,7 +256,7 @@ const buttons = {
       "boxShadow": "none",
       "textTransform": "inherit",
       "borderRadius": "4px",
-      "fontWeight": 500,
+      "fontWeight": fontWeight.medium,
       "transition": "all 0.2s ease",
       "&:hover": {
         backgroundColor: `${colors.success}08`,
@@ -271,7 +273,7 @@ const buttons = {
       "textTransform": "inherit",
       "borderRadius": "4px",
       "border": "none",
-      "fontWeight": 500,
+      "fontWeight": fontWeight.medium,
       "transition": "all 0.2s ease",
       "&:hover": {
         backgroundColor: colors.warningHover,
@@ -286,7 +288,7 @@ const buttons = {
       "boxShadow": "none",
       "textTransform": "inherit",
       "borderRadius": "4px",
-      "fontWeight": 500,
+      "fontWeight": fontWeight.medium,
       "transition": "all 0.2s ease",
       "&:hover": {
         backgroundColor: `${colors.warning}08`,
@@ -301,7 +303,7 @@ const buttons = {
       "boxShadow": "none",
       "textTransform": "inherit",
       "borderRadius": "4px",
-      "fontWeight": 500,
+      "fontWeight": fontWeight.medium,
       "transition": "all 0.2s ease",
       "&:hover": {
         backgroundColor: `${colors.warning}08`,
@@ -318,7 +320,7 @@ const buttons = {
       "textTransform": "inherit",
       "borderRadius": "4px",
       "border": "none",
-      "fontWeight": 500,
+      "fontWeight": fontWeight.medium,
       "transition": "all 0.2s ease",
       "&:hover": {
         backgroundColor: colors.errorHover,
@@ -337,7 +339,7 @@ const buttons = {
       "boxShadow": "none",
       "textTransform": "inherit",
       "borderRadius": "4px",
-      "fontWeight": 500,
+      "fontWeight": fontWeight.medium,
       "transition": "all 0.2s ease",
       "&:hover": {
         backgroundColor: `${colors.error}08`,
@@ -352,7 +354,7 @@ const buttons = {
       "boxShadow": "none",
       "textTransform": "inherit",
       "borderRadius": "4px",
-      "fontWeight": 500,
+      "fontWeight": fontWeight.medium,
       "transition": "all 0.2s ease",
       "&:hover": {
         backgroundColor: `${colors.error}08`,
@@ -369,7 +371,7 @@ const buttons = {
       "textTransform": "inherit",
       "borderRadius": "4px",
       "border": "none",
-      "fontWeight": 500,
+      "fontWeight": fontWeight.medium,
       "transition": "all 0.2s ease",
       "&:hover": {
         backgroundColor: colors.infoHover,
@@ -384,7 +386,7 @@ const buttons = {
       "boxShadow": "none",
       "textTransform": "inherit",
       "borderRadius": "4px",
-      "fontWeight": 500,
+      "fontWeight": fontWeight.medium,
       "transition": "all 0.2s ease",
       "&:hover": {
         backgroundColor: `${colors.info}08`,
@@ -399,7 +401,7 @@ const buttons = {
       "boxShadow": "none",
       "textTransform": "inherit",
       "borderRadius": "4px",
-      "fontWeight": 500,
+      "fontWeight": fontWeight.medium,
       "transition": "all 0.2s ease",
       "&:hover": {
         backgroundColor: `${colors.info}08`,
@@ -411,12 +413,11 @@ const buttons = {
 const textStyles = {
   pageTitle: {
     color: "#1A1919",
-    fontSize: fontSizes.large,
-    fontWeight: 600,
+    ...typographyTextStyles.pageTitle,
   },
   pageDescription: {
     color: "#344054",
-    fontSize: fontSizes.medium,
+    ...typographyTextStyles.body,
   },
 };
 
@@ -426,7 +427,7 @@ const dropDownStyles = {
     "& ul": { p: "5px" },
     "& li": {
       "m": 0,
-      "fontSize": 13,
+      "fontSize": fontSize.base,
       "& .MuiTouchRipple-root": {
         display: "none",
       },

--- a/CodeRules/09-design-system/typography.md
+++ b/CodeRules/09-design-system/typography.md
@@ -46,7 +46,7 @@ Base font size: **13px**
 | Element | Size | Weight | Line Height | Notes |
 |---------|------|--------|-------------|-------|
 | Button text | 13px | 500 | 1 | Sentence case |
-| Form label | 13px | 500 | 22px | Above input fields |
+| Form label | 13px | 500 | 1.5 | Above input fields |
 | Input text | 13px | 400 | 1.5 | Inside text fields |
 | Placeholder | 13px | 400 | 1.5 | `text.accent` color |
 | Error message | 11px | 400 | 1.4 | Below input fields |
@@ -72,24 +72,31 @@ Do NOT use arbitrary sizes like 15px, 17px, 19px, etc.
 
 ## Usage in Code
 
-```tsx
-// Use sx prop with explicit values (not MUI Typography variants)
-<Typography sx={{ fontSize: 16, fontWeight: 600 }}>Card Title</Typography>
-<Typography sx={{ fontSize: 13, fontWeight: 400 }}>Body text</Typography>
-<Typography sx={{ fontSize: 12, fontWeight: 500 }}>Small label</Typography>
+Source of truth: [`Clients/src/presentation/themes/typography.ts`](../../Clients/src/presentation/themes/typography.ts)
 
-// Use theme typography mixins
+```tsx
+import { textStyles, fontSize, fontWeight } from "@/presentation/themes/typography";
 import { typographyMixins } from "@/presentation/themes/mixins";
 
+// Prefer semantic text styles
+<Typography sx={textStyles.cardTitle}>Card Title</Typography>
+<Typography sx={textStyles.body}>Body text</Typography>
+<Typography sx={textStyles.formLabel}>Email</Typography>
+
+// Or mixins (adds theme colors)
 <Typography sx={typographyMixins.pageTitle(theme)}>Page Title</Typography>
 <Typography sx={typographyMixins.cardTitle(theme)}>Card Title</Typography>
+
+// Primitives when no role fits
+<Typography sx={{ fontSize: fontSize.sm, fontWeight: fontWeight.medium }}>Small label</Typography>
 ```
 
 > **Note:** Do not use MUI Typography variants (h1-h6, body1, body2) directly.
-> Use explicit `sx` props with the sizes defined above.
+> Use `textStyles` / mixins / `fontSize` tokens from `typography.ts`.
 
 ## Related Documents
 
 - [Colors](./colors.md)
 - [Spacing](./spacing.md)
 - [Component Patterns](./component-patterns.md)
+- [Design Tokens](../../docs/technical/guides/design-tokens.md#typography)

--- a/docs/technical/frontend/styling.md
+++ b/docs/technical/frontend/styling.md
@@ -10,11 +10,13 @@ VerifyWise uses Material-UI (MUI) v7 with Emotion for CSS-in-JS styling. The des
 Clients/src/presentation/
 ├── themes/
 │   ├── light.ts          # Main theme & MUI overrides
+│   ├── typography.ts     # Type scale + textStyles
+│   ├── palette.ts        # Semantic color tokens
 │   ├── components.ts     # Component style exports
 │   ├── mixins.ts         # Reusable style functions
 │   ├── alerts.ts         # Alert color definitions
 │   ├── tables.ts         # Table styling standards
-│   └── v1SingleTheme.ts  # Design constants
+│   └── v1SingleTheme.ts  # Legacy style bag (derives from tokens)
 ├── styles/
 │   └── colors.ts         # Dashboard color palette
 ├── App.css               # Global styles
@@ -111,31 +113,38 @@ grid: "#a2a3a3"
 
 ## Typography
 
+Source of truth: `Clients/src/presentation/themes/typography.ts`  
+Full reference: [Design Tokens — Typography](../guides/design-tokens.md#typography)
+
 ### Font Stack
 
 ```css
-font-family: "Geist", "Inter", system-ui, -apple-system,
+font-family: 'Geist', system-ui, -apple-system,
              BlinkMacSystemFont, Helvetica, Arial, sans-serif;
 ```
 
 ### Font Sizes
 
-| Size | Value | Usage |
-|------|-------|-------|
-| Base | 13px | Default text |
-| Small | 11px | Labels, captions |
-| Medium | 13px | Body text |
-| Large | 16px | Headings |
-| XLarge | 24px | Page titles |
+Allowed: **11, 12, 13, 14, 16, 18, 24** (`fontSize.caption` … `fontSize["2xl"]`).
+
+| Token | Value | Usage |
+|-------|-------|-------|
+| `caption` | 11px | Captions, errors |
+| `sm` | 12px | Secondary, badges |
+| `base` | 13px | Default UI / body |
+| `md` | 14px | Emphasized body |
+| `lg` / `xl` / `2xl` | 16 / 18 / 24 | Card / section / page titles |
+
+Prefer `textStyles.*` (e.g. `textStyles.body`, `textStyles.cardTitle`) over raw sizes.
 
 ### Font Weights
 
-| Weight | Value | Usage |
-|--------|-------|-------|
-| Normal | 400 | Body text |
-| Medium | 500 | Labels |
-| Semibold | 600 | Headings |
-| Bold | 700 | Emphasis |
+| Token | Value | Usage |
+|-------|-------|-------|
+| `regular` | 400 | Body text |
+| `medium` | 500 | Labels |
+| `semibold` | 600 | Headings |
+| `bold` | 700 | Emphasis |
 
 ### Text Styles (from colors.ts)
 
@@ -244,9 +253,9 @@ import { buttonMixins, cardMixins, layoutMixins } from "@/presentation/themes/mi
 <Box sx={layoutMixins.flexBetween()} />
 <Box sx={layoutMixins.container()} />
 
-// Typography styles
-<Typography sx={typographyMixins.pageTitle()} />
-<Typography sx={typographyMixins.cardDescription()} />
+// Typography styles (or import textStyles from themes/typography)
+<Typography sx={typographyMixins.pageTitle(theme)} />
+<Typography sx={typographyMixins.cardTitle(theme)} />
 
 // Status styles
 <Chip sx={statusMixins.success()} />
@@ -536,14 +545,16 @@ disableRipple  // Already disabled globally
 | Border radius | `4px` (buttons/cards), `2px` (inputs) |
 | Button height | `34px` (medium) |
 | Base spacing | `2px` multiplier |
-| Base font size | `13px` |
-| Font family | Geist, Inter, system |
+| Base font size | `13px` (`fontSize.base`) |
+| Font family | Geist + system (`fontFamily.sans`) |
 
 ## Key Files
 
 | File | Purpose |
 |------|---------|
 | `themes/light.ts` | Theme configuration, MUI overrides |
+| `themes/typography.ts` | Type scale + semantic textStyles |
+| `themes/palette.ts` | Semantic color tokens |
 | `themes/components.ts` | Component style exports |
 | `themes/mixins.ts` | Reusable style functions |
 | `themes/alerts.ts` | Alert color definitions |

--- a/docs/technical/guides/design-tokens.md
+++ b/docs/technical/guides/design-tokens.md
@@ -10,7 +10,10 @@ This guide documents the design tokens, theme configuration, and visual standard
 Clients/src/presentation/themes/
 ├── index.ts           # Central export hub
 ├── light.ts           # Main MUI theme configuration
-├── v1SingleTheme.ts   # Standardized patterns
+├── palette.ts         # Semantic color tokens
+├── primitives.ts      # Color ramps (when present on branch)
+├── typography.ts      # Type scale + semantic textStyles (Phase 2)
+├── v1SingleTheme.ts   # Legacy style bag (derives from tokens)
 ├── theme.d.ts         # TypeScript type definitions
 ├── components.ts      # Reusable component styles
 ├── mixins.ts          # Style mixins
@@ -122,59 +125,77 @@ export const alertStyles = {
 
 ## Typography
 
+Source of truth: [`Clients/src/presentation/themes/typography.ts`](../../../Clients/src/presentation/themes/typography.ts)  
+Rules: [`CodeRules/09-design-system/typography.md`](../../../CodeRules/09-design-system/typography.md)
+
+Allowed sizes only: **11, 12, 13, 14, 16, 18, 24**. Do not invent sizes outside this scale.
+
 ### Font Families
 
 ```typescript
-const fontFamily = [
-  "Geist",
-  "Inter",
-  "system-ui",
-  "-apple-system",
-  "BlinkMacSystemFont",
-  "Helvetica",
-  "Arial",
-  "sans-serif",
-].join(", ");
+import { fontFamily } from "@/presentation/themes/typography";
 
-const monoFontFamily = [
-  "Geist Mono",
-  "Fira Code",
-  "Consolas",
-  "monospace",
-].join(", ");
+fontFamily.sans // 'Geist', system-ui, -apple-system, BlinkMacSystemFont, Helvetica, Arial, sans-serif
+fontFamily.mono // 'Fira Code', 'Consolas', monospace
 ```
 
-### Font Sizes
+### Font Sizes (`fontSize.*`)
 
 | Token | Size | Usage |
 |-------|------|-------|
-| `xs` / `sm` | 12px | Small labels, captions |
-| `base` | 13px | Default body text |
-| `md` | 14px | Emphasized body text |
-| `lg` | 15px | Large body text |
-| `xl` | 16px | Small headings |
-| `2xl` | 20px | Section headings |
-| `3xl` | 22px | Page headings |
-| `4xl` | 26px | Large headings |
-| `5xl` | 30px | Display headings |
+| `caption` | 11px | Captions, footnotes, error text |
+| `sm` | 12px | Body small, badges, table headers |
+| `base` | 13px | Default UI / body / tabs / modal description |
+| `md` | 14px | Emphasized body, subsection titles |
+| `lg` | 16px | Card / modal / drawer titles |
+| `xl` | 18px | Section titles |
+| `2xl` | 24px | Page titles |
 
-### Font Weights
+### Font Weights (`fontWeight.*`)
 
 | Token | Weight | Usage |
 |-------|--------|-------|
-| `normal` | 400 | Body text |
-| `medium` | 500 | Emphasized text, buttons |
-| `semibold` | 600 | Headings, labels |
-| `bold` | 700 | Strong emphasis |
+| `regular` | 400 | Body text |
+| `medium` | 500 | Labels, buttons, badges |
+| `semibold` | 600 | Headings |
+| `bold` | 700 | Strong emphasis (rare) |
 
-### Line Heights
+### Line Heights (`lineHeight.*`)
 
 | Token | Value | Usage |
 |-------|-------|-------|
-| `tight` | 1.2 | Headings |
-| `snug` | 1.3 | Compact text |
-| `normal` | 1.4 | Default body |
-| `relaxed` | 1.5 | Readable paragraphs |
+| `tight` | 1.2 | Buttons, badges |
+| `snug` | 1.3 | Page titles |
+| `normal` | 1.4 | Captions, section/card titles |
+| `relaxed` | 1.5 | Body text |
+| `loose` | 1.75 | Long-form content |
+
+### Semantic text styles (`textStyles.*`)
+
+Prefer roles over raw sizes in UI code:
+
+| Style | Size / weight | Typical use |
+|-------|---------------|-------------|
+| `pageTitle` | 24 / 600 | Page H1 |
+| `sectionTitle` | 18 / 600 | In-page section |
+| `cardTitle` | 16 / 600 | Card, modal, drawer title |
+| `subsectionTitle` | 14 / 600 | Nested heading |
+| `body` | 13 / 400 | Default copy, modal description, sidebar/tab labels |
+| `bodyLarge` / `bodySmall` / `caption` | 14 / 12 / 11 | Emphasized / secondary / meta |
+| `formLabel` / `input` / `error` | 13 / 13 / 11 | Forms |
+| `button` / `badge` / `tooltip` | 13 / 12 / 13 | Controls |
+| `tableHeader` / `tableCell` | 12 / 13 | Tables |
+
+```typescript
+import { textStyles, fontSize } from "@/presentation/themes/typography";
+
+<Typography sx={textStyles.cardTitle}>Modal title</Typography>
+<Typography sx={textStyles.body}>Modal description</Typography>
+```
+
+### Phase 2 note
+
+Typography foundation (tokens + theme helpers) is in place. Broad replacement of hardcoded `fontSize` literals across feature pages remains a later migration.
 
 ## Spacing
 
@@ -395,13 +416,13 @@ sx={cardMixins.interactive}
 import { typographyMixins } from "../themes/mixins";
 
 // Page title
-sx={typographyMixins.pageTitle}
+sx={typographyMixins.pageTitle(theme)}
 
-// Section heading
-sx={typographyMixins.sectionHeading}
+// Section title
+sx={typographyMixins.sectionTitle(theme)}
 
 // Body text
-sx={typographyMixins.body}
+sx={typographyMixins.body(theme)}
 ```
 
 ### Status Mixins
@@ -523,7 +544,7 @@ function MyComponent() {
 import { cardMixins, typographyMixins } from "../themes/mixins";
 
 <Card sx={{ ...cardMixins.standard, padding: 3 }}>
-  <Typography sx={typographyMixins.sectionHeading}>
+  <Typography sx={typographyMixins.sectionTitle(theme)}>
     Section Title
   </Typography>
 </Card>
@@ -559,6 +580,8 @@ import { cardMixins, typographyMixins } from "../themes/mixins";
 | File | Purpose |
 |------|---------|
 | `Clients/src/presentation/themes/light.ts` | Main MUI theme |
+| `Clients/src/presentation/themes/typography.ts` | Type scale + semantic textStyles |
+| `Clients/src/presentation/themes/palette.ts` | Semantic color tokens |
 | `Clients/src/presentation/themes/components.ts` | Reusable component styles |
 | `Clients/src/presentation/themes/mixins.ts` | Style mixins |
 | `Clients/src/presentation/themes/alerts.ts` | Alert status styles |


### PR DESCRIPTION
## Describe your changes

## Summary
- Add `Clients/src/presentation/themes/typography.ts` as the single source of truth for font families, sizes (11–24), weights, line heights, and semantic `textStyles`.
- Wire `light.ts`, mixins, tables, components, and `v1SingleTheme` to those tokens so theme helpers no longer invent their own px maps.
- Sync StyleGuide Typography section, `design-tokens.md`, `styling.md`, and CodeRules typography docs with the new tokens (Geist stack; no Inter).



## Write your issue number after "Fixes "

Fixes #4276 

## Please ensure all items are checked off before requesting a review:

- [ ] I deployed the code locally.
- [ ] I have performed a self-review of my code.
- [ ] I have included the issue # in the PR.
- [ ] I have labelled the PR correctly.
- [ ] The issue I am working on is assigned to me.
- [ ] I have avoided using hardcoded values to ensure scalability and maintain consistency across the application.
- [ ] I have ensured that font sizes, color choices, and other UI elements are referenced from the theme.
- [ ] My pull request is focused and addresses a single, specific feature.
- [ ] If there are UI changes, I have attached a screenshot or video to this PR.
- [ ] If I added or modified an API endpoint, the change is reflected in the generated OpenAPI spec (`npm run generate:swagger`).
- [ ] If the endpoint requires authentication, it uses `authenticateJWT` and the generated spec declares `bearerAuth` security.
- [ ] I ran `npm run check:api-drift` and committed the regenerated `swagger.yaml` and `endpoints.ts`.
- [ ] If this PR adds or modifies an organization-scoped table, the [tenant isolation registry](Servers/tests/integration/tenant-isolation/tenantIsolation.registry.ts) and [test matrix](Servers/tests/integration/tenant-isolation) are updated. See the [tenant isolation runbook](docs/technical/security/tenant-isolation.md) for details.
