### PR TITLE
Admin Registration Lockdown

### DIFF
--- a/Clients/src/application/config/routes.tsx
+++ b/Clients/src/application/config/routes.tsx
@@ -6,6 +6,7 @@ import { SHOW_AI_GATEWAY_PROMPTS } from "./featureFlags";
 // Eager imports — app shell, route guard, and Use cases page (mounts with layout for table skeleton UX)
 import Dashboard from "../../presentation/containers/Dashboard";
 import ProtectedRoute from "../../presentation/components/ProtectedRoute";
+import SetupGate from "../../presentation/components/SetupGate";
 import VWHome from "../../presentation/pages/Home/1.0Home";
 
 // ── Authentication routes ─────────────────────────────────────────────
@@ -27,6 +28,9 @@ const MicrosoftCallback = lazyRoute(
 );
 const RegisterUser = lazyRoute(
   () => import("../../presentation/pages/Authentication/RegisterUser"),
+);
+const RegisterMultiTenant = lazyRoute(
+  () => import("../../presentation/pages/Authentication/RegisterMultiTenant"),
 );
 
 // ── Core dashboard routes ─────────────────────────────────────────────
@@ -1141,8 +1145,28 @@ export const createRoutes = (
       </Suspense>
     }
   />,
-  <Route key="register" path="/register" element={<Navigate to="/login" replace />} />,
-  <Route key="admin-reg" path="/admin-reg" element={<Navigate to="/login" replace />} />,
+  <Route
+    key="register"
+    path="/register"
+    element={
+      <Suspense fallback={<LazyFallback />}>
+        <SetupGate>
+          <RegisterMultiTenant />
+        </SetupGate>
+      </Suspense>
+    }
+  />,
+  <Route
+    key="admin-reg"
+    path="/admin-reg"
+    element={
+      <Suspense fallback={<LazyFallback />}>
+        <SetupGate>
+          <RegisterMultiTenant />
+        </SetupGate>
+      </Suspense>
+    }
+  />,
   <Route
     key="login"
     path="/login"

--- a/Clients/src/application/repository/organization.repository.ts
+++ b/Clients/src/application/repository/organization.repository.ts
@@ -37,6 +37,22 @@ export async function CreateMyOrganization({
 }
 
 /**
+ * Creates the first organization and admin user during initial system setup.
+ *
+ * This endpoint only succeeds when the system has no users/organizations yet.
+ *
+ * @param {RequestParams} params - The parameters for creating the first organization.
+ * @returns {Promise<any>} A promise that resolves to the response data.
+ */
+export async function CreateFirstOrganization({
+  routeUrl = "/organizations/setup",
+  body,
+}: RequestParams): Promise<any> {
+  const response = await apiServices.post(routeUrl, body);
+  return response;
+}
+
+/**
  * Updates the current user's organization details.
  *
  * @param {RequestParams} params - The parameters for updating the organization.

--- a/Clients/src/presentation/components/SetupGate/index.tsx
+++ b/Clients/src/presentation/components/SetupGate/index.tsx
@@ -1,0 +1,60 @@
+import { useEffect, useState } from "react";
+import { useSelector } from "react-redux";
+import { Navigate } from "react-router-dom";
+import { checkOrganizationExists } from "../../../application/repository/organization.repository";
+import { RootState } from "../../../application/redux/store";
+import { LazyFallback } from "../../../application/utils/lazyRoute";
+
+interface SetupGateProps {
+  children: React.ReactNode;
+}
+
+/**
+ * SetupGate ensures the registration/setup routes are only reachable while the
+ * system has not been initialized yet.
+ *
+ * - If no organization exists, render the setup form.
+ * - If an organization exists, redirect authenticated users to `/` and
+ *   unauthenticated users to `/login`.
+ */
+const SetupGate = ({ children }: SetupGateProps) => {
+  const { authToken } = useSelector((state: RootState) => state.auth);
+  const [organizationExists, setOrganizationExists] = useState<boolean | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    const checkExists = async () => {
+      try {
+        const exists = await checkOrganizationExists();
+        if (!cancelled) {
+          setOrganizationExists(exists);
+        }
+      } catch (error) {
+        console.error("Failed to check organization existence:", error);
+        // Fail closed: treat an error as "already initialized" so the setup
+        // form is not exposed unintentionally.
+        if (!cancelled) {
+          setOrganizationExists(true);
+        }
+      }
+    };
+
+    checkExists();
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  if (organizationExists === null) {
+    return <LazyFallback />;
+  }
+
+  if (organizationExists) {
+    return <Navigate to={authToken ? "/" : "/login"} replace />;
+  }
+
+  return <>{children}</>;
+};
+
+export default SetupGate;

--- a/Clients/src/presentation/pages/Authentication/RegisterMultiTenant/index.tsx
+++ b/Clients/src/presentation/pages/Authentication/RegisterMultiTenant/index.tsx
@@ -25,7 +25,7 @@ import {
   setAuthToken,
   setExpiration,
 } from "../../../../application/redux/auth/authSlice";
-import { CreateMyOrganization } from "../../../../application/repository/organization.repository";
+import { CreateFirstOrganization } from "../../../../application/repository/organization.repository";
 import useUsers from "../../../../application/hooks/useUsers";
 
 // Initial state for form values
@@ -146,8 +146,8 @@ const RegisterMultiTenant: React.FC = () => {
       userRoleId: values.roleId,
     };
 
-    const response = (await CreateMyOrganization({
-      routeUrl: "/organizations",
+    const response = (await CreateFirstOrganization({
+      routeUrl: "/organizations/setup",
       body: requestBody,
     })) as any;
     setValues(initialState);

--- a/Servers/controllers/organization.ctrl.ts
+++ b/Servers/controllers/organization.ctrl.ts
@@ -28,9 +28,11 @@
  */
 
 import { Request, Response } from "express";
+import { Transaction } from "sequelize";
 import { STATUS_CODE } from "../utils/statusCode.utils";
 import { sequelize } from "../database/db";
 import { OrganizationModel } from "../domain.layer/models/organization/organization.model";
+import { UserModel } from "../domain.layer/models/user/user.model";
 import {
   createOrganizationQuery,
   deleteOrganizationByIdQuery,
@@ -266,6 +268,56 @@ export async function getOrganizationById(req: Request, res: Response): Promise<
  *   }
  * }
  */
+async function buildOrganizationAndAdmin(
+  body: {
+    name: string;
+    logo?: string;
+    userEmail: string;
+    userName: string;
+    userSurname: string;
+    userPassword: string;
+  },
+  transaction: Transaction,
+  res: Response,
+): Promise<{
+  user: UserModel;
+  organization: OrganizationModel;
+  accessToken: string;
+}> {
+  const organizationModel = await OrganizationModel.createNewOrganization(body.name, body.logo);
+  await organizationModel.validateOrganizationData();
+  const createdOrganization = await createOrganizationQuery(organizationModel, transaction);
+
+  if (!createdOrganization) {
+    throw new ValidationException("Unable to create organization");
+  }
+
+  const organization_id = createdOrganization.id!;
+  const user = await createNewUserWrapper(
+    {
+      email: body.userEmail,
+      name: body.userName,
+      surname: body.userSurname,
+      password: body.userPassword,
+      roleId: 1, // Admin
+      organizationId: organization_id,
+    },
+    transaction,
+  );
+
+  const { accessToken } = generateUserTokens(
+    {
+      id: user.id!,
+      email: body.userEmail,
+      roleName: "Admin",
+      organizationId: organization_id,
+    },
+    res,
+  );
+
+  return { user, organization: createdOrganization, accessToken };
+}
+
 export async function createOrganization(req: Request, res: Response): Promise<any> {
   const transaction = await sequelize.transaction();
   logStructured(
@@ -276,99 +328,45 @@ export async function createOrganization(req: Request, res: Response): Promise<a
   );
   logger.debug("🛠️ Creating new organization");
   try {
-    const body = req.body as {
-      name: string;
-      logo: string;
-      userEmail: string;
-      userName: string;
-      userSurname: string;
-      userPassword: string;
-    };
-
-    // Use the OrganizationModel's createNewOrganization method with validation
-    const organizationModel = await OrganizationModel.createNewOrganization(body.name, body.logo);
-
-    // Validate the organization data before saving
-    await organizationModel.validateOrganizationData();
-
-    // Use the utility query function for database operation
-    const createdOrganization = await createOrganizationQuery(organizationModel, transaction);
-
-    if (createdOrganization) {
-      const organization_id = createdOrganization.id!;
-      // With shared-schema multi-tenancy, no tenant schema creation needed
-      // All data goes to public schema with organization_id column
-      const user = await createNewUserWrapper(
-        {
-          email: body.userEmail,
-          name: body.userName,
-          surname: body.userSurname,
-          password: body.userPassword,
-          roleId: 1, // Assuming 1 is the default role ID for Admin
-          organizationId: organization_id,
-        },
-        transaction,
-      );
-
-      // Generate tokens for the newly created user
-      const { accessToken } = generateUserTokens(
-        {
-          id: user.id!,
-          email: body.userEmail,
-          roleName: "Admin", // roleId 1 corresponds to Admin
-          organizationId: organization_id,
-        },
-        res,
-      );
-
-      await transaction.commit();
-      logStructured(
-        "successful",
-        `organization created: ${createdOrganization.name}`,
-        "createOrganization",
-        "organization.ctrl.ts",
-      );
-      await logEvent(
-        "Create",
-        `Organization created: ${createdOrganization.name}`,
-        user.id!,
-        organization_id,
-      );
-      return res.status(201).json(
-        STATUS_CODE[201]({
-          user: user.toSafeJSON(),
-          organization: {
-            id: createdOrganization.id,
-            name: createdOrganization.name,
-          },
-          token: accessToken,
-        }),
-      );
-    }
+    const result = await buildOrganizationAndAdmin(req.body, transaction, res);
+    await transaction.commit();
 
     logStructured(
-      "error",
-      "failed to create organization",
+      "successful",
+      `organization created: ${result.organization.name}`,
       "createOrganization",
       "organization.ctrl.ts",
     );
-    await logEvent("Error", "Organization creation failed", req.userId!, req.organizationId!);
-    await transaction.rollback();
-    return res.status(400).json(STATUS_CODE[400](req.t!("Unable to create organization")));
+    await logEvent(
+      "Create",
+      `Organization created: ${result.organization.name}`,
+      result.user.id!,
+      result.organization.id!,
+    );
+
+    return res.status(201).json(
+      STATUS_CODE[201]({
+        user: result.user.toSafeJSON(),
+        organization: {
+          id: result.organization.id,
+          name: result.organization.name,
+        },
+        token: result.accessToken,
+      }),
+    );
   } catch (error) {
     await transaction.rollback();
 
-    // Handle specific validation errors
     if (error instanceof ValidationException) {
       logStructured(
         "error",
-        `validation failed: ${error.message}`,
+        `validation failed: ${(error as Error).message}`,
         "createOrganization",
         "organization.ctrl.ts",
       );
       await logEvent(
         "Error",
-        `Validation error during organization creation: ${error.message}`,
+        `Validation error during organization creation: ${(error as Error).message}`,
         req.userId!,
         req.organizationId!,
       );
@@ -378,13 +376,13 @@ export async function createOrganization(req: Request, res: Response): Promise<a
     if (error instanceof BusinessLogicException) {
       logStructured(
         "error",
-        `business logic error: ${error.message}`,
+        `business logic error: ${(error as Error).message}`,
         "createOrganization",
         "organization.ctrl.ts",
       );
       await logEvent(
         "Error",
-        `Business logic error during organization creation: ${error.message}`,
+        `Business logic error during organization creation: ${(error as Error).message}`,
         req.userId!,
         req.organizationId!,
       );
@@ -404,6 +402,97 @@ export async function createOrganization(req: Request, res: Response): Promise<a
       req.organizationId!,
     );
     logger.error("❌ Error in createOrganization:", error);
+    return res.status(500).json(STATUS_CODE[500](translateError(req, error)));
+  }
+}
+
+export async function createFirstOrganization(req: Request, res: Response): Promise<any> {
+  const transaction = await sequelize.transaction();
+  logStructured(
+    "processing",
+    "starting createFirstOrganization",
+    "createFirstOrganization",
+    "organization.ctrl.ts",
+  );
+  logger.debug("🛠️ Creating first organization");
+  try {
+    const result = await buildOrganizationAndAdmin(req.body, transaction, res);
+    await transaction.commit();
+
+    logStructured(
+      "successful",
+      `first organization created: ${result.organization.name}`,
+      "createFirstOrganization",
+      "organization.ctrl.ts",
+    );
+    await logEvent(
+      "Create",
+      `First organization created: ${result.organization.name}`,
+      result.user.id!,
+      result.organization.id!,
+    );
+
+    return res.status(201).json(
+      STATUS_CODE[201]({
+        user: result.user.toSafeJSON(),
+        organization: {
+          id: result.organization.id,
+          name: result.organization.name,
+        },
+        token: result.accessToken,
+      }),
+    );
+  } catch (error) {
+    await transaction.rollback();
+
+    const actorId = req.userId ?? 0;
+    const organizationId = req.organizationId ?? 0;
+
+    if (error instanceof ValidationException) {
+      logStructured(
+        "error",
+        `validation failed: ${(error as Error).message}`,
+        "createFirstOrganization",
+        "organization.ctrl.ts",
+      );
+      await logEvent(
+        "Error",
+        `Validation error during first organization creation: ${(error as Error).message}`,
+        actorId,
+        organizationId,
+      );
+      return res.status(400).json(STATUS_CODE[400](translateError(req, error)));
+    }
+
+    if (error instanceof BusinessLogicException) {
+      logStructured(
+        "error",
+        `business logic error: ${(error as Error).message}`,
+        "createFirstOrganization",
+        "organization.ctrl.ts",
+      );
+      await logEvent(
+        "Error",
+        `Business logic error during first organization creation: ${(error as Error).message}`,
+        actorId,
+        organizationId,
+      );
+      return res.status(403).json(STATUS_CODE[403](translateError(req, error)));
+    }
+
+    logStructured(
+      "error",
+      "unexpected error during first organization creation",
+      "createFirstOrganization",
+      "organization.ctrl.ts",
+    );
+    await logEvent(
+      "Error",
+      `Unexpected error during first organization creation: ${(error as Error).message}`,
+      actorId,
+      organizationId,
+    );
+    logger.error("❌ Error in createFirstOrganization:", error);
     return res.status(500).json(STATUS_CODE[500](translateError(req, error)));
   }
 }

--- a/Servers/middleware/setupGuard.middleware.ts
+++ b/Servers/middleware/setupGuard.middleware.ts
@@ -1,0 +1,58 @@
+import { NextFunction, Request, Response } from "express";
+import { STATUS_CODE } from "../utils/statusCode.utils";
+import { checkUserExistsQuery } from "../utils/user.utils";
+
+/**
+ * Blocks the request if the system already has at least one user.
+ *
+ * Use this on public first-setup endpoints (e.g. the initial organization
+ * registration route) so they can only be used while the system is still
+ * uninitialized.
+ */
+export const requireSystemNotInitialized = async (
+  req: Request,
+  res: Response,
+  next: NextFunction,
+): Promise<void | Response> => {
+  try {
+    const userExists = await checkUserExistsQuery();
+    if (userExists) {
+      return res.status(403).json(
+        STATUS_CODE[403]({
+          message: req.t!("System is already initialized. Registration is closed."),
+        }),
+      );
+    }
+    next();
+  } catch (error) {
+    console.error("Error in requireSystemNotInitialized middleware:", error);
+    return res.status(500).json(STATUS_CODE[500]((error as Error).message));
+  }
+};
+
+/**
+ * Blocks the request if the system has not been initialized yet.
+ *
+ * This is the inverse guard for endpoints that should only work once at least
+ * one user exists.
+ */
+export const requireSystemInitialized = async (
+  req: Request,
+  res: Response,
+  next: NextFunction,
+): Promise<void | Response> => {
+  try {
+    const userExists = await checkUserExistsQuery();
+    if (!userExists) {
+      return res.status(403).json(
+        STATUS_CODE[403]({
+          message: req.t!("System is not initialized. Please complete setup first."),
+        }),
+      );
+    }
+    next();
+  } catch (error) {
+    console.error("Error in requireSystemInitialized middleware:", error);
+    return res.status(500).json(STATUS_CODE[500]((error as Error).message));
+  }
+};

--- a/Servers/routes/organization.route.ts
+++ b/Servers/routes/organization.route.ts
@@ -26,6 +26,7 @@ const router = express.Router();
 
 import {
   createOrganization,
+  createFirstOrganization,
   getOrganizationById,
   updateOrganizationById,
   getOrganizationsExists,
@@ -34,6 +35,7 @@ import {
 
 import authenticateJWT from "../middleware/auth.middleware";
 import superAdminOnly from "../middleware/superAdminOnly.middleware";
+import { requireSystemNotInitialized } from "../middleware/setupGuard.middleware";
 
 /**
  * GET /organizations/exists
@@ -50,6 +52,20 @@ import superAdminOnly from "../middleware/superAdminOnly.middleware";
  * @returns {boolean} True if organizations exist, false otherwise
  */
 router.get("/exists", getOrganizationsExists);
+
+/**
+ * POST /organizations/setup
+ *
+ * Public first-time setup endpoint.
+ * Creates the first organization and admin user only when the system has no
+ * users yet. Once initialized, this endpoint returns 403.
+ *
+ * @name post/setup
+ * @function
+ * @memberof module:routes/organization.route
+ * @inner
+ */
+router.post("/setup", requireSystemNotInitialized, createFirstOrganization);
 
 /**
  * GET /organizations/:id

--- a/Servers/tests/integration/setup-guard.test.ts
+++ b/Servers/tests/integration/setup-guard.test.ts
@@ -1,0 +1,48 @@
+import { createTestApp, testRequest } from "./setup";
+import { createTestOrganization, createTestUser, cleanupDatabase } from "./helpers";
+
+jest.setTimeout(20000);
+
+const SETUP_EMAIL = "setup-admin@test.com";
+const SETUP_PASSWORD = "SetupPass123!";
+
+describe("POST /api/organizations/setup", () => {
+  afterEach(async () => {
+    await cleanupDatabase();
+  });
+
+  it("creates the first organization and admin on a fresh system", async () => {
+    await cleanupDatabase();
+    const app = createTestApp();
+
+    const res = await testRequest(app).post("/api/organizations/setup").send({
+      name: "First Org",
+      userEmail: SETUP_EMAIL,
+      userName: "Admin",
+      userSurname: "User",
+      userPassword: SETUP_PASSWORD,
+    });
+
+    expect(res.status).toBe(201);
+    expect(res.body.data.organization).toBeDefined();
+    expect(res.body.data.organization.name).toBe("First Org");
+    expect(res.body.data.user.email).toBe(SETUP_EMAIL);
+    expect(res.body.data.token).toBeDefined();
+  });
+
+  it("returns 403 when the system is already initialized", async () => {
+    const orgId = await createTestOrganization();
+    await createTestUser(orgId, 1, SETUP_EMAIL, SETUP_PASSWORD);
+
+    const app = createTestApp();
+    const res = await testRequest(app).post("/api/organizations/setup").send({
+      name: "Second Org",
+      userEmail: "another@test.com",
+      userName: "Another",
+      userSurname: "User",
+      userPassword: SETUP_PASSWORD,
+    });
+
+    expect(res.status).toBe(403);
+  });
+});


### PR DESCRIPTION
## Admin Registration Lockdown

## Please ensure all items are checked off before requesting a review:

- [ ] I deployed the code locally.
- [ ] I have performed a self-review of my code.
- [ ] I have included the issue # in the PR.
- [ ] I have labelled the PR correctly.
- [ ] The issue I am working on is assigned to me.
- [ ] I have avoided using hardcoded values to ensure scalability and maintain consistency across the application.
- [ ] I have ensured that font sizes, color choices, and other UI elements are referenced from the theme.
- [ ] My pull request is focused and addresses a single, specific feature.
- [ ] If there are UI changes, I have attached a screenshot or video to this PR.
- [ ] If I added or modified an API endpoint, the change is reflected in the generated OpenAPI spec (`npm run generate:swagger`).
- [ ] If the endpoint requires authentication, it uses `authenticateJWT` and the generated spec declares `bearerAuth` security.
- [ ] I ran `npm run check:api-drift` and committed the regenerated `swagger.yaml` and `endpoints.ts`.
- [ ] If this PR adds or modifies an organization-scoped table, the [tenant isolation registry](Servers/tests/integration/tenant-isolation/tenantIsolation.registry.ts) and [test matrix](Servers/tests/integration/tenant-isolation) are updated. See the [tenant isolation runbook](docs/technical/security/tenant-isolation.md) for details.

-------------------------------

## Branch Context
- **Goal:** Fix the reported security issue where the `/register` route remained functional after the first admin account was set up, allowing additional admin accounts to be created.

---

## Vulnerability Summary

The registration surface was only closed in the UI:
- `/register` and `/admin-reg` were hard-coded redirects to `/login`.
- The backend had no "system already initialized" guard.
- `POST /api/users/register` required an invitation token, but there was no single, unambiguous first-setup endpoint protected against reuse after initialization.

A client that bypassed the static redirect (or a future UI regression) could hit public registration-style endpoints after the system was already set up.

---

## Fix Implemented

### Backend
1. **New middleware:** `Servers/middleware/setupGuard.middleware.ts`
   - `requireSystemNotInitialized` — blocks the request with `403` if any user already exists.
   - `requireSystemInitialized` — inverse guard for endpoints that should only work after setup.
2. **New public first-setup endpoint:** `POST /api/organizations/setup`
   - Added in `Servers/routes/organization.route.ts`.
   - Uses `requireSystemNotInitialized`, so it can only be called while the system has no users.
   - Reuses the existing organization + admin creation logic via a new controller `createFirstOrganization` in `Servers/controllers/organization.ctrl.ts`.
   - Returns the same response shape as the existing `POST /api/organizations` endpoint (user, organization, token).
3. **Refactored `createOrganization`** to share core logic with `createFirstOrganization` through a private `buildOrganizationAndAdmin` helper, avoiding code duplication while preserving existing behavior.
4. **Left existing `POST /api/organizations` unchanged** — it still requires `authenticateJWT` + `superAdminOnly` for normal multi-tenant organization creation.

### Frontend
1. **New component:** `Clients/src/presentation/components/SetupGate/index.tsx`
   - Calls the public `GET /api/organizations/exists` endpoint.
   - Renders children only when no organization exists.
   - Redirects authenticated users to `/` and unauthenticated users to `/login` when an organization already exists.
   - Fails closed: if the existence check errors, it treats the system as initialized.
2. **Updated routing:** `Clients/src/application/config/routes.tsx`
   - Replaced the static `<Navigate to="/login" />` entries for `/register` and `/admin-reg` with `SetupGate`-wrapped `RegisterMultiTenant` routes.
3. **Updated registration flow:** `Clients/src/presentation/pages/Authentication/RegisterMultiTenant/index.tsx`
   - Now calls the new `CreateFirstOrganization` repository function posting to `/organizations/setup`.
4. **New repository helper:** `CreateFirstOrganization` in `Clients/src/application/repository/organization.repository.ts`.

### Tests
- Added `Servers/tests/integration/setup-guard.test.ts` with two cases:
  1. `POST /api/organizations/setup` succeeds and creates the first organization + admin on a fresh database.
  2. The same endpoint returns `403` once a user/organization already exists.

---

## Files Modified / Created

| Path | Change |
|---|---|
| `Servers/middleware/setupGuard.middleware.ts` | Created |
| `Servers/routes/organization.route.ts` | Added `/setup` route and guard import |
| `Servers/controllers/organization.ctrl.ts` | Added `createFirstOrganization`, refactored shared logic |
| `Clients/src/presentation/components/SetupGate/index.tsx` | Created |
| `Clients/src/application/config/routes.tsx` | Replaced static redirects with `SetupGate` |
| `Clients/src/presentation/pages/Authentication/RegisterMultiTenant/index.tsx` | Calls setup endpoint |
| `Clients/src/application/repository/organization.repository.ts` | Added `CreateFirstOrganization` |
| `Servers/tests/integration/setup-guard.test.ts` | Created |
| `agent.md` | Rewritten |

---

## Behavior After Fix

- On a fresh system, navigating to `/register` or `/admin-reg` shows the first-time setup form.
- Submitting the form creates the first organization + admin via `POST /api/organizations/setup`.
- Once any user exists, `POST /api/organizations/setup` returns `403`.
- After setup, `/register` and `/admin-reg` redirect to `/login` (or `/` for authenticated users).
- Existing invitation-based registration (`/user-reg`, `POST /api/users/register`) and super-admin organization creation (`POST /api/organizations`) continue to work as before.
