### PR TITLE
refactor(themes): migrate theme spacing to MUI spacing units

### DIFF
--- a/Clients/src/presentation/components/Table/PolicyTable/index.tsx
+++ b/Clients/src/presentation/components/Table/PolicyTable/index.tsx
@@ -300,7 +300,7 @@ const CustomizablePolicyTable = ({
             }}
           >
             {data.cols.map((col) => (
-              <TableCell key={col.id} style={singleTheme.tableStyles.primary.body.cell}>
+              <TableCell key={col.id} sx={singleTheme.tableStyles.primary.body.cell}>
                 {row[col.id]}
               </TableCell>
             ))}

--- a/Clients/src/presentation/components/Table/index.tsx
+++ b/Clients/src/presentation/components/Table/index.tsx
@@ -132,7 +132,7 @@ const CustomizableBasicTable = ({
           >
             <TableRow sx={singleTheme.tableStyles.primary.header.row}>
               {data.cols.map((col) => (
-                <TableCell key={col.id} style={singleTheme.tableStyles.primary.header.cell}>
+                <TableCell key={col.id} sx={singleTheme.tableStyles.primary.header.cell}>
                   {col.name}
                 </TableCell>
               ))}

--- a/Clients/src/presentation/pages/StyleGuide/sections/FormInputsSection.tsx
+++ b/Clients/src/presentation/pages/StyleGuide/sections/FormInputsSection.tsx
@@ -526,7 +526,7 @@ const FormInputsSection: React.FC = () => {
                 { property: "Icon position", value: "right: 12px" },
                 { property: "Icon color", value: "text.tertiary" },
                 { property: "Menu margin-top", value: "4px" },
-                { property: "Menu item padding", value: "4px 6px" },
+                { property: "Menu item padding", value: "4px 8px" },
                 { property: "Menu item margin", value: "2px" },
                 { property: "Menu item min-width", value: "100px" },
                 { property: "Menu hover bg", value: "background.accent" },

--- a/Clients/src/presentation/pages/StyleGuide/sections/TablesSection.tsx
+++ b/Clients/src/presentation/pages/StyleGuide/sections/TablesSection.tsx
@@ -39,7 +39,7 @@ const tableCodeSnippet = `<TableContainer>
         {columns.map((col) => (
           <TableCell
             key={col.id}
-            style={singleTheme.tableStyles.primary.header.cell}
+            sx={singleTheme.tableStyles.primary.header.cell}
           >
             {col.name}
           </TableCell>

--- a/Clients/src/presentation/themes/light.ts
+++ b/Clients/src/presentation/themes/light.ts
@@ -12,6 +12,7 @@ const shadow = "0px 4px 24px -4px rgba(16, 24, 40, 0.08), 0px 3px 3px -3px rgba(
 
 const light = createTheme({
   typography: { fontFamily: fontFamily.sans, fontSize: fontSize.base },
+  // 2px base — theme.spacing(n) = n × 2px (see CodeRules/09-design-system/spacing.md)
   spacing: 2,
   palette: {
     primary: { main: brand.primary },
@@ -142,8 +143,8 @@ const light = createTheme({
         disableRipple: true,
       },
       styleOverrides: {
-        root: {
-          "padding": 4,
+        root: ({ theme }) => ({
+          "padding": theme.spacing(2),
           "transition": "none",
           "&:focus:not(:focus-visible)": {
             outline: "none",
@@ -155,20 +156,20 @@ const light = createTheme({
           "&:hover": {
             backgroundColor: background.fill,
           },
-        },
+        }),
       },
     },
     MuiPaper: {
       styleOverrides: {
-        root: {
-          marginTop: 4,
+        root: ({ theme }) => ({
+          marginTop: theme.spacing(2),
           border: 1,
           borderStyle: "solid",
           borderColor: border.light,
           borderRadius: 4,
           boxShadow: shadow,
           backgroundColor: background.main,
-        },
+        }),
       },
     },
     MuiList: {
@@ -193,19 +194,19 @@ const light = createTheme({
         disableRipple: true,
       },
       styleOverrides: {
-        root: {
+        root: ({ theme }) => ({
           "borderRadius": 4,
           "backgroundColor": "inherit",
-          "padding": "4px 6px",
+          "padding": theme.spacing(2, 4), // was 4px 6px; 6px snapped to 8px
           "color": text.secondary,
           "fontSize": fontSize.base,
-          "margin": 2,
+          "margin": theme.spacing(1),
           "marginBottom": 0,
           "minWidth": 100,
           "&:hover, &.Mui-selected, &.Mui-selected:hover, &.Mui-selected.Mui-focusVisible": {
             backgroundColor: background.fill,
           },
-        },
+        }),
       },
     },
     MuiTableCell: {
@@ -328,12 +329,12 @@ const light = createTheme({
     },
     MuiTooltip: {
       styleOverrides: {
-        tooltip: {
+        tooltip: ({ theme }) => ({
           fontSize: fontSize.base,
           backgroundColor: "#1F2937",
-          padding: "8px 12px",
+          padding: theme.spacing(4, 6),
           borderRadius: "4px",
-        },
+        }),
         arrow: {
           color: "#1F2937",
         },

--- a/Clients/src/presentation/themes/tables.ts
+++ b/Clients/src/presentation/themes/tables.ts
@@ -21,7 +21,7 @@ export const tableStyles = {
         "color": "#475467",
         "fontSize": fontSize.base,
         "fontWeight": fontWeight.regular,
-        "padding": "14px 12px",
+        "p": 6,
         "whiteSpace": "nowrap",
         "&:not(:lastChild)": {
           minWidth: "120px",
@@ -51,7 +51,7 @@ export const tableStyles = {
       },
       cell: {
         "fontSize": fontSize.base,
-        "padding": "14px 12px",
+        "p": 6,
         "whiteSpace": "nowrap",
         "&:not(:lastChild)": {
           minWidth: "120px",
@@ -60,7 +60,8 @@ export const tableStyles = {
       },
       button: {
         "fontSize": fontSize.base,
-        "padding": "2px 8px",
+        "py": 1,
+        "px": 4,
         "textTransform": "none",
         "borderRadius": "4px",
         "&:hover": {

--- a/Clients/src/presentation/themes/v1SingleTheme.ts
+++ b/Clients/src/presentation/themes/v1SingleTheme.ts
@@ -28,24 +28,27 @@ const fontSizes = {
   large: `${fontSize.lg}px`,
 };
 
-// Standardized button sizes
+// Standardized button sizes — sx spacing units (× 2px)
 const buttonSizes = {
   small: {
     height: 28,
     fontSize: `${fontSize.sm}px`,
-    padding: "6px 12px",
+    py: 4,
+    px: 6,
     minHeight: 28,
   },
   medium: {
     height: 32,
     fontSize: `${fontSize.base}px`,
-    padding: "8px 16px",
+    py: 4,
+    px: 8,
     minHeight: 32,
   },
   large: {
     height: 40,
     fontSize: `${fontSize.md}px`,
-    padding: "10px 20px",
+    py: 6,
+    px: 10,
     minHeight: 40,
   },
 };
@@ -456,7 +459,7 @@ const iconButtons = {
 const iconButtonsRectangle = {
   "height": "34px",
   "width": "34px",
-  "padding": "8px",
+  "p": 4,
   "borderRadius": "4px",
   "border": "1px solid #E2E4E9",
   "backgroundColor": "#ffffff",

--- a/CodeRules/09-design-system/spacing.md
+++ b/CodeRules/09-design-system/spacing.md
@@ -4,52 +4,52 @@ VerifyWise uses a **2px base unit** for `theme.spacing()`. This differs from MUI
 
 ## Spacing Scale
 
-| `theme.spacing(n)` | Result | Usage |
-|---------------------|--------|-------|
-| `spacing(1)` | 2px | Micro spacing, icon gaps |
-| `spacing(2)` | 4px | Tight spacing, small padding |
-| `spacing(4)` | 8px | Default gap, button padding |
-| `spacing(6)` | 12px | Card padding, field spacing |
-| `spacing(8)` | 16px | Section spacing, large gaps |
-| `spacing(10)` | 20px | Container padding |
-| `spacing(12)` | 24px | Modal padding, major spacing |
-| `spacing(16)` | 32px | Page padding, section margins |
-| `spacing(20)` | 40px | Large page padding |
+| `theme.spacing(n)` | Result | Usage                         |
+| ------------------ | ------ | ----------------------------- |
+| `spacing(1)`       | 2px    | Micro spacing, icon gaps      |
+| `spacing(2)`       | 4px    | Tight spacing, small padding  |
+| `spacing(4)`       | 8px    | Default gap, button padding   |
+| `spacing(6)`       | 12px   | Card padding, field spacing   |
+| `spacing(8)`       | 16px   | Section spacing, large gaps   |
+| `spacing(10)`      | 20px   | Container padding             |
+| `spacing(12)`      | 24px   | Modal padding, major spacing  |
+| `spacing(16)`      | 32px   | Page padding, section margins |
+| `spacing(20)`      | 40px   | Large page padding            |
 
 > **Important:** `theme.spacing(4)` = **8px**, not 32px. Multiply `n × 2` to get pixels.
 
 ## Common Padding Patterns
 
-| Context | Padding |
-|---------|---------|
-| Buttons / Inputs | `8px 12px` |
+| Context            | Padding     |
+| ------------------ | ----------- |
+| Buttons / Inputs   | `8px 12px`  |
 | Cards / Containers | `12px 16px` |
-| Page sections | `16px 20px` |
-| Modal content | `24px 32px` |
-| Page content | `32px 40px` |
+| Page sections      | `16px 20px` |
+| Modal content      | `24px 32px` |
+| Page content       | `32px 40px` |
 
 ## Gap Values
 
-| Gap | Usage |
-|-----|-------|
-| 4px | Tight grouping (icon + text) |
-| 8px | Related items (form fields in a row) |
-| 12px | Section items |
-| 16px | Cards in a grid |
-| 24px | Major sections |
-| 32px | Page sections |
+| Gap  | Usage                                |
+| ---- | ------------------------------------ |
+| 4px  | Tight grouping (icon + text)         |
+| 8px  | Related items (form fields in a row) |
+| 12px | Section items                        |
+| 16px | Cards in a grid                      |
+| 24px | Major sections                       |
+| 32px | Page sections                        |
 
 > Always use `gap` for flex/grid spacing instead of margins between children.
 
 ## Common Margins
 
-| Context | Value |
-|---------|-------|
-| Label to input | `mb: "4px"` |
-| Title to subtitle | `mb: "8px"` |
-| Section header to content | `mb: "16px"` |
-| Section to section | `mb: "24px"` |
-| Page header to content | `mb: "32px"` |
+| Context                     | Value        |
+| --------------------------- | ------------ |
+| Label to input              | `mb: "4px"`  |
+| Title to subtitle           | `mb: "8px"`  |
+| Section header to content   | `mb: "16px"` |
+| Section to section          | `mb: "24px"` |
+| Page header to content      | `mb: "32px"` |
 | Footer / checklist sections | `mt: "40px"` |
 
 ## Layout Mixins
@@ -80,29 +80,29 @@ import { layoutMixins, cardMixins, formMixins } from "@/presentation/themes/mixi
 
 ### Available Mixins
 
-| Category | Mixins |
-|----------|--------|
-| **Layout** | `flexCenter()`, `flexBetween()`, `flexStart()`, `fullHeight()`, `container(theme)` |
-| **Button** | `primary(theme)`, `secondary(theme)`, `outlined(theme)` |
-| **Card** | `base(theme)`, `stats(theme)`, `interactive(theme)` |
-| **Modal** | `container(theme)`, `header(theme)`, `closeButton(theme)` |
-| **Table** | `container(theme)`, `headerCell(theme)`, `bodyCell(theme)`, `hoverableRow(theme)` |
-| **Form** | `container(theme)`, `fieldContainer(theme)`, `inputField(theme)` |
-| **Icon** | `button(theme)`, `standard(theme)` |
+| Category       | Mixins                                                                                     |
+| -------------- | ------------------------------------------------------------------------------------------ |
+| **Layout**     | `flexCenter()`, `flexBetween()`, `flexStart()`, `fullHeight()`, `container(theme)`         |
+| **Button**     | `primary(theme)`, `secondary(theme)`, `outlined(theme)`                                    |
+| **Card**       | `base(theme)`, `stats(theme)`, `interactive(theme)`                                        |
+| **Modal**      | `container(theme)`, `header(theme)`, `closeButton(theme)`                                  |
+| **Table**      | `container(theme)`, `headerCell(theme)`, `bodyCell(theme)`, `hoverableRow(theme)`          |
+| **Form**       | `container(theme)`, `fieldContainer(theme)`, `inputField(theme)`                           |
+| **Icon**       | `button(theme)`, `standard(theme)`                                                         |
 | **Typography** | `pageTitle(theme)`, `pageDescription(theme)`, `cardTitle(theme)`, `cardDescription(theme)` |
-| **Status** | `success(theme)`, `error(theme)`, `warning(theme)`, `info(theme)` |
+| **Status**     | `success(theme)`, `error(theme)`, `warning(theme)`, `info(theme)`                          |
 
 ## Usage in Code
 
 ```tsx
-// Use theme.spacing() for consistent spacing
-<Box sx={{ p: 4, gap: 4 }}>  {/* 8px padding, 8px gap */}
-  <Typography sx={{ mb: "16px" }}>Title</Typography>
+// Prefer sx spacing units (n × 2px with spacing: 2)
+<Box sx={{ py: 2, px: 4, gap: 1 }}>
+  <Typography sx={{ mb: 8 }}>Title</Typography>
   <Content />
 </Box>
 
-// Responsive spacing
-<Box sx={{ p: { xs: 4, md: 8 } }}>  {/* 8px on mobile, 16px on desktop */}
+// Responsive spacing (sx numbers = spacing units: 4 → 8px, 8 → 16px)
+<Box sx={{ p: { xs: 4, md: 8 } }}>
   Content
 </Box>
 ```

--- a/docs/api-docs/src/components/StyleGuide/sections/FormInputsSection.tsx
+++ b/docs/api-docs/src/components/StyleGuide/sections/FormInputsSection.tsx
@@ -805,7 +805,7 @@ const FormInputsSection: React.FC = () => {
                 { property: "Icon position", value: "right: 12px" },
                 { property: "Icon color", value: "#475467" },
                 { property: "Menu margin-top", value: "4px" },
-                { property: "Menu item padding", value: "4px 6px" },
+                { property: "Menu item padding", value: "4px 8px" }, 
                 { property: "Menu item margin", value: "2px" },
                 { property: "Menu item min-width", value: "100px" },
                 { property: "Menu hover bg", value: "#f9fafb" },

--- a/docs/technical/guides/design-tokens.md
+++ b/docs/technical/guides/design-tokens.md
@@ -41,59 +41,59 @@ function App() {
 
 ### Brand Colors
 
-| Token | Value | Usage |
-|-------|-------|-------|
-| `primary.main` | `#13715B` | Primary actions, links, emphasis |
-| `primary.dark` | `#0A4A3A` | Hover states, dark variants |
-| `primary.light` | `#E6F2EF` | Light backgrounds, highlights |
+| Token           | Value     | Usage                            |
+| --------------- | --------- | -------------------------------- |
+| `primary.main`  | `#13715B` | Primary actions, links, emphasis |
+| `primary.dark`  | `#0A4A3A` | Hover states, dark variants      |
+| `primary.light` | `#E6F2EF` | Light backgrounds, highlights    |
 
 ### Text Colors
 
-| Token | Value | Usage |
-|-------|-------|-------|
-| `text.primary` | `#1c2130` | Main body text, headings |
-| `text.secondary` | `#344054` | Secondary text, labels |
-| `text.tertiary` | `#475467` | Muted text, placeholders |
-| `text.disabled` | `#9CA3AF` | Disabled state text |
+| Token            | Value     | Usage                    |
+| ---------------- | --------- | ------------------------ |
+| `text.primary`   | `#1c2130` | Main body text, headings |
+| `text.secondary` | `#344054` | Secondary text, labels   |
+| `text.tertiary`  | `#475467` | Muted text, placeholders |
+| `text.disabled`  | `#9CA3AF` | Disabled state text      |
 
 ### Background Colors
 
-| Token | Value | Usage |
-|-------|-------|-------|
-| `background.main` | `#FFFFFF` | Main content areas |
-| `background.alt` | `#FCFCFD` | Alternate sections |
-| `background.fill` | `#F4F4F4` | Filled areas, inputs |
-| `background.accent` | `#f9fafb` | Subtle highlights |
-| `background.hover` | `#E5E7EB` | Hover states |
+| Token               | Value     | Usage                |
+| ------------------- | --------- | -------------------- |
+| `background.main`   | `#FFFFFF` | Main content areas   |
+| `background.alt`    | `#FCFCFD` | Alternate sections   |
+| `background.fill`   | `#F4F4F4` | Filled areas, inputs |
+| `background.accent` | `#f9fafb` | Subtle highlights    |
+| `background.hover`  | `#E5E7EB` | Hover states         |
 
 ### Border Colors
 
-| Token | Value | Usage |
-|-------|-------|-------|
-| `border.dark` | `#d0d5dd` | Default borders |
-| `border.light` | `#eaecf0` | Subtle borders |
+| Token          | Value     | Usage           |
+| -------------- | --------- | --------------- |
+| `border.dark`  | `#d0d5dd` | Default borders |
+| `border.light` | `#eaecf0` | Subtle borders  |
 
 ### Status Colors
 
 #### Severity Levels
 
-| Level | Color | Usage |
-|-------|-------|-------|
-| Critical | `#DC2626` | Critical risks, errors |
-| High | `#EF4444` | High priority items |
-| Medium | `#F59E0B` | Medium priority, warnings |
-| Low | `#10B981` | Low priority items |
-| Very Low | `#22C55E` | Minimal concern |
+| Level    | Color     | Usage                     |
+| -------- | --------- | ------------------------- |
+| Critical | `#DC2626` | Critical risks, errors    |
+| High     | `#EF4444` | High priority items       |
+| Medium   | `#F59E0B` | Medium priority, warnings |
+| Low      | `#10B981` | Low priority items        |
+| Very Low | `#22C55E` | Minimal concern           |
 
 #### Implementation Status
 
-| Status | Color | Usage |
-|--------|-------|-------|
-| Implemented | `#13715B` | Completed items |
-| Awaiting Review | `#3B82F6` | Pending review |
+| Status            | Color     | Usage            |
+| ----------------- | --------- | ---------------- |
+| Implemented       | `#13715B` | Completed items  |
+| Awaiting Review   | `#3B82F6` | Pending review   |
 | Awaiting Approval | `#8B5CF6` | Pending approval |
-| Needs Rework | `#EA580C` | Requires changes |
-| Not Started | `#9CA3AF` | Not begun |
+| Needs Rework      | `#EA580C` | Requires changes |
+| Not Started       | `#9CA3AF` | Not begun        |
 
 #### Alert States
 
@@ -135,56 +135,56 @@ Allowed sizes only: **11, 12, 13, 14, 16, 18, 24**. Do not invent sizes outside 
 ```typescript
 import { fontFamily } from "@/presentation/themes/typography";
 
-fontFamily.sans // 'Geist', system-ui, -apple-system, BlinkMacSystemFont, Helvetica, Arial, sans-serif
-fontFamily.mono // 'Fira Code', 'Consolas', monospace
+fontFamily.sans; // 'Geist', system-ui, -apple-system, BlinkMacSystemFont, Helvetica, Arial, sans-serif
+fontFamily.mono; // 'Fira Code', 'Consolas', monospace
 ```
 
 ### Font Sizes (`fontSize.*`)
 
-| Token | Size | Usage |
-|-------|------|-------|
-| `caption` | 11px | Captions, footnotes, error text |
-| `sm` | 12px | Body small, badges, table headers |
-| `base` | 13px | Default UI / body / tabs / modal description |
-| `md` | 14px | Emphasized body, subsection titles |
-| `lg` | 16px | Card / modal / drawer titles |
-| `xl` | 18px | Section titles |
-| `2xl` | 24px | Page titles |
+| Token     | Size | Usage                                        |
+| --------- | ---- | -------------------------------------------- |
+| `caption` | 11px | Captions, footnotes, error text              |
+| `sm`      | 12px | Body small, badges, table headers            |
+| `base`    | 13px | Default UI / body / tabs / modal description |
+| `md`      | 14px | Emphasized body, subsection titles           |
+| `lg`      | 16px | Card / modal / drawer titles                 |
+| `xl`      | 18px | Section titles                               |
+| `2xl`     | 24px | Page titles                                  |
 
 ### Font Weights (`fontWeight.*`)
 
-| Token | Weight | Usage |
-|-------|--------|-------|
-| `regular` | 400 | Body text |
-| `medium` | 500 | Labels, buttons, badges |
-| `semibold` | 600 | Headings |
-| `bold` | 700 | Strong emphasis (rare) |
+| Token      | Weight | Usage                   |
+| ---------- | ------ | ----------------------- |
+| `regular`  | 400    | Body text               |
+| `medium`   | 500    | Labels, buttons, badges |
+| `semibold` | 600    | Headings                |
+| `bold`     | 700    | Strong emphasis (rare)  |
 
 ### Line Heights (`lineHeight.*`)
 
-| Token | Value | Usage |
-|-------|-------|-------|
-| `tight` | 1.2 | Buttons, badges |
-| `snug` | 1.3 | Page titles |
-| `normal` | 1.4 | Captions, section/card titles |
-| `relaxed` | 1.5 | Body text |
-| `loose` | 1.75 | Long-form content |
+| Token     | Value | Usage                         |
+| --------- | ----- | ----------------------------- |
+| `tight`   | 1.2   | Buttons, badges               |
+| `snug`    | 1.3   | Page titles                   |
+| `normal`  | 1.4   | Captions, section/card titles |
+| `relaxed` | 1.5   | Body text                     |
+| `loose`   | 1.75  | Long-form content             |
 
 ### Semantic text styles (`textStyles.*`)
 
 Prefer roles over raw sizes in UI code:
 
-| Style | Size / weight | Typical use |
-|-------|---------------|-------------|
-| `pageTitle` | 24 / 600 | Page H1 |
-| `sectionTitle` | 18 / 600 | In-page section |
-| `cardTitle` | 16 / 600 | Card, modal, drawer title |
-| `subsectionTitle` | 14 / 600 | Nested heading |
-| `body` | 13 / 400 | Default copy, modal description, sidebar/tab labels |
-| `bodyLarge` / `bodySmall` / `caption` | 14 / 12 / 11 | Emphasized / secondary / meta |
-| `formLabel` / `input` / `error` | 13 / 13 / 11 | Forms |
-| `button` / `badge` / `tooltip` | 13 / 12 / 13 | Controls |
-| `tableHeader` / `tableCell` | 12 / 13 | Tables |
+| Style                                 | Size / weight | Typical use                                         |
+| ------------------------------------- | ------------- | --------------------------------------------------- |
+| `pageTitle`                           | 24 / 600      | Page H1                                             |
+| `sectionTitle`                        | 18 / 600      | In-page section                                     |
+| `cardTitle`                           | 16 / 600      | Card, modal, drawer title                           |
+| `subsectionTitle`                     | 14 / 600      | Nested heading                                      |
+| `body`                                | 13 / 400      | Default copy, modal description, sidebar/tab labels |
+| `bodyLarge` / `bodySmall` / `caption` | 14 / 12 / 11  | Emphasized / secondary / meta                       |
+| `formLabel` / `input` / `error`       | 13 / 13 / 11  | Forms                                               |
+| `button` / `badge` / `tooltip`        | 13 / 12 / 13  | Controls                                            |
+| `tableHeader` / `tableCell`           | 12 / 13       | Tables                                              |
 
 ```typescript
 import { textStyles, fontSize } from "@/presentation/themes/typography";
@@ -199,39 +199,46 @@ Typography foundation (tokens + theme helpers) is in place. Broad replacement of
 
 ## Spacing
 
+VerifyWise uses a **2px base** for MUI `theme.spacing()` (`spacing: 2` in `light.ts`). This differs from MUI’s default 8px base.
+
+Documented in [CodeRules spacing](../../../CodeRules/09-design-system/spacing.md).
+
 ### Spacing Scale
 
-| Token | Size | Usage |
-|-------|------|-------|
-| `xs` | 4px | Tight spacing, icon gaps |
-| `sm` | 8px | Small gaps, padding |
-| `md` | 12px | Default spacing |
-| `lg` | 16px | Section spacing |
-| `xl` | 24px | Large gaps |
-| `2xl` | 32px | Section margins |
-| `3xl` | 40px | Page sections |
-| `4xl` | 48px | Major sections |
+| `theme.spacing(n)` | Result |
+| ------------------ | ------ |
+| `spacing(1)`       | 2px    |
+| `spacing(2)`       | 4px    |
+| `spacing(4)`       | 8px    |
+| `spacing(6)`       | 12px   |
+| `spacing(8)`       | 16px   |
+| `spacing(10)`      | 20px   |
+| `spacing(12)`      | 24px   |
+| `spacing(16)`      | 32px   |
+| `spacing(20)`      | 40px   |
 
 ### Using Theme Spacing
 
 ```typescript
-// MUI theme.spacing() uses 8px base
 sx={{
-  padding: 2,        // 16px (2 * 8)
-  marginTop: 1,      // 8px (1 * 8)
-  gap: 1.5,          // 12px (1.5 * 8)
+  p: 2,  // 4px
+  mt: 4,  // 8px
+  gap: 1, // 2px
 }}
+
+// When you need a CSS string:
+paddingTop: `${theme.spacing(1)} !important`
 ```
 
 ## Component Sizes
 
 ### Buttons
 
-| Size | Height | Font Size | Padding |
-|------|--------|-----------|---------|
-| Small | 28px | 12px | 8px 12px |
-| Medium | 34px | 13px | 10px 16px |
-| Large | 40px | 14px | 12px 20px |
+| Size   | Height | Font Size | Padding   |
+| ------ | ------ | --------- | --------- |
+| Small  | 28px   | 12px      | 8px 12px  |
+| Medium | 34px   | 13px      | 10px 16px |
+| Large  | 40px   | 14px      | 12px 20px |
 
 ```typescript
 // Standard button (medium)
@@ -249,19 +256,19 @@ sx={{
 
 ### Inputs
 
-| Size | Height | Usage |
-|------|--------|-------|
-| Small | 32px | Compact forms |
-| Medium | 40px | Default |
-| Large | 48px | Prominent inputs |
+| Size   | Height | Usage            |
+| ------ | ------ | ---------------- |
+| Small  | 32px   | Compact forms    |
+| Medium | 40px   | Default          |
+| Large  | 48px   | Prominent inputs |
 
 ### Cards
 
-| Padding | Size | Usage |
-|---------|------|-------|
-| Small | 12px | Compact cards |
-| Medium | 16px | Default cards |
-| Large | 24px | Prominent cards |
+| Padding | Size | Usage           |
+| ------- | ---- | --------------- |
+| Small   | 12px | Compact cards   |
+| Medium  | 16px | Default cards   |
+| Large   | 24px | Prominent cards |
 
 ## Shape & Borders
 
@@ -269,25 +276,25 @@ sx={{
 
 ```typescript
 // Standard border radius
-borderRadius: "4px"  // Primary standard
+borderRadius: "4px"; // Primary standard
 
 // Using theme
-borderRadius: theme.shape.borderRadius  // 4px
-borderRadius: theme.spacing(1.5)        // 12px for modals
+borderRadius: theme.shape.borderRadius; // 4px
+borderRadius: theme.spacing(1.5); // 12px for modals
 ```
 
 ### Border Styles
 
 ```typescript
 // Default border
-border: "1px solid #d0d5dd"
+border: "1px solid #d0d5dd";
 
 // Light border
-border: "1px solid #eaecf0"
+border: "1px solid #eaecf0";
 
 // Using theme
-border: `1px solid ${theme.palette.border.dark}`
-border: `1px solid ${theme.palette.border.light}`
+border: `1px solid ${theme.palette.border.dark}`;
+border: `1px solid ${theme.palette.border.light}`;
 ```
 
 ## Shadows
@@ -295,7 +302,7 @@ border: `1px solid ${theme.palette.border.light}`
 ### Primary Shadow
 
 ```typescript
-boxShadow: "0px 4px 24px -4px rgba(16, 24, 40, 0.08), 0px 3px 3px -3px rgba(16, 24, 40, 0.03)"
+boxShadow: "0px 4px 24px -4px rgba(16, 24, 40, 0.08), 0px 3px 3px -3px rgba(16, 24, 40, 0.03)";
 ```
 
 ### No Shadow (Default)
@@ -303,7 +310,7 @@ boxShadow: "0px 4px 24px -4px rgba(16, 24, 40, 0.08), 0px 3px 3px -3px rgba(16, 
 Most components use no shadow by default:
 
 ```typescript
-boxShadow: "none"
+boxShadow: "none";
 ```
 
 ## Component Style Patterns
@@ -565,28 +572,28 @@ import { cardMixins, typographyMixins } from "../themes/mixins";
 
 ### Quick Reference
 
-| Purpose | Light | Dark/Emphasis |
-|---------|-------|---------------|
-| Brand | `#13715B` | `#0A4A3A` |
-| Text | `#1c2130` | `#344054` |
-| Border | `#eaecf0` | `#d0d5dd` |
-| Background | `#FFFFFF` | `#f9fafb` |
-| Success | `#17b26a` | `#079455` |
-| Error | `#f04438` | `#d32f2f` |
-| Warning | `#fdb022` | `#DC6803` |
+| Purpose    | Light     | Dark/Emphasis |
+| ---------- | --------- | ------------- |
+| Brand      | `#13715B` | `#0A4A3A`     |
+| Text       | `#1c2130` | `#344054`     |
+| Border     | `#eaecf0` | `#d0d5dd`     |
+| Background | `#FFFFFF` | `#f9fafb`     |
+| Success    | `#17b26a` | `#079455`     |
+| Error      | `#f04438` | `#d32f2f`     |
+| Warning    | `#fdb022` | `#DC6803`     |
 
 ## Key Files
 
-| File | Purpose |
-|------|---------|
-| `Clients/src/presentation/themes/light.ts` | Main MUI theme |
+| File                                            | Purpose                          |
+| ----------------------------------------------- | -------------------------------- |
+| `Clients/src/presentation/themes/light.ts`      | Main MUI theme                   |
 | `Clients/src/presentation/themes/typography.ts` | Type scale + semantic textStyles |
-| `Clients/src/presentation/themes/palette.ts` | Semantic color tokens |
-| `Clients/src/presentation/themes/components.ts` | Reusable component styles |
-| `Clients/src/presentation/themes/mixins.ts` | Style mixins |
-| `Clients/src/presentation/themes/alerts.ts` | Alert status styles |
-| `Clients/src/presentation/themes/theme.d.ts` | TypeScript definitions |
-| `Clients/src/presentation/styles/colors.ts` | Color palette |
+| `Clients/src/presentation/themes/palette.ts`    | Semantic color tokens            |
+| `Clients/src/presentation/themes/components.ts` | Reusable component styles        |
+| `Clients/src/presentation/themes/mixins.ts`     | Style mixins                     |
+| `Clients/src/presentation/themes/alerts.ts`     | Alert status styles              |
+| `Clients/src/presentation/themes/theme.d.ts`    | TypeScript definitions           |
+| `Clients/src/presentation/styles/colors.ts`     | Color palette                    |
 
 ## Related Documentation
 


### PR DESCRIPTION
## Describe your changes

Replace magic px paddings in light/tables/v1SingleTheme with theme.spacing and sx units, update table call sites to sx, and sync StyleGuide/docs.

## Write your issue number after "Fixes "

Fixes #4300 

## Please ensure all items are checked off before requesting a review:

- [x] I deployed the code locally.
- [x] I have performed a self-review of my code.
- [x] I have included the issue # in the PR.
- [x] I have labelled the PR correctly.
- [x] The issue I am working on is assigned to me.
- [x] I have avoided using hardcoded values to ensure scalability and maintain consistency across the application.
- [x] I have ensured that font sizes, color choices, and other UI elements are referenced from the theme.
- [x] My pull request is focused and addresses a single, specific feature.
- [ ] If there are UI changes, I have attached a screenshot or video to this PR.
- [ ] If I added or modified an API endpoint, the change is reflected in the generated OpenAPI spec (`npm run generate:swagger`).
- [ ] If the endpoint requires authentication, it uses `authenticateJWT` and the generated spec declares `bearerAuth` security.
- [ ] I ran `npm run check:api-drift` and committed the regenerated `swagger.yaml` and `endpoints.ts`.
- [ ] If this PR adds or modifies an organization-scoped table, the [tenant isolation registry](Servers/tests/integration/tenant-isolation/tenantIsolation.registry.ts) and [test matrix](Servers/tests/integration/tenant-isolation) are updated. See the [tenant isolation runbook](docs/technical/security/tenant-isolation.md) for details.
