### PR TITLE
fix(risk): sync current risk level to the computed residual

### DIFF
--- a/Clients/src/presentation/components/AddNewRiskForm/MitigationSection/index.tsx
+++ b/Clients/src/presentation/components/AddNewRiskForm/MitigationSection/index.tsx
@@ -17,7 +17,15 @@ import { createFieldBlurHandler } from "../../../../application/utils/formValida
 import { checkStringValidation } from "../../../../application/validations/stringValidation";
 import selectValidation from "../../../../application/validations/selectValidation";
 import useUsers from "../../../../application/hooks/useUsers";
-import { mitigationStatusItems, riskLevelItems, approvalStatusItems } from "../projectRiskValue";
+import {
+  mitigationStatusItems,
+  riskLevelItems,
+  approvalStatusItems,
+  likelihoodItems,
+  riskSeverityItems,
+} from "../projectRiskValue";
+import { RiskCalculator } from "../../../tools/riskCalculator";
+import { RiskLikelihood, RiskSeverity } from "../../RiskLevel/riskValues";
 import { alertState } from "../../../../domain/interfaces/i.alert";
 import allowedRoles from "../../../../application/constants/permissions";
 
@@ -194,6 +202,34 @@ const MitigationSection: FC<MitigationSectionProps> = ({
     [setMitigationValues, clearFieldError],
   );
 
+  // Keep "Current risk level" in sync with the residual level computed from the
+  // mitigation likelihood and severity. Without this the field (which the
+  // dashboard and reporting read via current_risk_level) stays frozen at the
+  // pre-mitigation value, so mitigating a risk never lowers the reported level.
+  // The computed level string maps to the same options as the dropdown.
+  const computedResidualLevelId = useMemo(() => {
+    const likelihood = likelihoodItems.find((i) => i._id === mitigationValues.likelihood);
+    const severity = riskSeverityItems.find((i) => i._id === mitigationValues.riskSeverity);
+    if (!likelihood || !severity) return null;
+    const { level } = RiskCalculator.getRiskLevel(
+      likelihood.name as RiskLikelihood,
+      severity.name as RiskSeverity,
+    );
+    // getRiskLevel emits "No risk" for the lowest band; the dropdown labels it
+    // "Very Low risk", so match on the noRisk option explicitly.
+    const normalized = level === "No risk" ? "Very Low risk" : level;
+    return riskLevelItems.find((i) => i.name === normalized)?._id ?? null;
+  }, [mitigationValues.likelihood, mitigationValues.riskSeverity]);
+
+  useEffect(() => {
+    if (computedResidualLevelId == null) return;
+    setMitigationValues((prev) =>
+      prev.currentRiskLevel === computedResidualLevelId
+        ? prev
+        : { ...prev, currentRiskLevel: computedResidualLevelId },
+    );
+  }, [computedResidualLevelId, setMitigationValues]);
+
   const handleDateChange = useCallback(
     (
       field: keyof Pick<MitigationFormValues, "deadline" | "dateOfAssessment">,
@@ -255,7 +291,9 @@ const MitigationSection: FC<MitigationSectionProps> = ({
                 error={errors.mitigationStatus}
                 disabled={isEditingDisabled}
               />
-              {/* Current Risk Level */}
+              {/* Current risk level — derived from the residual computed below
+                  (likelihood × severity). Read-only so it can never diverge from
+                  the computed residual the dashboard and reporting rely on. */}
               <Select
                 id="current-risk-level-input"
                 label="Current risk level"
@@ -269,7 +307,7 @@ const MitigationSection: FC<MitigationSectionProps> = ({
                 sx={formFieldStyles}
                 isRequired
                 error={errors.currentRiskLevel}
-                disabled={isEditingDisabled}
+                disabled
               />
               {/* Deadline */}
               <DatePicker


### PR DESCRIPTION
## Problem

The mitigation tab showed two residual numbers that could disagree: the "Current risk level" field and a computed residual badge derived from the mitigation likelihood × severity. The dashboard, risk register, and reporting all read `current_risk_level`, but that field stayed frozen at the pre-mitigation value — so mitigating a risk down (e.g. to Low) never lowered the level shown, even though the computed badge correctly read Low.

## Changes

- Derive `current_risk_level` from the residual computed by the mitigation likelihood and severity (the same `RiskCalculator` the badge uses), keeping the two in sync. The lowest band ("No risk") maps to the dropdown's "Very Low risk" option.
- Make the "Current risk level" field read-only so it can never diverge from the computed residual again.

## Benefits

- Mitigating a risk now lowers the residual level everywhere it is read (dashboard, risk register, reporting), matching what the computed badge already shows.
- Removes a confusing two-sources-of-truth field.

Scope is one file, `Clients/src/presentation/components/AddNewRiskForm/MitigationSection/index.tsx`. Typecheck, prettier, i18n:strict, build, and the risk-form test suite all pass.