### PR TITLE
ci(security): make the security scanners actually run

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -64,6 +64,9 @@ jobs:
           DB_NAME: verifywise_test
           DB_USER: postgres
           DB_PASSWORD: postgres
+          # Required by the RLS runtime-role migration (rls-app-role.js), which
+          # fails closed without it. CI-only value; not a real credential.
+          DB_APP_PASSWORD: test-app-role-password-for-ci
           SUPERADMIN_EMAIL: admin@verifywise-test.com
           SUPERADMIN_PASSWORD: TestAdmin!Str0ng
         run: npx sequelize db:migrate

--- a/.github/workflows/gitleaks.yml
+++ b/.github/workflows/gitleaks.yml
@@ -20,8 +20,19 @@ jobs:
         with:
           fetch-depth: 0 # full history so gitleaks can scan the commit range
 
-      - name: Run Gitleaks
-        uses: gitleaks/gitleaks-action@v2
-        env:
-          GITLEAKS_ENABLE_COMMENTS: true
-          GITLEAKS_ENABLE_SUMMARY: true
+      # The gitleaks GitHub Action (v2) requires a paid GITLEAKS_LICENSE secret
+      # for organization repositories. Run the open-source gitleaks binary
+      # directly instead — same detection engine, no license gate.
+      - name: Install gitleaks
+        run: |
+          GITLEAKS_VERSION=8.21.2
+          curl -sSfL "https://github.com/gitleaks/gitleaks/releases/download/v${GITLEAKS_VERSION}/gitleaks_${GITLEAKS_VERSION}_linux_x64.tar.gz" \
+            | tar -xz -C /usr/local/bin gitleaks
+          gitleaks version
+
+      # Scan the checked-out tree (--no-git) rather than full history: the goal
+      # is to block secrets present in the current code. Historical commits that
+      # have already been remediated should not fail every future run. A
+      # committed .gitleaks.toml can tune rules/allowlists if needed.
+      - name: Scan for secrets
+        run: gitleaks detect --no-git --source . --redact --verbose --exit-code 1

--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -36,19 +36,21 @@ jobs:
           # Full history so the action can diff against the PR base commit.
           fetch-depth: 0
 
+      # The semgrep-action@v1 is deprecated and rejects the generateSarif /
+      # baselineRef inputs, so it never produced semgrep.sarif and the upload
+      # step failed. Run the Semgrep CLI directly: it emits SARIF and blocks on
+      # findings via its own exit code.
       - name: Run Semgrep
-        uses: semgrep/semgrep-action@v1
-        with:
-          config: >-
-            p/javascript
-            p/typescript
-            p/python
-            p/security-audit
-            p/secrets
-          generateSarif: true
-          # Diff-aware on PRs: only findings introduced since the base
-          # branch block the merge. Empty on push events (full scan).
-          baselineRef: ${{ github.base_ref }}
+        run: |
+          python3 -m pip install --quiet semgrep
+          semgrep scan \
+            --config p/javascript \
+            --config p/typescript \
+            --config p/python \
+            --config p/security-audit \
+            --config p/secrets \
+            --sarif --output semgrep.sarif \
+            --error
 
       - name: Upload Semgrep results to GitHub Security
         uses: github/codeql-action/upload-sarif@v4

--- a/.github/workflows/zap-api-scan.yml
+++ b/.github/workflows/zap-api-scan.yml
@@ -70,6 +70,9 @@ jobs:
           DB_NAME: verifywise_test
           DB_USER: postgres
           DB_PASSWORD: postgres
+          # Required by the RLS runtime-role migration (rls-app-role.js), which
+          # fails closed without it. CI-only value; not a real credential.
+          DB_APP_PASSWORD: test-app-role-password-for-ci
           SUPERADMIN_EMAIL: admin@verifywise-test.com
           SUPERADMIN_PASSWORD: TestAdmin!Str0ng
         run: npx sequelize db:migrate

--- a/.github/workflows/zap-baseline.yml
+++ b/.github/workflows/zap-baseline.yml
@@ -74,6 +74,9 @@ jobs:
           DB_NAME: verifywise_test
           DB_USER: postgres
           DB_PASSWORD: postgres
+          # Required by the RLS runtime-role migration (rls-app-role.js), which
+          # fails closed without it. CI-only value; not a real credential.
+          DB_APP_PASSWORD: test-app-role-password-for-ci
           SUPERADMIN_EMAIL: admin@verifywise-test.com
           SUPERADMIN_PASSWORD: TestAdmin!Str0ng
         run: npx sequelize db:migrate


### PR DESCRIPTION
Targets the `mo-374-jul-20-advanced-security-scanning` branch (PR #4304), fixing the security-scan workflows so they execute instead of failing on configuration. Four of these workflows are introduced by #4304, so these fixes belong on top of that branch rather than on develop.

## What was broken (config, not findings)

| Scanner | Problem | Fix |
|---|---|---|
| **Gitleaks** | `gitleaks-action@v2` requires a paid `GITLEAKS_LICENSE` secret for org repos — the scan never ran | Run the open-source gitleaks binary (pinned v8.21.2), scanning the checked-out tree (`--no-git`) so already-remediated history doesn't fail every run |
| **Semgrep** | `semgrep-action@v1` is deprecated and rejects the `generateSarif`/`baselineRef` inputs, so it never produced `semgrep.sarif` and the SARIF upload step errored | Run the Semgrep CLI directly with `--sarif --output` and `--error` |
| **ZAP baseline + api scan** | The migration step failed because the RLS runtime-role migration requires `DB_APP_PASSWORD`, unset in CI — the backend never started, so ZAP had nothing to scan | Provide a CI-only `DB_APP_PASSWORD`. Same fix applied to `e2e-tests.yml`, which migrates identically and would otherwise break for the same reason |

## Deliberately not touched

These fail on **real findings**, which are remediation work, not scanner config:

- **Trivy IaC** — genuine HIGH/CRITICAL misconfigurations in the IaC files.
- **pip-audit** (EvalServer / AIGateway / GRSModule) — vulnerable Python deps with available fixes (`starlette 0.49→1.0`, `gitpython`, `click`). Bumping them carries real compat risk (starlette major version) and is the service owners' call.
- **Semgrep's 2 blocking findings** — this change makes them surface correctly rather than hiding them.

All five workflow files validated as syntactically correct YAML.