### PR TITLE
test(audit): cover refresh_tokens in the tenant-isolation audit

### DIFF
--- a/Servers/scripts/auditTenantIsolationCoverage.ts
+++ b/Servers/scripts/auditTenantIsolationCoverage.ts
@@ -672,6 +672,11 @@ const deferredScopedTables: SharedTableEntry[] = [
       "Deferred to a future isolation wave; not covered by the first-pass matrix. See runbook section 2.4.",
   },
   {
+    name: "refresh_tokens",
+    justification:
+      "Auth session store carrying organization_id; isolation coverage deferred to a future wave with the RLS Phase 2 rollout. See runbook section 2.4.",
+  },
+  {
     name: "risk_history",
     justification:
       "Deferred to a future isolation wave; not covered by the first-pass matrix. See runbook section 2.4.",


### PR DESCRIPTION
Targets the `mo-374-jul-20-advanced-security-scanning` branch (PR #4304), resolving the tenant-isolation schema-drift audit failure in backend-checks.

## Problem

The security branch adds the org-scoped `refresh_tokens` table (session store carrying `organization_id`), but it wasn't declared in any of the tenant-isolation coverage lists. The schema-drift audit (`auditTenantIsolationCoverage.ts`) flags every `organization_id`-bearing table that isn't in the registry, the shared-tables allow-list, or the deferred list — so it failed with an uncovered scoped table.

## Change

Add `refresh_tokens` to `deferredScopedTables`: it carries `organization_id` but its cross-tenant isolation coverage is deferred to a future wave alongside the RLS Phase 2 rollout, matching how other new scoped tables are handled in this repo.

`one_time_tokens` (the PR's other new token table) is **user-scoped** — it has no `organization_id` — so it is correctly not registered.

## Verification

- Confirmed `refresh_tokens` is the only new `organization_id`-bearing table this PR adds beyond develop's existing coverage.
- After the change, `refresh_tokens` no longer appears in the audit's uncovered set.
- Backend `tsc --noEmit` passes.