### PR TITLE
Removing EU AI Act from Use cases

### DIFF
--- a/Clients/src/presentation/pages/ProjectView/AddNewFramework/index.tsx
+++ b/Clients/src/presentation/pages/ProjectView/AddNewFramework/index.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from "react";
+import React, { useState } from "react";
 import { Box, Typography, Stack, Button } from "@mui/material";
 import { Check as CheckGreenIcon } from "lucide-react";
 import StandardModal from "../../../components/Modals/StandardModal";
@@ -46,28 +46,6 @@ const AddFrameworkModal: React.FC<AddFrameworkModalProps> = ({
   const [alert, setAlert] = useState<AlertProps | null>(null);
   const [frameworkToRemove, setFrameworkToRemove] = useState<Framework | null>(null);
   const [isRemoveModalOpen, setIsRemoveModalOpen] = useState(false);
-  const [customFrameworkCount, setCustomFrameworkCount] = useState(0);
-
-  // Listen for custom framework count changes from plugins (event-based communication)
-  useEffect(() => {
-    const handleCustomFrameworkCount = (event: CustomEvent) => {
-      if (event.detail?.projectId === project.id) {
-        setCustomFrameworkCount(event.detail.count || 0);
-      }
-    };
-
-    window.addEventListener(
-      "customFrameworkCountChanged" as any,
-      handleCustomFrameworkCount as EventListener,
-    );
-
-    return () => {
-      window.removeEventListener(
-        "customFrameworkCountChanged" as any,
-        handleCustomFrameworkCount as EventListener,
-      );
-    };
-  }, [project.id]);
 
   const showToast = (variant: AlertProps["variant"], body: string) => {
     handleAlert({ variant, body, setAlert, alertTimeout: 3000 });
@@ -181,9 +159,6 @@ const AddFrameworkModal: React.FC<AddFrameworkModalProps> = ({
         >
           {frameworks.map((fw) => {
             const isAdded = isFrameworkAdded(fw);
-            // Total frameworks = system frameworks + custom frameworks (from plugin events)
-            const totalFrameworkCount = (project.framework?.length || 0) + customFrameworkCount;
-            const onlyOneFramework = totalFrameworkCount === 1 && isAdded;
             return (
               <Box key={fw.id} sx={frameworkCardStyle}>
                 <Box display="flex" justifyContent="space-between" alignItems="flex-start" mb={2}>
@@ -201,7 +176,7 @@ const AddFrameworkModal: React.FC<AddFrameworkModalProps> = ({
                     <Button
                       variant="outlined"
                       size="small"
-                      disabled={isLoading || onlyOneFramework}
+                      disabled={isLoading}
                       onClick={() => {
                         setFrameworkToRemove(fw);
                         setIsRemoveModalOpen(true);

--- a/Servers/utils/framework.utils.ts
+++ b/Servers/utils/framework.utils.ts
@@ -74,31 +74,10 @@ const canRemoveFrameworkFromProjectQuery = async (
   organizationId: number,
   transaction: Transaction,
 ): Promise<boolean> => {
-  const exists = await checkFrameworkExistsQuery(
-    frameworkId,
-    projectId,
-    organizationId,
-    transaction,
-  );
-  if (!exists) {
-    return false; // Framework not found in the project
-  }
-
-  // Count both system frameworks and custom frameworks (from plugin if installed) for the project
-  // A framework can only be removed if total count > 1
-  // Use safe query that handles missing plugin table
-  const [[{ can_remove }]] = (await sequelize.query(
-    `SELECT (
-      (SELECT COUNT(*) FROM projects_frameworks WHERE organization_id = :organizationId AND project_id = :projectId) +
-      CASE
-        WHEN EXISTS (SELECT 1 FROM information_schema.tables WHERE table_schema = 'verifywise' AND table_name = 'custom_framework_projects')
-        THEN (SELECT COUNT(*) FROM custom_framework_projects WHERE organization_id = :organizationId AND project_id = :projectId)
-        ELSE 0
-      END
-    ) > 1 AND EXISTS (SELECT 1 FROM projects_frameworks WHERE organization_id = :organizationId AND project_id = :projectId AND framework_id = :frameworkId) AS can_remove;`,
-    { replacements: { projectId, frameworkId, organizationId }, transaction },
-  )) as [[{ can_remove: boolean }], number];
-  return can_remove;
+  // A framework can be removed as long as it is attached to the project.
+  // A use case is allowed to have zero frameworks (frameworks are optional at creation),
+  // so removing the last remaining framework is permitted.
+  return checkFrameworkExistsQuery(frameworkId, projectId, organizationId, transaction);
 };
 
 export const canAddFrameworkToProjectQuery = async (


### PR DESCRIPTION
## Removing EU AI Act from Use cases

## Please ensure all items are checked off before requesting a review:

- [x] I deployed the code locally.
- [x] I have performed a self-review of my code.
- [x] I have included the issue # in the PR.
- [x] I have labelled the PR correctly.
- [x] The issue I am working on is assigned to me.
- [x] I have avoided using hardcoded values to ensure scalability and maintain consistency across the application.
- [x] I have ensured that font sizes, color choices, and other UI elements are referenced from the theme.
- [x] My pull request is focused and addresses a single, specific feature.
- [x] If there are UI changes, I have attached a screenshot or video to this PR.
- [x] If I added or modified an API endpoint, the change is reflected in the generated OpenAPI spec (`npm run generate:swagger`).
- [x] If the endpoint requires authentication, it uses `authenticateJWT` and the generated spec declares `bearerAuth` security.
- [x] I ran `npm run check:api-drift` and committed the regenerated `swagger.yaml` and `endpoints.ts`.
- [x] If this PR adds or modifies an organization-scoped table, the [tenant isolation registry](Servers/tests/integration/tenant-isolation/tenantIsolation.registry.ts) and [test matrix](Servers/tests/integration/tenant-isolation) are updated. See the [tenant isolation runbook](docs/technical/security/tenant-isolation.md) for details.

-------------


## 1. Problem

In `/project-view?projectId=1&tab=frameworks`, the **"AI Frameworks"** modal ("Add or remove AI frameworks or regulations…") let users **add** EU AI Act but never **remove** it — whether it was added at use-case creation or later.

## 2. Root Cause (two intentional "keep ≥ 1 framework" guards)

| Layer | Location | Behavior |
|---|---|---|
| Frontend | `Clients/src/presentation/pages/ProjectView/AddNewFramework/index.tsx` | Remove button `disabled` when `totalFrameworkCount === 1` (`onlyOneFramework`). EU AI Act is the only project-based framework ⇒ always disabled. |
| Backend | `Servers/utils/framework.utils.ts` → `canRemoveFrameworkFromProjectQuery` | SQL required `COUNT(frameworks) > 1`, else `false` → controller 404. |

The guards contradicted the product itself: frameworks are **optional at use-case creation**, so a zero-framework use case is already a valid state. The removal pipeline (confirmation modal → `DELETE /api/frameworks/fromProject` → cascade of EU assessment/control data + junction row) existed and was fully wired — only the guards blocked it.
