### PR TITLE
feat(agent-control): run-grain stat cards on the Runs page

### DIFF
--- a/AIGateway/src/crud/mcp_runs.py
+++ b/AIGateway/src/crud/mcp_runs.py
@@ -65,6 +65,48 @@ async def list_runs(org_id: int, limit: int = 50, offset: int = 0) -> dict:
     return {"data": data, "total": total, "limit": limit, "offset": offset}
 
 
+async def get_run_stats(org_id: int, days: int = 7) -> dict:
+    """Run-grain aggregates over the last N days: total runs, avg tool calls
+    per run, and the share of runs that hit at least one blocked tool call.
+
+    Runs are counted from the tool-call side (ai_gateway_mcp_audit_logs grouped
+    by agent_run_id). A run consisting solely of model calls with zero tool
+    calls is intentionally excluded — all three metrics are about tool activity.
+    """
+    days = int(days)  # validate before interpolating into INTERVAL
+
+    sql = f"""
+        WITH runs AS (
+            SELECT agent_run_id,
+                   COUNT(*) AS tool_count,
+                   COUNT(*) FILTER (WHERE result_status = 'blocked') AS blocked_count
+            FROM ai_gateway_mcp_audit_logs
+            WHERE organization_id = :org_id
+              AND agent_run_id IS NOT NULL
+              AND created_at >= NOW() - INTERVAL '{days} days'
+            GROUP BY agent_run_id
+        )
+        SELECT
+            COUNT(*) AS total_runs,
+            COALESCE(AVG(tool_count), 0) AS avg_tool_calls_per_run,
+            COALESCE(
+                100.0 * COUNT(*) FILTER (WHERE blocked_count > 0) / NULLIF(COUNT(*), 0),
+                0
+            ) AS pct_runs_with_block
+        FROM runs
+    """
+
+    async with get_db() as db:
+        row = (await db.execute(text(sql), {"org_id": org_id})).mappings().first()
+        if row is None:
+            return {"total_runs": 0, "avg_tool_calls_per_run": 0.0, "pct_runs_with_block": 0.0}
+        return {
+            "total_runs": int(row["total_runs"]),
+            "avg_tool_calls_per_run": round(float(row["avg_tool_calls_per_run"]), 1),
+            "pct_runs_with_block": round(float(row["pct_runs_with_block"]), 1),
+        }
+
+
 async def get_run(org_id: int, run_id: str) -> dict:
     """Interleaved entries (model + tool) for one run, ordered by created_at."""
     params = {"org_id": org_id, "run_id": run_id}

--- a/AIGateway/src/routers/mcp_runs.py
+++ b/AIGateway/src/routers/mcp_runs.py
@@ -4,7 +4,7 @@ from fastapi import APIRouter, Request, status, HTTPException
 
 from middlewares.auth import verify_internal_key
 from utils.auth import get_org_id
-from crud.mcp_runs import list_runs, get_run
+from crud.mcp_runs import list_runs, get_run, get_run_stats
 
 router = APIRouter(prefix="/mcp/runs", tags=["mcp-runs"])
 
@@ -21,6 +21,14 @@ async def runs_list(request: Request, limit: int = 50, offset: int = 0):
         "limit": result["limit"],
         "offset": result["offset"],
     }
+
+
+@router.get("/stats", status_code=status.HTTP_200_OK)
+async def runs_stats(request: Request, days: int = 7):
+    verify_internal_key(request)
+    org_id = get_org_id(request)
+    stats = await get_run_stats(org_id, days=days)
+    return {"status": "success", "data": stats}
 
 
 @router.get("/{run_id}", status_code=status.HTTP_200_OK)

--- a/Clients/src/i18n/translations.ts
+++ b/Clients/src/i18n/translations.ts
@@ -1429,6 +1429,7 @@ export const translations: Record<string, Record<string, string>> = {
       "KI-Agenten in Ihrer Organisation automatisch erkennen und inventarisieren. Erkannte Agenten prüfen, bestätigen oder ablehnen und für die Governance-Verfolgung mit Ihrem Modellinventar verknüpfen.",
     "Avg Latency": "Durchschnittliche Latenz",
     "Avg input tokens": "Durchschnittliche Eingabe-Tokens",
+    "Avg tool calls / run": "Durchschnittliche Tool-Aufrufe / Lauf",
     "Avg latency": "Durchschnittliche Latenz",
     "Avg latency, top 10 tools": "Durchschnittliche Latenz, Top 10 Tools",
     "Avg output tokens": "Durchschnittliche Ausgabe-Tokens",
@@ -2520,6 +2521,7 @@ export const translations: Record<string, Record<string, string>> = {
     "Tool-level access control": "Zugriffskontrolle auf Tool-Ebene",
     "Total applicants": "Bewerber insgesamt",
     "Total Calls": "Gesamtaufrufe",
+    "Total runs": "Läufe insgesamt",
     "Total cost": "Gesamtkosten",
     "Total events": "Ereignisse insgesamt",
     "Total findings": "Erkenntnisse insgesamt",
@@ -2536,6 +2538,11 @@ export const translations: Record<string, Record<string, string>> = {
     "Total tokens": "Tokens insgesamt",
     "Total tool invocations in the selected period":
       "Gesamte Tool-Aufrufe im ausgewählten Zeitraum",
+    "Distinct agent runs in the selected period":
+      "Eindeutige Agentenläufe im ausgewählten Zeitraum",
+    "Mean number of tool calls per run": "Durchschnittliche Anzahl an Tool-Aufrufen pro Lauf",
+    "Share of runs where at least one tool call was blocked by a policy or guardrail":
+      "Anteil der Läufe, bei denen mindestens ein Tool-Aufruf durch eine Richtlinie oder ein Guardrail blockiert wurde",
     "Total users": "Benutzer insgesamt",
     "Traffic controls": "Verkehrskontrollen",
     "Transparency measures": "Transparenzmaßnahmen",
@@ -2549,6 +2556,7 @@ export const translations: Record<string, Record<string, string>> = {
     "Unique apps": "Eindeutige Apps",
     "Unique repos scanned": "Eindeutige gescannte Repositories",
     "Unique Tools": "Eindeutige Tools",
+    "Runs with a block": "Läufe mit einer Blockierung",
     "Unknown": "Unbekannt",
     "Unlinked": "Nicht verknüpft",
     "Untitled audit": "Unbenannte Prüfung",
@@ -10534,6 +10542,7 @@ export const translations: Record<string, Record<string, string>> = {
       "Découvrez et inventoriez automatiquement les agents IA dans votre organisation. Examinez les agents découverts, confirmez-les ou rejetez-les, et reliez-les à votre inventaire de modèles pour le suivi de gouvernance.",
     "Avg Latency": "Latence moyenne",
     "Avg input tokens": "Tokens d'entrée moyens",
+    "Avg tool calls / run": "Appels d'outils moyens / exécution",
     "Avg latency": "Latence moyenne",
     "Avg latency, top 10 tools": "Latence moyenne, top 10 outils",
     "Avg output tokens": "Tokens de sortie moyens",
@@ -11594,6 +11603,7 @@ export const translations: Record<string, Record<string, string>> = {
     "Total applicants": "Candidats au total",
     "Total Calls": "Appels totaux",
     "Total cost": "Coût total",
+    "Total runs": "Exécutions totales",
     "Total events": "Événements au total",
     "Total findings": "Constats au total",
     "Total LLM vulnerability findings across all OWASP Top 10 for LLM types":
@@ -11609,6 +11619,11 @@ export const translations: Record<string, Record<string, string>> = {
     "Total tokens": "Tokens au total",
     "Total tool invocations in the selected period":
       "Invocations totales d'outils sur la période sélectionnée",
+    "Distinct agent runs in the selected period":
+      "Exécutions d'agents distinctes sur la période sélectionnée",
+    "Mean number of tool calls per run": "Nombre moyen d'appels d'outils par exécution",
+    "Share of runs where at least one tool call was blocked by a policy or guardrail":
+      "Part des exécutions où au moins un appel d'outil a été bloqué par une politique ou un garde-fou",
     "Total users": "Utilisateurs au total",
     "Traffic controls": "Contrôles de trafic",
     "Transparency measures": "Mesures de transparence",
@@ -11622,6 +11637,7 @@ export const translations: Record<string, Record<string, string>> = {
     "Unique apps": "Applications uniques",
     "Unique repos scanned": "Dépôts uniques analysés",
     "Unique Tools": "Outils uniques",
+    "Runs with a block": "Exécutions avec un blocage",
     "Unlinked": "Non relié",
     "Untitled audit": "Audit sans titre",
     "Untitled form": "Formulaire sans titre",
@@ -18896,6 +18912,7 @@ export const translations: Record<string, Record<string, string>> = {
     "Associated model (optional)": "Modelo asociado (opcional)",
     "Avg Latency": "Latencia media",
     "Avg input tokens": "Tokens de entrada medios",
+    "Avg tool calls / run": "Llamadas a herramientas medias / ejecución",
     "Avg latency": "Latencia media",
     "Avg latency, top 10 tools": "Latencia media, 10 herramientas principales",
     "Avg output tokens": "Tokens de salida medios",
@@ -19881,6 +19898,7 @@ export const translations: Record<string, Record<string, string>> = {
     "Total applicants": "Total de solicitantes",
     "Total Calls": "Total de llamadas",
     "Total cost": "Coste total",
+    "Total runs": "Ejecuciones totales",
     "Total events": "Total de eventos",
     "Total findings": "Total de hallazgos",
     "Total number of source files analyzed": "Número total de archivos de origen analizados",
@@ -19901,6 +19919,7 @@ export const translations: Record<string, Record<string, string>> = {
     "Unique apps": "Aplicaciones únicas",
     "Unique repos scanned": "Repositorios únicos analizados",
     "Unique Tools": "Herramientas únicas",
+    "Runs with a block": "Ejecuciones con un bloqueo",
     "Unknown": "Desconocido",
     "Unlinked": "Sin vincular",
     "Untitled audit": "Auditoría sin título",
@@ -23170,6 +23189,11 @@ export const translations: Record<string, Record<string, string>> = {
       "Gasto total en todos los endpoints durante este periodo",
     "Total tool invocations in the selected period":
       "Total de invocaciones de herramientas en el periodo seleccionado",
+    "Distinct agent runs in the selected period":
+      "Ejecuciones de agentes distintas en el periodo seleccionado",
+    "Mean number of tool calls per run": "Número medio de llamadas a herramientas por ejecución",
+    "Share of runs where at least one tool call was blocked by a policy or guardrail":
+      "Proporción de ejecuciones en las que al menos una llamada a una herramienta fue bloqueada por una política o barrera de protección",
     "What your guardrails caught in this period":
       "Lo que sus barreras de protección detectaron en este periodo",
     "Whose name and role appear on the declaration document":

--- a/Clients/src/presentation/pages/AIGateway/MCPRuns/index.tsx
+++ b/Clients/src/presentation/pages/AIGateway/MCPRuns/index.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState, useCallback } from "react";
 import { Box, Stack, Typography } from "@mui/material";
-import { Activity, AlertTriangle, RotateCcw } from "lucide-react";
+import { Activity, AlertTriangle, RotateCcw, Wrench } from "lucide-react";
 import { apiServices } from "../../../../infrastructure/api/networkServices";
 import { PageHeaderExtended } from "../../../components/Layout/PageHeaderExtended";
 import MCPTable, { MCPTableColumn } from "../MCPTable";
@@ -9,6 +9,8 @@ import RunDetailDrawer from "./RunDetailDrawer";
 import palette from "../../../themes/palette";
 import { CustomizableButton } from "../../../components/button/customizable-button";
 import CustomizableSkeleton from "../../../components/Skeletons";
+import Select from "../../../components/Inputs/Select";
+import { StatCard } from "../../../components/Cards/StatCard";
 
 interface RunRow {
   agent_run_id: string;
@@ -21,6 +23,18 @@ interface RunRow {
   started_at: string;
   last_at: string;
 }
+
+interface RunStats {
+  total_runs: number;
+  avg_tool_calls_per_run: number;
+  pct_runs_with_block: number;
+}
+
+const PERIOD_ITEMS = [
+  { _id: "7", name: "Last 7 days" },
+  { _id: "14", name: "Last 14 days" },
+  { _id: "30", name: "Last 30 days" },
+];
 
 const RUNS_LIMIT = 50;
 
@@ -38,6 +52,8 @@ export default function MCPRuns() {
   const [loading, setLoading] = useState(true);
   const [loadError, setLoadError] = useState<string | null>(null);
   const [selected, setSelected] = useState<string | null>(null);
+  const [stats, setStats] = useState<RunStats | null>(null);
+  const [days, setDays] = useState("7");
 
   const load = useCallback(async () => {
     setLoading(true);
@@ -58,6 +74,21 @@ export default function MCPRuns() {
     load();
   }, [load]);
 
+  const loadStats = useCallback(async () => {
+    try {
+      const res = await apiServices.get<Record<string, any>>(
+        `/ai-gateway/mcp/runs/stats?days=${days}`,
+      );
+      setStats(res?.data?.data ?? null);
+    } catch {
+      setStats(null);
+    }
+  }, [days]);
+
+  useEffect(() => {
+    loadStats();
+  }, [loadStats]);
+
   return (
     <PageHeaderExtended
       title="Runs"
@@ -65,6 +96,46 @@ export default function MCPRuns() {
       helpArticlePath="ai-gateway/mcp-runs"
     >
       <Box sx={{ px: 3, pt: 2 }}>
+        <Stack direction="row" sx={{ justifyContent: "flex-end", mb: "16px" }}>
+          <Box sx={{ width: 180 }}>
+            <Select
+              id="runs-period"
+              value={days}
+              items={PERIOD_ITEMS}
+              onChange={(e) => setDays(e.target.value as string)}
+            />
+          </Box>
+        </Stack>
+        {stats && (
+          <Box
+            sx={{
+              display: "grid",
+              gridTemplateColumns: "repeat(3, 1fr)",
+              gap: "16px",
+              mb: "16px",
+            }}
+          >
+            <StatCard
+              title="Total runs"
+              value={stats.total_runs}
+              Icon={Activity}
+              tooltip="Distinct agent runs in the selected period"
+            />
+            <StatCard
+              title="Avg tool calls / run"
+              value={stats.avg_tool_calls_per_run}
+              Icon={Wrench}
+              tooltip="Mean number of tool calls per run"
+            />
+            <StatCard
+              title="Runs with a block"
+              value={`${stats.pct_runs_with_block}%`}
+              Icon={AlertTriangle}
+              highlight={stats.pct_runs_with_block > 0}
+              tooltip="Share of runs where at least one tool call was blocked by a policy or guardrail"
+            />
+          </Box>
+        )}
         {loading ? (
           <CustomizableSkeleton variant="rectangular" width="100%" height={400} />
         ) : loadError ? (


### PR DESCRIPTION
## Summary

Adds a row of run-grain summary cards (and a 7/14/30-day period selector) to the Agent Control Runs page, so the page reads as a dashboard rather than a bare table. These metrics are meaningful only at the run grain (a run correlates many model + tool calls) and do not duplicate the tool-call-grain tiles the Activity page already shows.

## Changes

**Backend** — new aggregate endpoint `GET /ai-gateway/mcp/runs/stats?days=<7|14|30>`
- `get_run_stats` in `AIGateway/src/crud/mcp_runs.py`, mirroring the existing `get_audit_stats` pattern (org-scoped, `int(days)` guard before the interval, empty-period returns zeros).
- Route declared before the `/{run_id}` route so `stats` is not captured as a run id.
- Returns `{ total_runs, avg_tool_calls_per_run, pct_runs_with_block }`.

**Frontend** — `Clients/src/presentation/pages/AIGateway/MCPRuns/index.tsx`
- Three cards: total runs, avg tool calls / run, and % of runs with at least one blocked call (highlighted when non-zero).
- Period selector reusing the same options as the Activity page.
- Stats fetch is decoupled from the runs-table fetch: a stats failure never blanks the table.
- New strings covered in de/fr/es.

## Notes

- Runs are counted from the tool-call side, so a run consisting solely of model calls with no tool calls is excluded by design (all three metrics are about tool activity) — documented in the query.
- No changes to the existing runs table, drawer, or empty state.