### PR TITLE
fix(ai-trust-center): create logo row on first upload instead of failing

### DIFF
--- a/Servers/utils/__tests__/aiTrustCentre.utils.test.ts
+++ b/Servers/utils/__tests__/aiTrustCentre.utils.test.ts
@@ -1,0 +1,57 @@
+jest.mock("../../database/db", () => ({
+  sequelize: {
+    query: jest.fn().mockResolvedValue([[], 0]),
+  },
+}));
+
+jest.mock("../fileUpload.utils", () => ({
+  deleteFileById: jest.fn().mockResolvedValue(undefined),
+  getFileById: jest.fn().mockResolvedValue(undefined),
+}));
+
+import { uploadCompanyLogoQuery } from "../aiTrustCentre.utils";
+import { sequelize } from "../../database/db";
+import { deleteFileById } from "../fileUpload.utils";
+import { Transaction } from "sequelize";
+
+const query = sequelize.query as jest.Mock;
+const deleteFile = deleteFileById as jest.Mock;
+const tx = {} as Transaction;
+
+describe("uploadCompanyLogoQuery", () => {
+  beforeEach(() => {
+    query.mockReset();
+    deleteFile.mockReset().mockResolvedValue(undefined);
+  });
+
+  it("inserts a new ai_trust_center row when none exists yet (first logo upload)", async () => {
+    // SELECT current logo returns no row (org has never initialized the trust center)
+    query.mockResolvedValueOnce([[], 0]);
+    // INSERT returns the new logo
+    query.mockResolvedValueOnce([[{ logo: 42 }], 1]);
+
+    const result = await uploadCompanyLogoQuery(42, 7, tx);
+
+    const insertSql = query.mock.calls[1][0] as string;
+    expect(insertSql).toMatch(/INSERT INTO ai_trust_center/i);
+    expect(query.mock.calls[1][1].replacements).toEqual({ organizationId: 7, fileId: 42 });
+    // No prior logo, so nothing to delete
+    expect(deleteFile).not.toHaveBeenCalled();
+    expect(result).toEqual({ logo: 42 });
+  });
+
+  it("updates the existing row and deletes the previous logo when a row exists", async () => {
+    // SELECT current logo returns an existing logo file id
+    query.mockResolvedValueOnce([[{ logo: 10 }], 1]);
+    // UPDATE returns the new logo
+    query.mockResolvedValueOnce([[{ logo: 99 }], 1]);
+
+    const result = await uploadCompanyLogoQuery(99, 7, tx);
+
+    const updateSql = query.mock.calls[1][0] as string;
+    expect(updateSql).toMatch(/UPDATE ai_trust_center SET logo/i);
+    // Previous logo (10) is cleaned up
+    expect(deleteFile).toHaveBeenCalledWith(10, 7, tx);
+    expect(result).toEqual({ logo: 99 });
+  });
+});

--- a/Servers/utils/aiTrustCentre.utils.ts
+++ b/Servers/utils/aiTrustCentre.utils.ts
@@ -268,12 +268,25 @@ export const uploadCompanyLogoQuery = async (
     `SELECT logo FROM ai_trust_center WHERE organization_id = :organizationId LIMIT 1;`,
     { replacements: { organizationId }, transaction },
   )) as [{ logo: number }[], number];
-  const deleteFileId = currentLogo[0][0]?.logo;
+  const existingRow = currentLogo[0][0];
+  const deleteFileId = existingRow?.logo;
 
-  const result = (await sequelize.query(
-    `UPDATE ai_trust_center SET logo = :fileId WHERE organization_id = :organizationId RETURNING logo;`,
-    { replacements: { organizationId, fileId: file }, transaction },
-  )) as [{ file_id: number }[], number];
+  // The ai_trust_center base row is not seeded on org creation, so it may not
+  // exist yet the first time a logo is uploaded. A bare UPDATE would then match
+  // zero rows and return undefined, which the controller reports as a 503
+  // "failed to upload company logo". Insert the row when it is missing so the
+  // first logo upload for an org succeeds, and update it otherwise.
+  const result = (
+    existingRow === undefined
+      ? await sequelize.query(
+          `INSERT INTO ai_trust_center (organization_id, logo) VALUES (:organizationId, :fileId) RETURNING logo;`,
+          { replacements: { organizationId, fileId: file }, transaction },
+        )
+      : await sequelize.query(
+          `UPDATE ai_trust_center SET logo = :fileId WHERE organization_id = :organizationId RETURNING logo;`,
+          { replacements: { organizationId, fileId: file }, transaction },
+        )
+  ) as [{ logo: number }[], number];
 
   if (deleteFileId) {
     await deleteFileById(deleteFileId, organizationId, transaction);


### PR DESCRIPTION
## Summary

Fixes a 503 "failed to upload company logo" that hit any organization setting its AI Trust Center logo for the first time.

## Root cause

The `ai_trust_center` base row is never seeded — not on organization creation, not in migrations, and there is no init path for it. `uploadCompanyLogoQuery` ran a bare `UPDATE ... WHERE organization_id = :organizationId`, which matches zero rows for an org that has not yet initialized its AI Trust Center. The query returned `undefined`, and the controller surfaced it as a 503 "failed to upload company logo".

## Changes

- **`aiTrustCentre.utils.ts`** — `uploadCompanyLogoQuery` now inserts the `ai_trust_center` row when it is absent and updates it when present, within the existing transaction. Previous-logo cleanup still runs only when a prior row/logo existed.
- **tests** — new utils test covering both paths: INSERT (missing row) and UPDATE (existing row + old-logo deletion).

## Notes

- No schema migration required: `ai_trust_center.organization_id` has no unique constraint, so an explicit insert-when-missing is used rather than `ON CONFLICT`.
- This is the separate, pre-existing issue surfaced during review of #4192; it is unrelated to that PR's org-level file access fix.