### PR TITLE
Refactor/policy editor split 3

### DIFF
--- a/Clients/src/presentation/pages/PolicyDashboard/PolicyEditor/AuthImage.tsx
+++ b/Clients/src/presentation/pages/PolicyDashboard/PolicyEditor/AuthImage.tsx
@@ -1,0 +1,154 @@
+import React, { useEffect, useState, useCallback, useRef } from "react";
+import { NodeViewWrapper, NodeViewProps, ReactNodeViewRenderer } from "@tiptap/react";
+import TipTapImage from "@tiptap/extension-image";
+import { store } from "../../../../application/redux/store";
+
+/** Auth-aware TipTap image node view with drag-to-resize. */
+const AuthImage: React.FC<NodeViewProps> = ({ node, updateAttributes, selected }) => {
+  const src = node.attrs.src || "";
+  const alt = node.attrs.alt || "";
+  const width = node.attrs.width as number | null;
+  const isApiUrl = src.startsWith("/api/") || src.includes("/api/file-manager/");
+  const [blobUrl, setBlobUrl] = useState<string | null>(null);
+  const [error, setError] = useState(false);
+  const imgRef = useRef<HTMLImageElement>(null);
+  const startXRef = useRef(0);
+  const startWidthRef = useRef(0);
+
+  useEffect(() => {
+    if (!isApiUrl || !src) return;
+    let cancelled = false;
+    const controller = new AbortController();
+    (async () => {
+      try {
+        const token = store.getState().auth.authToken;
+        const res = await fetch(src, {
+          headers: { Authorization: `Bearer ${token}` },
+          signal: controller.signal,
+        });
+        if (!res.ok) throw new Error(`HTTP ${res.status}`);
+        const blob = await res.blob();
+        if (!cancelled) setBlobUrl(URL.createObjectURL(blob));
+      } catch (e: any) {
+        if (e.name !== "AbortError" && !cancelled) setError(true);
+      }
+    })();
+    return () => {
+      cancelled = true;
+      controller.abort();
+    };
+  }, [src, isApiUrl]);
+
+  const handleResizeStart = useCallback(
+    (e: React.MouseEvent) => {
+      e.preventDefault();
+      e.stopPropagation();
+      startXRef.current = e.clientX;
+      startWidthRef.current = imgRef.current?.offsetWidth || 300;
+
+      const onMove = (ev: MouseEvent) => {
+        const diff = ev.clientX - startXRef.current;
+        const newWidth = Math.max(100, startWidthRef.current + diff);
+        updateAttributes({ width: newWidth });
+      };
+      const onUp = () => {
+        document.removeEventListener("mousemove", onMove);
+        document.removeEventListener("mouseup", onUp);
+      };
+      document.addEventListener("mousemove", onMove);
+      document.addEventListener("mouseup", onUp);
+    },
+    [updateAttributes],
+  );
+
+  const displaySrc = isApiUrl ? blobUrl : src;
+
+  return (
+    <NodeViewWrapper>
+      {error ? (
+        <div
+          style={{
+            background: "#fee2e2",
+            color: "#991b1b",
+            padding: "8px 12px",
+            borderRadius: 6,
+            fontSize: "0.9rem",
+            textAlign: "center",
+            margin: "12px 0",
+          }}
+        >
+          Image not found
+        </div>
+      ) : displaySrc ? (
+        <div
+          style={{
+            position: "relative",
+            display: "inline-block",
+            margin: "12px 0",
+            outline: selected ? "2px solid brand.primary" : "none",
+            borderRadius: 8,
+          }}
+        >
+          <img
+            ref={imgRef}
+            src={displaySrc}
+            alt={alt}
+            style={{
+              display: "block",
+              width: width ? `${width}px` : undefined,
+              maxWidth: "100%",
+              borderRadius: 8,
+            }}
+          />
+          {selected && (
+            <div
+              onMouseDown={handleResizeStart}
+              style={{
+                position: "absolute",
+                right: -5,
+                bottom: -5,
+                width: 12,
+                height: 12,
+                backgroundColor: "brand.primary",
+                border: "2px solid background.main",
+                borderRadius: 2,
+                cursor: "nwse-resize",
+                boxShadow: "0 1px 3px rgba(0,0,0,0.3)",
+              }}
+            />
+          )}
+        </div>
+      ) : (
+        <div
+          style={{
+            background: "#f0f0f0",
+            color: "#666",
+            padding: "16px 24px",
+            borderRadius: 6,
+            textAlign: "center",
+            fontSize: "0.9rem",
+            margin: "12px 0",
+          }}
+        >
+          Loading image...
+        </div>
+      )}
+    </NodeViewWrapper>
+  );
+};
+
+export const AuthImageExtension = TipTapImage.extend({
+  addAttributes() {
+    return {
+      ...this.parent?.(),
+      width: {
+        default: null,
+        parseHTML: (el) => (el.getAttribute("width") ? Number(el.getAttribute("width")) : null),
+        renderHTML: (attrs) => (attrs.width ? { width: attrs.width } : {}),
+      },
+    };
+  },
+  addNodeView() {
+    return ReactNodeViewRenderer(AuthImage);
+  },
+});

--- a/Clients/src/presentation/pages/PolicyDashboard/PolicyEditor/ColorPickerPopover.tsx
+++ b/Clients/src/presentation/pages/PolicyDashboard/PolicyEditor/ColorPickerPopover.tsx
@@ -1,0 +1,91 @@
+import { Box, Popover } from "@mui/material";
+import type { Editor } from "@tiptap/react";
+import { palette } from "../../../themes/palette";
+
+const { border } = palette;
+
+const COLOR_PALETTE = [
+  "text.black",
+  "text.secondary",
+  "text.tertiary",
+  "text.icon",
+  "#dc2626",
+  "#ea580c",
+  "#d97706",
+  "#ca8a04",
+  "#16a34a",
+  "#059669",
+  "#0d9488",
+  "#0891b2",
+  "#2563eb",
+  "#4f46e5",
+  "#7c3aed",
+  "#9333ea",
+];
+
+export interface ColorPickerPopoverProps {
+  editor: Editor | null;
+  anchorEl: HTMLElement | null;
+  onClose: () => void;
+}
+
+/** Text color swatch popover for the policy editor toolbar. */
+export function ColorPickerPopover({ editor, anchorEl, onClose }: ColorPickerPopoverProps) {
+  return (
+    <Popover
+      open={Boolean(anchorEl)}
+      anchorEl={anchorEl}
+      onClose={onClose}
+      anchorOrigin={{ vertical: "bottom", horizontal: "left" }}
+      transformOrigin={{ vertical: "top", horizontal: "left" }}
+      slotProps={{
+        paper: {
+          sx: {
+            p: 1.5,
+            borderRadius: "6px",
+            border: "1px solid",
+            borderColor: border.dark,
+            boxShadow: "0 4px 12px rgba(0,0,0,0.1)",
+          },
+        },
+      }}
+    >
+      <Box sx={{ display: "grid", gridTemplateColumns: "repeat(8, 1fr)", gap: "4px" }}>
+        {COLOR_PALETTE.map((c) => (
+          <Box
+            key={c}
+            onClick={() => {
+              editor?.chain().focus().setColor(c).run();
+              onClose();
+            }}
+            sx={{
+              "width": 24,
+              "height": 24,
+              "borderRadius": "4px",
+              "backgroundColor": c,
+              "cursor": "pointer",
+              "border": "1px solid rgba(0,0,0,0.1)",
+              "&:hover": { transform: "scale(1.15)", transition: "transform 0.1s" },
+            }}
+          />
+        ))}
+      </Box>
+      <Box
+        onClick={() => {
+          editor?.chain().focus().unsetColor().run();
+          onClose();
+        }}
+        sx={{
+          "mt": 1,
+          "textAlign": "center",
+          "fontSize": 11,
+          "color": "text.icon",
+          "cursor": "pointer",
+          "&:hover": { color: "text.secondary" },
+        }}
+      >
+        Reset to default
+      </Box>
+    </Popover>
+  );
+}

--- a/Clients/src/presentation/pages/PolicyDashboard/PolicyEditor/FindReplacePopover.tsx
+++ b/Clients/src/presentation/pages/PolicyDashboard/PolicyEditor/FindReplacePopover.tsx
@@ -1,0 +1,183 @@
+import { Box, IconButton, Popover, Stack, Tooltip, Typography } from "@mui/material";
+import { ChevronDown, ChevronUp } from "lucide-react";
+import Field from "../../../components/Inputs/Field";
+import { CustomizableButton } from "../../../components/button/customizable-button";
+
+export interface FindReplacePopoverProps {
+  anchorEl: HTMLElement | null;
+  onClose: () => void;
+  searchText: string;
+  onSearchTextChange: (value: string) => void;
+  replaceText: string;
+  onReplaceTextChange: (value: string) => void;
+  searchMatchCount: number;
+  onSearchNext: () => void;
+  onSearchPrev: () => void;
+  onReplaceCurrent: () => void;
+  onReplaceAll: () => void;
+}
+
+/** Find & replace popover for the TipTap policy editor. */
+export function FindReplacePopover({
+  anchorEl,
+  onClose,
+  searchText,
+  onSearchTextChange,
+  replaceText,
+  onReplaceTextChange,
+  searchMatchCount,
+  onSearchNext,
+  onSearchPrev,
+  onReplaceCurrent,
+  onReplaceAll,
+}: FindReplacePopoverProps) {
+  return (
+    <Popover
+      open={Boolean(anchorEl)}
+      anchorEl={anchorEl}
+      onClose={onClose}
+      anchorOrigin={{ vertical: "bottom", horizontal: "right" }}
+      transformOrigin={{ vertical: "top", horizontal: "right" }}
+      disableAutoFocus
+      disableEnforceFocus
+      slotProps={{
+        paper: {
+          sx: {
+            width: 340,
+            borderRadius: "4px",
+            border: "1px solid",
+            borderColor: "border.dark",
+            boxShadow: "0 4px 16px rgba(0,0,0,0.12)",
+            p: "16px",
+          },
+        },
+      }}
+    >
+      <Stack gap="12px">
+        <Stack direction="row" gap="8px" alignItems="center">
+          <Box sx={{ flex: 1 }}>
+            <Field
+              id="search-find-input"
+              placeholder="Find in document..."
+              value={searchText}
+              onChange={(e) => onSearchTextChange(e.target.value)}
+              onKeyDown={(e) => {
+                if (e.key === "Enter") onSearchNext();
+              }}
+              autoFocus
+              sx={{
+                "& .field-input": { height: 34 },
+                "& input": { padding: "0 10px", fontSize: 13 },
+              }}
+            />
+          </Box>
+          <Tooltip title="Previous" arrow>
+            <IconButton
+              onClick={onSearchPrev}
+              disabled={searchMatchCount === 0}
+              size="small"
+              sx={{
+                "padding": "6px",
+                "borderRadius": "4px",
+                "border": "1px solid",
+                "borderColor": "border.dark",
+                "color": "text.secondary",
+                "&:hover": { backgroundColor: "background.accent" },
+                "&:disabled": { color: "border.dark", borderColor: "border.light" },
+              }}
+            >
+              <ChevronUp size={16} />
+            </IconButton>
+          </Tooltip>
+          <Tooltip title="Next" arrow>
+            <IconButton
+              onClick={onSearchNext}
+              disabled={searchMatchCount === 0}
+              size="small"
+              sx={{
+                "padding": "6px",
+                "borderRadius": "4px",
+                "border": "1px solid",
+                "borderColor": "border.dark",
+                "color": "text.secondary",
+                "&:hover": { backgroundColor: "background.accent" },
+                "&:disabled": { color: "border.dark", borderColor: "border.light" },
+              }}
+            >
+              <ChevronDown size={16} />
+            </IconButton>
+          </Tooltip>
+        </Stack>
+
+        {searchText && (
+          <Typography sx={{ fontSize: 11, color: "text.muted", mt: "-4px" }}>
+            {searchMatchCount === 0
+              ? "No matches found"
+              : `${searchMatchCount} match${searchMatchCount !== 1 ? "es" : ""} found`}
+          </Typography>
+        )}
+
+        <Stack direction="row" gap="8px" alignItems="center">
+          <Box sx={{ flex: 1 }}>
+            <Field
+              id="search-replace-input"
+              placeholder="Replace with..."
+              value={replaceText}
+              onChange={(e) => onReplaceTextChange(e.target.value)}
+              onKeyDown={(e) => {
+                if (e.key === "Enter") onReplaceCurrent();
+              }}
+              sx={{
+                "& .field-input": { height: 34 },
+                "& input": { padding: "0 10px", fontSize: 13 },
+              }}
+            />
+          </Box>
+          <Tooltip title="Replace" arrow>
+            <span>
+              <CustomizableButton
+                variant="outlined"
+                text="Replace"
+                onClick={onReplaceCurrent}
+                isDisabled={searchMatchCount === 0}
+                sx={{
+                  "minWidth": "auto",
+                  "height": 34,
+                  "px": "10px",
+                  "fontSize": 12,
+                  "backgroundColor": "background.main",
+                  "border": "1px solid",
+                  "borderColor": "border.dark",
+                  "color": "text.secondary",
+                  "whiteSpace": "nowrap",
+                  "&:hover": { backgroundColor: "background.accent" },
+                }}
+              />
+            </span>
+          </Tooltip>
+        </Stack>
+
+        <Box sx={{ display: "flex", justifyContent: "flex-end" }}>
+          <CustomizableButton
+            variant="outlined"
+            text="Replace all"
+            onClick={onReplaceAll}
+            isDisabled={searchMatchCount === 0}
+            sx={{
+              "minWidth": "auto",
+              "height": 34,
+              "px": "10px",
+              "fontSize": 12,
+              "backgroundColor": "background.main",
+              "border": "1px solid",
+              "borderColor": "border.dark",
+              "color": "text.secondary",
+              "whiteSpace": "nowrap",
+              "&:hover": { backgroundColor: "background.accent" },
+            }}
+          />
+        </Box>
+      </Stack>
+    </Popover>
+  );
+}

--- a/Clients/src/presentation/pages/PolicyDashboard/PolicyEditor/PolicyEditorActionsBar.tsx
+++ b/Clients/src/presentation/pages/PolicyDashboard/PolicyEditor/PolicyEditorActionsBar.tsx
@@ -1,0 +1,264 @@
+import React, { useRef, useState } from "react";
+import { Box, IconButton, Popover, Tooltip, Typography } from "@mui/material";
+import {
+  Check,
+  FileDown,
+  FileText,
+  History as HistoryIcon,
+  Loader2,
+  SaveIcon,
+  Upload,
+} from "lucide-react";
+import { CustomizableButton } from "../../../components/button/customizable-button";
+import { background, border, brand, palette } from "../../../themes/palette";
+import { textStyles } from "../../../themes/typography";
+
+/** History active fill — prior `#E6F4F1` chrome. */
+const HISTORY_ACTIVE_BG = "#E6F4F1";
+const HISTORY_ACTIVE_HOVER_BG = "#D1EDE6";
+const SAVE_SUCCESS_BG = "#079455";
+
+export interface PolicyEditorActionsBarProps {
+  isNew: boolean;
+  hasPolicyId: boolean;
+  isHistorySidebarOpen: boolean;
+  onToggleHistorySidebar: () => void;
+  isExportingPDF: boolean;
+  isExportingDOCX: boolean;
+  exportError: string | null;
+  onDownloadExport: (format: "pdf" | "docx") => void;
+  isImporting: boolean;
+  onDocxFileSelect: (event: React.ChangeEvent<HTMLInputElement>) => void;
+  isSaving: boolean;
+  saveSuccess: boolean;
+  isSaveDisabled: boolean;
+  saveButtonText: string;
+  onSave: () => void;
+}
+
+/** History, export, import, and save controls for the policy editor. */
+export function PolicyEditorActionsBar({
+  isNew,
+  hasPolicyId,
+  isHistorySidebarOpen,
+  onToggleHistorySidebar,
+  isExportingPDF,
+  isExportingDOCX,
+  exportError,
+  onDownloadExport,
+  isImporting,
+  onDocxFileSelect,
+  isSaving,
+  saveSuccess,
+  isSaveDisabled,
+  saveButtonText,
+  onSave,
+}: PolicyEditorActionsBarProps) {
+  const [exportAnchorEl, setExportAnchorEl] = useState<HTMLElement | null>(null);
+  const docxInputRef = useRef<HTMLInputElement>(null);
+
+  return (
+    <Box sx={{ display: "flex", flexDirection: "row", gap: "8px", alignItems: "center" }}>
+      {exportError && (
+        <Typography
+          sx={{
+            ...textStyles.caption,
+            color: palette.status?.error?.text || "#f04438",
+            backgroundColor: palette.status?.error?.bg || "#f9eced",
+            px: 1.5,
+            py: 0.75,
+            borderRadius: "4px",
+          }}
+        >
+          {exportError}
+        </Typography>
+      )}
+
+      {!isNew && hasPolicyId && (
+        <Tooltip title="Activity history" arrow>
+          <IconButton
+            onClick={onToggleHistorySidebar}
+            size="small"
+            sx={{
+              "color": isHistorySidebarOpen ? brand.primary : "text.muted",
+              "padding": "4px",
+              "borderRadius": "4px",
+              "backgroundColor": isHistorySidebarOpen ? HISTORY_ACTIVE_BG : "transparent",
+              "&:hover": {
+                backgroundColor: isHistorySidebarOpen
+                  ? HISTORY_ACTIVE_HOVER_BG
+                  : palette.background.hover,
+              },
+            }}
+          >
+            <HistoryIcon size={16} />
+          </IconButton>
+        </Tooltip>
+      )}
+
+      {!isNew && hasPolicyId && (
+        <>
+          <CustomizableButton
+            variant="outlined"
+            text={
+              isExportingPDF ? "Exporting PDF..." : isExportingDOCX ? "Exporting Word..." : "Export"
+            }
+            isDisabled={isExportingPDF || isExportingDOCX}
+            sx={{
+              "backgroundColor": palette.background.main,
+              "border": `1px solid ${palette.border.dark}`,
+              "color": palette.text.secondary,
+              "gap": 1,
+              "minWidth": "90px",
+              "&:hover": {
+                backgroundColor: palette.background.accent,
+                borderColor: palette.text.muted,
+              },
+              "&:disabled": {
+                backgroundColor: palette.background.accent,
+                borderColor: palette.border.light,
+                color: palette.text.muted,
+              },
+            }}
+            onClick={(e: React.MouseEvent<HTMLElement>) => setExportAnchorEl(e.currentTarget)}
+            icon={
+              isExportingPDF || isExportingDOCX ? (
+                <Loader2 size={16} style={{ animation: "spin 1s linear infinite" }} />
+              ) : (
+                <FileDown size={16} />
+              )
+            }
+          />
+          <Popover
+            open={Boolean(exportAnchorEl)}
+            anchorEl={exportAnchorEl}
+            onClose={() => setExportAnchorEl(null)}
+            anchorOrigin={{ vertical: "bottom", horizontal: "left" }}
+            transformOrigin={{ vertical: "top", horizontal: "left" }}
+            slotProps={{
+              paper: {
+                sx: {
+                  mt: 0.5,
+                  borderRadius: "4px",
+                  border: `1px solid ${palette.border.light}`,
+                  boxShadow: "0 4px 12px rgba(0,0,0,0.08)",
+                  minWidth: 140,
+                  p: 0.5,
+                  display: "flex",
+                  flexDirection: "column",
+                },
+              },
+            }}
+          >
+            {[
+              {
+                icon: <FileText size={14} />,
+                label: "Download as PDF",
+                format: "pdf" as const,
+              },
+              {
+                icon: <FileDown size={14} />,
+                label: "Download as Word",
+                format: "docx" as const,
+              },
+            ].map(({ icon, label, format }) => (
+              <Box
+                key={format}
+                component="button"
+                onClick={() => {
+                  setExportAnchorEl(null);
+                  onDownloadExport(format);
+                }}
+                sx={{
+                  "display": "flex",
+                  "alignItems": "center",
+                  "gap": 1,
+                  "px": 1.5,
+                  "py": 1,
+                  "border": "none",
+                  "background": "none",
+                  "cursor": "pointer",
+                  "borderRadius": "4px",
+                  ...textStyles.caption,
+                  "color": "text.secondary",
+                  "width": "100%",
+                  "textAlign": "left",
+                  "&:hover": { backgroundColor: palette.background.hover },
+                }}
+              >
+                {icon}
+                {label}
+              </Box>
+            ))}
+          </Popover>
+        </>
+      )}
+
+      <CustomizableButton
+        variant="outlined"
+        text={isImporting ? "Importing..." : "Import"}
+        isDisabled={isImporting}
+        sx={{
+          "backgroundColor": palette.background.main,
+          "border": `1px solid ${palette.border.dark}`,
+          "color": "text.secondary",
+          "gap": 1,
+          "minWidth": "90px",
+          "&:hover": {
+            backgroundColor: palette.background.accent,
+            borderColor: "text.muted",
+          },
+          "&:disabled": {
+            backgroundColor: palette.background.accent,
+            borderColor: palette.border.light,
+            color: "text.muted",
+          },
+        }}
+        onClick={() => docxInputRef.current?.click()}
+        icon={
+          isImporting ? (
+            <Loader2 size={16} style={{ animation: "spin 1s linear infinite" }} />
+          ) : (
+            <Upload size={16} />
+          )
+        }
+      />
+      <input
+        ref={docxInputRef}
+        type="file"
+        accept=".docx"
+        style={{ display: "none" }}
+        onChange={onDocxFileSelect}
+      />
+
+      <CustomizableButton
+        variant="contained"
+        text={saveButtonText}
+        isDisabled={isSaveDisabled}
+        sx={{
+          "backgroundColor": saveSuccess ? SAVE_SUCCESS_BG : palette.accent.primary,
+          "border": `1px solid ${saveSuccess ? SAVE_SUCCESS_BG : palette.accent.primary}`,
+          "gap": 2,
+          "&:hover": {
+            backgroundColor: saveSuccess ? SAVE_SUCCESS_BG : palette.accent.primary,
+            borderColor: saveSuccess ? SAVE_SUCCESS_BG : palette.accent.primary.border,
+          },
+          "&:disabled": {
+            backgroundColor: palette.accent.primary,
+            opacity: 0.7,
+          },
+        }}
+        onClick={onSave}
+        icon={
+          isSaving ? (
+            <Loader2 size={16} style={{ animation: "spin 1s linear infinite" }} />
+          ) : saveSuccess ? (
+            <Check size={16} />
+          ) : (
+            <SaveIcon size={16} />
+          )
+        }
+      />
+    </Box>
+  );
+}

--- a/Clients/src/presentation/pages/PolicyDashboard/PolicyEditor/PolicyEditorActionsBar.tsx
+++ b/Clients/src/presentation/pages/PolicyDashboard/PolicyEditor/PolicyEditorActionsBar.tsx
@@ -10,7 +10,7 @@ import {
   Upload,
 } from "lucide-react";
 import { CustomizableButton } from "../../../components/button/customizable-button";
-import { background, border, brand, palette } from "../../../themes/palette";
+import { brand, palette } from "../../../themes/palette";
 import { textStyles } from "../../../themes/typography";
 
 /** History active fill — prior `#E6F4F1` chrome. */
@@ -63,8 +63,8 @@ export function PolicyEditorActionsBar({
         <Typography
           sx={{
             ...textStyles.caption,
-            color: palette.status?.error?.text || "#f04438",
-            backgroundColor: palette.status?.error?.bg || "#f9eced",
+            color: palette.status.error.text,
+            backgroundColor: palette.status.error.bg,
             px: 1.5,
             py: 0.75,
             borderRadius: "4px",
@@ -80,7 +80,7 @@ export function PolicyEditorActionsBar({
             onClick={onToggleHistorySidebar}
             size="small"
             sx={{
-              "color": isHistorySidebarOpen ? brand.primary : "text.muted",
+              "color": isHistorySidebarOpen ? brand.primary : palette.text.muted,
               "padding": "4px",
               "borderRadius": "4px",
               "backgroundColor": isHistorySidebarOpen ? HISTORY_ACTIVE_BG : "transparent",
@@ -236,15 +236,15 @@ export function PolicyEditorActionsBar({
         text={saveButtonText}
         isDisabled={isSaveDisabled}
         sx={{
-          "backgroundColor": saveSuccess ? SAVE_SUCCESS_BG : palette.accent.primary,
-          "border": `1px solid ${saveSuccess ? SAVE_SUCCESS_BG : palette.accent.primary}`,
+          "backgroundColor": saveSuccess ? SAVE_SUCCESS_BG : brand.primary,
+          "border": `1px solid ${saveSuccess ? SAVE_SUCCESS_BG : brand.primary}`,
           "gap": 2,
           "&:hover": {
-            backgroundColor: saveSuccess ? SAVE_SUCCESS_BG : palette.accent.primary,
-            borderColor: saveSuccess ? SAVE_SUCCESS_BG : palette.accent.primary.border,
+            backgroundColor: saveSuccess ? SAVE_SUCCESS_BG : brand.primaryHover,
+            borderColor: saveSuccess ? SAVE_SUCCESS_BG : brand.primaryHover,
           },
           "&:disabled": {
-            backgroundColor: palette.accent.primary,
+            backgroundColor: brand.primary,
             opacity: 0.7,
           },
         }}

--- a/Clients/src/presentation/pages/PolicyDashboard/PolicyEditor/PolicyEditorHeader.tsx
+++ b/Clients/src/presentation/pages/PolicyDashboard/PolicyEditor/PolicyEditorHeader.tsx
@@ -1,0 +1,45 @@
+import { Stack } from "@mui/material";
+import { PolicyEditorTitleArea, type PolicyEditorTitleAreaProps } from "./PolicyEditorTitleArea";
+import { PolicyEditorActionsBar, type PolicyEditorActionsBarProps } from "./PolicyEditorActionsBar";
+
+export type PolicyEditorHeaderProps = PolicyEditorTitleAreaProps & PolicyEditorActionsBarProps;
+
+/** Title editing chrome and save/export/import actions for the policy editor. */
+export function PolicyEditorHeader(props: PolicyEditorHeaderProps) {
+  const {
+    pageTitle,
+    isEditingTitle,
+    editedTitle,
+    isSavingTitle,
+    titleError,
+    onBack,
+    onStartEditTitle,
+    onEditedTitleChange,
+    onSaveTitle,
+    onCancelEditTitle,
+    ...actionsProps
+  } = props;
+
+  return (
+    <Stack
+      direction="row"
+      justifyContent="space-between"
+      alignItems="center"
+      sx={{ mb: "8px", flexShrink: 0 }}
+    >
+      <PolicyEditorTitleArea
+        pageTitle={pageTitle}
+        isEditingTitle={isEditingTitle}
+        editedTitle={editedTitle}
+        isSavingTitle={isSavingTitle}
+        titleError={titleError}
+        onBack={onBack}
+        onStartEditTitle={onStartEditTitle}
+        onEditedTitleChange={onEditedTitleChange}
+        onSaveTitle={onSaveTitle}
+        onCancelEditTitle={onCancelEditTitle}
+      />
+      <PolicyEditorActionsBar {...actionsProps} />
+    </Stack>
+  );
+}

--- a/Clients/src/presentation/pages/PolicyDashboard/PolicyEditor/PolicyEditorTitleArea.tsx
+++ b/Clients/src/presentation/pages/PolicyDashboard/PolicyEditor/PolicyEditorTitleArea.tsx
@@ -1,0 +1,129 @@
+import { Box, IconButton, TextField, Tooltip, Typography } from "@mui/material";
+import { ArrowLeft, Check, Loader2, Pencil, X } from "lucide-react";
+import { palette } from "../../../themes/palette";
+import { textStyles } from "../../../themes/typography";
+
+export interface PolicyEditorTitleAreaProps {
+  pageTitle: string;
+  isEditingTitle: boolean;
+  editedTitle: string;
+  isSavingTitle: boolean;
+  titleError?: string;
+  onBack: () => void;
+  onStartEditTitle: () => void;
+  onEditedTitleChange: (value: string) => void;
+  onSaveTitle: () => void;
+  onCancelEditTitle: () => void;
+}
+
+/** Back control + inline policy title editing. */
+export function PolicyEditorTitleArea({
+  pageTitle,
+  isEditingTitle,
+  editedTitle,
+  isSavingTitle,
+  titleError,
+  onBack,
+  onStartEditTitle,
+  onEditedTitleChange,
+  onSaveTitle,
+  onCancelEditTitle,
+}: PolicyEditorTitleAreaProps) {
+  return (
+    <Box sx={{ display: "flex", flexDirection: "row", alignItems: "center", gap: 1 }}>
+      <Tooltip title="Back to policies" arrow>
+        <IconButton
+          onClick={onBack}
+          size="small"
+          sx={{
+            "padding": "4px",
+            "borderRadius": "4px",
+            "color": palette.text.muted,
+            "&:hover": { backgroundColor: palette.background.hover, color: palette.text.secondary },
+          }}
+        >
+          <ArrowLeft size={18} />
+        </IconButton>
+      </Tooltip>
+      <Box
+        sx={{
+          "display": "inline-flex",
+          "alignItems": "center",
+          "gap": 0.5,
+          "&:hover .edit-title-icon": {
+            opacity: 1,
+          },
+        }}
+      >
+        {isEditingTitle ? (
+          <>
+            <TextField
+              value={editedTitle}
+              onChange={(e) => onEditedTitleChange(e.target.value)}
+              onKeyDown={(e) => {
+                if (e.key === "Enter") onSaveTitle();
+                if (e.key === "Escape") onCancelEditTitle();
+              }}
+              placeholder="Policy title"
+              variant="outlined"
+              size="small"
+              autoFocus
+              disabled={isSavingTitle}
+              error={!!titleError}
+              helperText={titleError}
+              inputProps={{ maxLength: 128 }}
+              sx={{
+                "minWidth": "400px",
+                "& .MuiOutlinedInput-root": {
+                  ...textStyles.cardTitle,
+                  color: palette.text.secondary,
+                },
+              }}
+            />
+            <IconButton
+              size="small"
+              onClick={onSaveTitle}
+              disabled={!editedTitle.trim() || isSavingTitle}
+              sx={{ color: palette.brand.primary }}
+            >
+              {isSavingTitle ? (
+                <Loader2 size={18} style={{ animation: "spin 1s linear infinite" }} />
+              ) : (
+                <Check size={18} />
+              )}
+            </IconButton>
+            <IconButton
+              size="small"
+              onClick={onCancelEditTitle}
+              disabled={isSavingTitle}
+              sx={{ color: palette.text.disabled }}
+            >
+              <X size={18} />
+            </IconButton>
+          </>
+        ) : (
+          <>
+            <Typography sx={{ ...textStyles.cardTitle, color: palette.text.secondary }}>
+              {pageTitle}
+            </Typography>
+            <IconButton
+              size="small"
+              onClick={onStartEditTitle}
+              className="edit-title-icon"
+              sx={{
+                "transition": "opacity 0.2s",
+                "color": palette.text.disabled,
+                "&:hover": {
+                  color: palette.brand.primary,
+                  backgroundColor: palette.background.hover,
+                },
+              }}
+            >
+              <Pencil size={14} />
+            </IconButton>
+          </>
+        )}
+      </Box>
+    </Box>
+  );
+}

--- a/Clients/src/presentation/pages/PolicyDashboard/PolicyEditor/PolicyEditorToolbar.tsx
+++ b/Clients/src/presentation/pages/PolicyDashboard/PolicyEditor/PolicyEditorToolbar.tsx
@@ -1,0 +1,178 @@
+import { useCallback, useEffect, useState } from "react";
+import type { Editor } from "@tiptap/react";
+import { Box, IconButton, Tooltip, Typography } from "@mui/material";
+import Select from "../../../components/Inputs/Select";
+import { palette } from "../../../themes/palette";
+import { defaultToolbarState } from "./toolbarTypes";
+import { getToolbarConfig } from "./toolbarConfig";
+import { ColorPickerPopover } from "./ColorPickerPopover";
+
+const { background, brand } = palette;
+const TOOLBAR_ACTIVE_BG = "#E0F7FA";
+
+export interface PolicyEditorToolbarProps {
+  editor: Editor | null;
+  isUploadingImage: boolean;
+  onInsertImage: () => void;
+  onOpenLink: (selectedText: string) => void;
+  onOpenFindReplace: (anchorEl: HTMLElement) => void;
+}
+
+/** Main TipTap toolbar: block type, formatting actions, color picker, word count. */
+export function PolicyEditorToolbar({
+  editor,
+  isUploadingImage,
+  onInsertImage,
+  onOpenLink,
+  onOpenFindReplace,
+}: PolicyEditorToolbarProps) {
+  const [toolbarState, setToolbarState] = useState(defaultToolbarState);
+  const [currentBlockType, setCurrentBlockType] = useState<string>("p");
+  const [colorAnchorEl, setColorAnchorEl] = useState<HTMLElement | null>(null);
+
+  const updateToolbarState = useCallback(() => {
+    if (!editor) return;
+    try {
+      let blockType = "p";
+      if (editor.isActive("heading", { level: 1 })) blockType = "h1";
+      else if (editor.isActive("heading", { level: 2 })) blockType = "h2";
+      else if (editor.isActive("heading", { level: 3 })) blockType = "h3";
+      else if (editor.isActive("blockquote")) blockType = "blockquote";
+
+      setCurrentBlockType(blockType);
+      setToolbarState({
+        "bold": editor.isActive("bold"),
+        "italic": editor.isActive("italic"),
+        "underline": editor.isActive("underline"),
+        "strike": editor.isActive("strike"),
+        "ol": editor.isActive("orderedList"),
+        "ul": editor.isActive("bulletList"),
+        "align-left": editor.isActive({ textAlign: "left" }),
+        "align-center": editor.isActive({ textAlign: "center" }),
+        "align-right": editor.isActive({ textAlign: "right" }),
+        "link": editor.isActive("link"),
+        "highlight": editor.isActive("highlight"),
+        "blockquote": blockType === "blockquote",
+        "code": editor.isActive("codeBlock"),
+        "undo": false,
+        "redo": false,
+        "image": false,
+        "table": editor.isActive("table"),
+        "hr": false,
+        "taskList": editor.isActive("taskList"),
+        "superscript": editor.isActive("superscript"),
+        "subscript": editor.isActive("subscript"),
+        "color": false,
+        "search": false,
+      });
+    } catch {
+      // ignore
+    }
+  }, [editor]);
+
+  useEffect(() => {
+    if (!editor) return;
+    updateToolbarState();
+    editor.on("selectionUpdate", updateToolbarState);
+    editor.on("transaction", updateToolbarState);
+    return () => {
+      editor.off("selectionUpdate", updateToolbarState);
+      editor.off("transaction", updateToolbarState);
+    };
+  }, [editor, updateToolbarState]);
+
+  const handleBlockTypeChange = (event: { target: { value: string | number } }) => {
+    const newType = String(event.target.value);
+    setCurrentBlockType(newType);
+    if (!editor) return;
+    if (newType === "p") editor.chain().focus().setParagraph().run();
+    else if (newType === "h1") editor.chain().focus().toggleHeading({ level: 1 }).run();
+    else if (newType === "h2") editor.chain().focus().toggleHeading({ level: 2 }).run();
+    else if (newType === "h3") editor.chain().focus().toggleHeading({ level: 3 }).run();
+    setTimeout(() => updateToolbarState(), 0);
+  };
+
+  const toolbarConfig = getToolbarConfig({
+    editor,
+    isUploadingImage,
+    onInsertImage,
+    onOpenLink,
+  });
+
+  return (
+    <>
+      <Box
+        sx={{
+          display: "flex",
+          flexWrap: "wrap",
+          gap: 0.5,
+          mb: "8px",
+          alignItems: "center",
+          flexShrink: 0,
+        }}
+      >
+        <Box sx={{ mr: 2 }}>
+          <Select
+            id="block-type-select"
+            value={currentBlockType}
+            onChange={handleBlockTypeChange}
+            items={[
+              { _id: "p", name: "Text" },
+              { _id: "h1", name: "Header 1" },
+              { _id: "h2", name: "Header 2" },
+              { _id: "h3", name: "Header 3" },
+            ]}
+            sx={{ width: 120, height: "34px" }}
+          />
+        </Box>
+
+        {toolbarConfig.map(({ key, title, icon, action }) => (
+          <Tooltip key={key} title={title}>
+            <IconButton
+              onClick={(e) => {
+                if (key === "color") {
+                  setColorAnchorEl(e.currentTarget);
+                  return;
+                }
+                if (key === "search") {
+                  onOpenFindReplace(e.currentTarget);
+                  return;
+                }
+                action?.();
+                setTimeout(() => updateToolbarState(), 0);
+              }}
+              size="small"
+              sx={{
+                "padding": "6px",
+                "borderRadius": "3px",
+                "backgroundColor": toolbarState[key] ? TOOLBAR_ACTIVE_BG : background.main,
+                "border": "1px solid",
+                "borderColor": toolbarState[key] ? brand.primary : "transparent",
+                "&:hover": { backgroundColor: background.surface },
+              }}
+            >
+              {icon}
+            </IconButton>
+          </Tooltip>
+        ))}
+
+        {editor && (
+          <Box sx={{ ml: "auto", display: "flex", gap: 2, alignItems: "center" }}>
+            <Typography sx={{ fontSize: 11, color: "text.muted" }}>
+              {editor.storage.characterCount.words()} words
+            </Typography>
+            <Typography sx={{ fontSize: 11, color: "text.muted" }}>
+              {editor.storage.characterCount.characters()} characters
+            </Typography>
+          </Box>
+        )}
+      </Box>
+
+      <ColorPickerPopover
+        editor={editor}
+        anchorEl={colorAnchorEl}
+        onClose={() => setColorAnchorEl(null)}
+      />
+    </>
+  );
+}

--- a/Clients/src/presentation/pages/PolicyDashboard/PolicyEditor/PolicyTableBubbleMenu.tsx
+++ b/Clients/src/presentation/pages/PolicyDashboard/PolicyEditor/PolicyTableBubbleMenu.tsx
@@ -1,0 +1,165 @@
+import React from "react";
+import type { Editor } from "@tiptap/react";
+import { BubbleMenu } from "@tiptap/react/menus";
+import { Box, Divider, IconButton, Tooltip } from "@mui/material";
+import {
+  Plus,
+  X,
+  Rows3,
+  Columns3,
+  TableCellsMerge,
+  TableCellsSplit,
+  ToggleLeft,
+  Trash2,
+} from "lucide-react";
+import { palette } from "../../../themes/palette";
+
+const { text, background, border, status } = palette;
+
+interface TableToolbarItem {
+  key: string;
+  title: string;
+  icon: React.ReactNode;
+  action: () => void;
+  separator?: boolean;
+  danger?: boolean;
+}
+
+function getTableToolbarConfig(editor: Editor): TableToolbarItem[] {
+  return [
+    {
+      key: "addRowBefore",
+      title: "Add row above",
+      icon: <Plus size={14} />,
+      action: () => editor.chain().focus().addRowBefore().run(),
+    },
+    {
+      key: "addRowAfter",
+      title: "Add row below",
+      icon: <Rows3 size={14} />,
+      action: () => editor.chain().focus().addRowAfter().run(),
+    },
+    {
+      key: "deleteRow",
+      title: "Delete row",
+      icon: <X size={14} />,
+      action: () => editor.chain().focus().deleteRow().run(),
+      separator: true,
+    },
+    {
+      key: "addColumnBefore",
+      title: "Add column left",
+      icon: <Plus size={14} />,
+      action: () => editor.chain().focus().addColumnBefore().run(),
+    },
+    {
+      key: "addColumnAfter",
+      title: "Add column right",
+      icon: <Columns3 size={14} />,
+      action: () => editor.chain().focus().addColumnAfter().run(),
+    },
+    {
+      key: "deleteColumn",
+      title: "Delete column",
+      icon: <X size={14} />,
+      action: () => editor.chain().focus().deleteColumn().run(),
+      separator: true,
+    },
+    {
+      key: "mergeCells",
+      title: "Merge cells",
+      icon: <TableCellsMerge size={14} />,
+      action: () => editor.chain().focus().mergeCells().run(),
+    },
+    {
+      key: "splitCell",
+      title: "Split cell",
+      icon: <TableCellsSplit size={14} />,
+      action: () => editor.chain().focus().splitCell().run(),
+      separator: true,
+    },
+    {
+      key: "toggleHeaderRow",
+      title: "Toggle header row",
+      icon: <ToggleLeft size={14} />,
+      action: () => editor.chain().focus().toggleHeaderRow().run(),
+    },
+    {
+      key: "toggleHeaderColumn",
+      title: "Toggle header column",
+      icon: <ToggleLeft size={14} />,
+      action: () => editor.chain().focus().toggleHeaderColumn().run(),
+      separator: true,
+    },
+    {
+      key: "deleteTable",
+      title: "Delete table",
+      icon: <Trash2 size={14} />,
+      action: () => editor.chain().focus().deleteTable().run(),
+      danger: true,
+    },
+  ];
+}
+
+export interface PolicyTableBubbleMenuProps {
+  editor: Editor;
+}
+
+/** Floating TipTap bubble menu for table editing actions. */
+export function PolicyTableBubbleMenu({ editor }: PolicyTableBubbleMenuProps) {
+  const tableToolbarConfig = getTableToolbarConfig(editor);
+
+  return (
+    <BubbleMenu
+      editor={editor}
+      pluginKey="tableMenu"
+      shouldShow={({ editor: e }) => e.isActive("table")}
+      updateDelay={100}
+    >
+      <Box
+        sx={{
+          display: "flex",
+          gap: "2px",
+          p: "4px",
+          alignItems: "center",
+          backgroundColor: background.main,
+          border: "1px solid",
+          borderColor: border.dark,
+          borderRadius: "6px",
+          boxShadow: "0 4px 12px rgba(0,0,0,0.12), 0 1px 3px rgba(0,0,0,0.08)",
+        }}
+      >
+        {tableToolbarConfig.map(({ key, title, icon, action, separator, danger }) => (
+          <React.Fragment key={key}>
+            <Tooltip title={title} placement="top" arrow>
+              <IconButton
+                onMouseDown={(e) => {
+                  e.preventDefault();
+                  action();
+                }}
+                size="small"
+                sx={{
+                  "padding": "5px",
+                  "borderRadius": "4px",
+                  "color": danger ? status.error.text : text.secondary,
+                  "&:hover": {
+                    backgroundColor: danger ? status.error.bg : background.hover,
+                  },
+                }}
+              >
+                {icon}
+              </IconButton>
+            </Tooltip>
+            {separator && (
+              <Divider
+                orientation="vertical"
+                flexItem
+                sx={{ mx: "2px", borderColor: status.default.border }}
+              />
+            )}
+          </React.Fragment>
+        ))}
+      </Box>
+    </BubbleMenu>
+  );
+}

--- a/Clients/src/presentation/pages/PolicyDashboard/PolicyEditor/editorStyles.ts
+++ b/Clients/src/presentation/pages/PolicyDashboard/PolicyEditor/editorStyles.ts
@@ -1,0 +1,194 @@
+import type { GlobalStylesProps } from "@mui/material";
+import { palette } from "../../../themes/palette";
+import { fontFamily, fontSize, fontWeight } from "../../../themes/typography";
+
+const { text, background, border, brand, accent } = palette;
+
+/**
+ * TipTap / ProseMirror styles for the policy editor surface.
+ * Module-level constant from static design tokens — no theme, no per-render work.
+ */
+export const policyEditorStyles: GlobalStylesProps["styles"] = {
+  ".policy-tiptap-editor .ProseMirror": {
+    "height": "100%",
+    "minHeight": 300,
+    "overflowY": "auto",
+    "padding": "20px 24px",
+    "border": "none",
+    "borderRadius": "4px",
+    "backgroundColor": background.main,
+    "fontFamily": fontFamily.sans,
+    "fontSize": fontSize.base,
+    "color": text.primary,
+    "outline": "none",
+
+    "&:focus": {
+      outline: "none",
+    },
+    "& p.is-editor-empty:first-child::before": {
+      content: "attr(data-placeholder)",
+      float: "left",
+      color: text.disabled,
+      pointerEvents: "none",
+      height: 0,
+    },
+    "& mark": {
+      backgroundColor: "#fef08a",
+      padding: "0 2px",
+      borderRadius: "2px",
+    },
+    "& blockquote": {
+      borderLeft: `3px solid ${border.dark}`,
+      margin: "8px 0",
+      padding: "8px 16px",
+      color: text.tertiary,
+      backgroundColor: background.alt,
+      borderRadius: "0 4px 4px 0",
+    },
+    "& pre": {
+      backgroundColor: "#1e1e1e",
+      color: "#d4d4d4",
+      padding: "12px 16px",
+      borderRadius: "6px",
+      fontFamily: fontFamily.mono,
+      fontSize: fontSize.sm,
+      overflowX: "auto",
+      margin: "12px 0",
+    },
+    "& pre code": {
+      background: "none",
+      color: "inherit",
+      padding: 0,
+    },
+    "& code": {
+      backgroundColor: background.surface,
+      padding: "2px 4px",
+      borderRadius: "3px",
+      fontFamily: fontFamily.mono,
+      fontSize: fontSize.sm,
+    },
+    "& hr": {
+      border: "none",
+      borderTop: `1px solid ${border.dark}`,
+      margin: "16px 0",
+    },
+    "& table": {
+      borderCollapse: "collapse",
+      width: "100%",
+      margin: "12px 0",
+      tableLayout: "fixed",
+      overflow: "hidden",
+    },
+    "& th, & td": {
+      border: `1px solid ${border.dark}`,
+      padding: "8px 12px",
+      textAlign: "left",
+      verticalAlign: "top",
+      minWidth: 80,
+      position: "relative",
+      boxSizing: "border-box",
+      fontSize: fontSize.base,
+    },
+    "& th": {
+      backgroundColor: brand.primaryLight,
+      fontWeight: fontWeight.semibold,
+    },
+    "& .selectedCell": {
+      backgroundColor: `${background.selected} !important`,
+      borderColor: `${brand.primary} !important`,
+    },
+    "& .selectedCell::after": {
+      content: '""',
+      position: "absolute",
+      inset: 0,
+      background: `${brand.primary}14`,
+      pointerEvents: "none",
+    },
+    "& .column-resize-handle": {
+      position: "absolute",
+      right: -2,
+      top: 0,
+      bottom: -2,
+      width: 4,
+      backgroundColor: brand.primary,
+      cursor: "col-resize",
+      zIndex: 10,
+    },
+    "&.resize-cursor": {
+      cursor: "col-resize",
+    },
+    "& td:hover": {
+      backgroundColor: background.gradientStop,
+    },
+    "& img": {
+      maxWidth: "100%",
+      borderRadius: "8px",
+      margin: "12px 0",
+    },
+    "& a": {
+      color: accent.blue.text,
+      textDecoration: "underline",
+      cursor: "pointer",
+    },
+    "& ul, & ol": {
+      paddingLeft: 24,
+    },
+    "& h1": {
+      fontSize: fontSize["2xl"],
+      fontWeight: fontWeight.bold,
+      margin: "16px 0 8px",
+    },
+    "& h2": {
+      fontSize: fontSize.xl,
+      fontWeight: fontWeight.semibold,
+      margin: "12px 0 6px",
+    },
+    "& h3": {
+      fontSize: fontSize.lg,
+      fontWeight: fontWeight.semibold,
+      margin: "10px 0 4px",
+    },
+    '& ul[data-type="taskList"]': {
+      listStyle: "none",
+      paddingLeft: 4,
+    },
+    '& ul[data-type="taskList"] li': {
+      display: "flex",
+      alignItems: "flex-start",
+      gap: 8,
+      margin: "4px 0",
+    },
+    '& ul[data-type="taskList"] li label': {
+      display: "flex",
+      alignItems: "center",
+      flexShrink: 0,
+      marginTop: 2,
+    },
+    '& ul[data-type="taskList"] li label input[type="checkbox"]': {
+      width: 16,
+      height: 16,
+      cursor: "pointer",
+      accentColor: brand.primary,
+    },
+    '& ul[data-type="taskList"] li > div': {
+      flex: 1,
+    },
+    '& ul[data-type="taskList"] li[data-checked="true"] > div > p': {
+      textDecoration: "line-through",
+      color: text.disabled,
+    },
+    "& sup": {
+      fontSize: "0.75em",
+      verticalAlign: "super",
+    },
+    "& sub": {
+      fontSize: "0.75em",
+      verticalAlign: "sub",
+    },
+    "& .search-highlight": {
+      backgroundColor: "#fef08a",
+      borderRadius: "2px",
+      boxShadow: "0 0 0 1px #eab308",
+    },
+  },
+};

--- a/Clients/src/presentation/pages/PolicyDashboard/PolicyEditor/normalizeSlateHtml.ts
+++ b/Clients/src/presentation/pages/PolicyDashboard/PolicyEditor/normalizeSlateHtml.ts
@@ -1,0 +1,21 @@
+/** Normalize legacy Slate HTML into TipTap-friendly markup. */
+export function normalizeSlateHtml(html: string): string {
+  let n = html.replace(
+    /<div([^>]*?)data-slate-type="(h[1-6]|p|blockquote)"([^>]*)>/gi,
+    (_m, before, tag, after) => `<${tag}${before}${after}>`,
+  );
+  n = n.replace(/<div[^>]*class="slate-editor"[^>]*>/gi, "");
+  n = n.replace(/<span[^>]*data-slate-string="true"[^>]*>([^<]*)<\/span>/gi, "$1");
+  n = n.replace(/<span[^>]*data-slate-leaf="true"[^>]*>/gi, "");
+  n = n.replace(/<span[^>]*data-slate-node="text"[^>]*>/gi, "");
+  n = n.replace(/\s*data-slate-[a-z-]+="[^"]*"/gi, "");
+  n = n.replace(/\s*data-block-id="[^"]*"/gi, "");
+  n = n.replace(/\s*class="slate-[^"]*"/gi, "");
+  n = n.replace(/\s*style="position:\s*relative\s*;?\s*"/gi, "");
+  n = n.replace(/\s*style=""/gi, "");
+  n = n.replace(/\s*class=""/gi, "");
+  n = n.replace(/<div>\s*([^<])/gi, "<p>$1");
+  n = n.replace(/<\/div>/gi, "</p>");
+  n = n.replace(/<\/p>\s*<\/p>/gi, "</p>");
+  return n;
+}

--- a/Clients/src/presentation/pages/PolicyDashboard/PolicyEditor/searchHighlightExtension.ts
+++ b/Clients/src/presentation/pages/PolicyDashboard/PolicyEditor/searchHighlightExtension.ts
@@ -1,0 +1,57 @@
+import { Extension } from "@tiptap/react";
+import { Plugin, PluginKey } from "@tiptap/pm/state";
+import { Decoration, DecorationSet } from "@tiptap/pm/view";
+
+/** Shared PluginKey so find/replace can update highlight decorations via transaction meta. */
+export const searchHighlightKey = new PluginKey("searchHighlight");
+
+export function createSearchHighlightExtension() {
+  return Extension.create({
+    name: "searchHighlight",
+    addProseMirrorPlugins() {
+      return [
+        new Plugin({
+          key: searchHighlightKey,
+          state: {
+            init() {
+              return { term: "", decorations: DecorationSet.empty };
+            },
+            apply(tr, prev) {
+              const meta = tr.getMeta(searchHighlightKey);
+              if (meta !== undefined) {
+                const term = meta as string;
+                if (!term) return { term: "", decorations: DecorationSet.empty };
+                const decorations: Decoration[] = [];
+                const searchLower = term.toLowerCase();
+                tr.doc.descendants((node, pos) => {
+                  if (!node.isText || !node.text) return;
+                  const text = node.text.toLowerCase();
+                  let idx = text.indexOf(searchLower);
+                  while (idx !== -1) {
+                    decorations.push(
+                      Decoration.inline(pos + idx, pos + idx + term.length, {
+                        class: "search-highlight",
+                      }),
+                    );
+                    idx = text.indexOf(searchLower, idx + term.length);
+                  }
+                });
+                return { term, decorations: DecorationSet.create(tr.doc, decorations) };
+              }
+              // Remap existing decorations on doc change
+              if (tr.docChanged && prev.decorations !== DecorationSet.empty) {
+                return { ...prev, decorations: prev.decorations.map(tr.mapping, tr.doc) };
+              }
+              return prev;
+            },
+          },
+          props: {
+            decorations(state) {
+              return this.getState(state)?.decorations ?? DecorationSet.empty;
+            },
+          },
+        }),
+      ];
+    },
+  });
+}

--- a/Clients/src/presentation/pages/PolicyDashboard/PolicyEditor/toolbarConfig.tsx
+++ b/Clients/src/presentation/pages/PolicyDashboard/PolicyEditor/toolbarConfig.tsx
@@ -1,0 +1,197 @@
+import React from "react";
+import type { Editor } from "@tiptap/react";
+import {
+  Underline as UnderlineIcon,
+  Bold,
+  Italic,
+  Strikethrough,
+  ListOrdered,
+  List,
+  AlignLeft,
+  AlignCenter,
+  AlignRight,
+  Link,
+  Unlink,
+  Image,
+  Redo2,
+  Undo2,
+  Quote,
+  Highlighter,
+  Table,
+  Code,
+  Minus,
+  ListChecks,
+  SuperscriptIcon,
+  SubscriptIcon,
+  Palette,
+  Search,
+} from "lucide-react";
+import { type ToolbarKey } from "./toolbarTypes";
+
+export interface ToolbarAction {
+  key: ToolbarKey;
+  title: string;
+  icon: React.ReactNode;
+  action: () => void;
+}
+
+export function getToolbarConfig(options: {
+  editor: Editor | null;
+  isUploadingImage: boolean;
+  onInsertImage: () => void;
+  onOpenLink: (selectedText: string) => void;
+}): ToolbarAction[] {
+  const { editor, isUploadingImage, onInsertImage, onOpenLink } = options;
+
+  return [
+    {
+      key: "undo",
+      title: "Undo",
+      icon: <Undo2 size={16} />,
+      action: () => editor?.chain().focus().undo().run(),
+    },
+    {
+      key: "redo",
+      title: "Redo",
+      icon: <Redo2 size={16} />,
+      action: () => editor?.chain().focus().redo().run(),
+    },
+    {
+      key: "bold",
+      title: "Bold",
+      icon: <Bold size={16} />,
+      action: () => editor?.chain().focus().toggleBold().run(),
+    },
+    {
+      key: "italic",
+      title: "Italic",
+      icon: <Italic size={16} />,
+      action: () => editor?.chain().focus().toggleItalic().run(),
+    },
+    {
+      key: "underline",
+      title: "Underline",
+      icon: <UnderlineIcon size={16} />,
+      action: () => editor?.chain().focus().toggleUnderline().run(),
+    },
+    {
+      key: "strike",
+      title: "Strikethrough",
+      icon: <Strikethrough size={16} />,
+      action: () => editor?.chain().focus().toggleStrike().run(),
+    },
+    {
+      key: "superscript",
+      title: "Superscript",
+      icon: <SuperscriptIcon size={16} />,
+      action: () => editor?.chain().focus().toggleSuperscript().run(),
+    },
+    {
+      key: "subscript",
+      title: "Subscript",
+      icon: <SubscriptIcon size={16} />,
+      action: () => editor?.chain().focus().toggleSubscript().run(),
+    },
+    {
+      key: "highlight",
+      title: "Highlight",
+      icon: <Highlighter size={16} />,
+      action: () => editor?.chain().focus().toggleHighlight().run(),
+    },
+    {
+      key: "code",
+      title: "Code block",
+      icon: <Code size={16} />,
+      action: () => editor?.chain().focus().toggleCodeBlock().run(),
+    },
+    {
+      key: "ol",
+      title: "Numbered list",
+      icon: <ListOrdered size={16} />,
+      action: () => editor?.chain().focus().toggleOrderedList().run(),
+    },
+    {
+      key: "ul",
+      title: "Bulleted list",
+      icon: <List size={16} />,
+      action: () => editor?.chain().focus().toggleBulletList().run(),
+    },
+    {
+      key: "taskList",
+      title: "Task list",
+      icon: <ListChecks size={16} />,
+      action: () => editor?.chain().focus().toggleTaskList().run(),
+    },
+    {
+      key: "blockquote",
+      title: "Blockquote",
+      icon: <Quote size={16} />,
+      action: () => editor?.chain().focus().toggleBlockquote().run(),
+    },
+    {
+      key: "hr",
+      title: "Horizontal rule",
+      icon: <Minus size={16} />,
+      action: () => editor?.chain().focus().setHorizontalRule().run(),
+    },
+    {
+      key: "align-left",
+      title: "Align left",
+      icon: <AlignLeft size={16} />,
+      action: () => editor?.chain().focus().setTextAlign("left").run(),
+    },
+    {
+      key: "align-center",
+      title: "Align center",
+      icon: <AlignCenter size={16} />,
+      action: () => editor?.chain().focus().setTextAlign("center").run(),
+    },
+    {
+      key: "align-right",
+      title: "Align right",
+      icon: <AlignRight size={16} />,
+      action: () => editor?.chain().focus().setTextAlign("right").run(),
+    },
+    {
+      key: "link",
+      title: editor?.isActive("link") ? "Remove link" : "Insert link",
+      icon: editor?.isActive("link") ? <Unlink size={16} /> : <Link size={16} />,
+      action: () => {
+        if (!editor) return;
+        if (editor.isActive("link")) {
+          editor.chain().focus().unsetLink().run();
+          return;
+        }
+        const { from, to } = editor.state.selection;
+        onOpenLink(from !== to ? editor.state.doc.textBetween(from, to) : "");
+      },
+    },
+    {
+      key: "image",
+      title: isUploadingImage ? "Uploading..." : "Insert image",
+      icon: <Image size={16} />,
+      action: () => {
+        if (!isUploadingImage) onInsertImage();
+      },
+    },
+    {
+      key: "table",
+      title: "Insert table",
+      icon: <Table size={16} />,
+      action: () =>
+        editor?.chain().focus().insertTable({ rows: 3, cols: 4, withHeaderRow: true }).run(),
+    },
+    {
+      key: "color",
+      title: "Text color",
+      icon: <Palette size={16} />,
+      action: () => {},
+    },
+    {
+      key: "search",
+      title: "Find & replace",
+      icon: <Search size={16} />,
+      action: () => {},
+    },
+  ];
+}

--- a/Clients/src/presentation/pages/PolicyDashboard/PolicyEditor/toolbarTypes.ts
+++ b/Clients/src/presentation/pages/PolicyDashboard/PolicyEditor/toolbarTypes.ts
@@ -1,0 +1,50 @@
+export type ToolbarKey =
+  | "bold"
+  | "italic"
+  | "underline"
+  | "undo"
+  | "redo"
+  | "strike"
+  | "ol"
+  | "ul"
+  | "align-left"
+  | "align-center"
+  | "align-right"
+  | "link"
+  | "image"
+  | "highlight"
+  | "blockquote"
+  | "table"
+  | "code"
+  | "hr"
+  | "taskList"
+  | "superscript"
+  | "subscript"
+  | "color"
+  | "search";
+
+export const defaultToolbarState: Record<ToolbarKey, boolean> = {
+  "bold": false,
+  "italic": false,
+  "underline": false,
+  "undo": false,
+  "redo": false,
+  "strike": false,
+  "ol": false,
+  "ul": false,
+  "align-left": false,
+  "align-center": false,
+  "align-right": false,
+  "link": false,
+  "image": false,
+  "highlight": false,
+  "blockquote": false,
+  "table": false,
+  "code": false,
+  "hr": false,
+  "taskList": false,
+  "superscript": false,
+  "subscript": false,
+  "color": false,
+  "search": false,
+};

--- a/Clients/src/presentation/pages/PolicyDashboard/PolicyEditor/usePolicyFindReplace.ts
+++ b/Clients/src/presentation/pages/PolicyDashboard/PolicyEditor/usePolicyFindReplace.ts
@@ -1,0 +1,194 @@
+import { useCallback, useEffect, useState } from "react";
+import type { Editor } from "@tiptap/react";
+import { searchHighlightKey } from "./searchHighlightExtension";
+
+/** Find & replace logic for the TipTap policy editor. */
+export function usePolicyFindReplace(editor: Editor | null) {
+  const [searchAnchorEl, setSearchAnchorEl] = useState<HTMLElement | null>(null);
+  const [searchText, setSearchText] = useState("");
+  const [replaceText, setReplaceText] = useState("");
+  const [searchMatchCount, setSearchMatchCount] = useState(0);
+
+  const countMatches = useCallback(() => {
+    if (!editor || !searchText) {
+      setSearchMatchCount(0);
+      return;
+    }
+    const searchLower = searchText.toLowerCase();
+    let count = 0;
+    editor.state.doc.descendants((node) => {
+      if (!node.isText || !node.text) return;
+      const text = node.text.toLowerCase();
+      let idx = text.indexOf(searchLower);
+      while (idx !== -1) {
+        count++;
+        idx = text.indexOf(searchLower, idx + searchText.length);
+      }
+    });
+    setSearchMatchCount(count);
+  }, [editor, searchText]);
+
+  // Count matches, update decorations, and auto-find first match when searchText changes
+  useEffect(() => {
+    countMatches();
+    if (!editor) return;
+    const tr = editor.state.tr.setMeta(searchHighlightKey, searchText || "");
+    editor.view.dispatch(tr);
+    if (searchText) {
+      const searchLower = searchText.toLowerCase();
+      let found = false;
+      editor.state.doc.descendants((node, pos) => {
+        if (found || !node.isText || !node.text) return;
+        const text = node.text.toLowerCase();
+        const idx = text.indexOf(searchLower);
+        if (idx !== -1) {
+          const from = pos + idx;
+          const to = from + searchText.length;
+          editor.chain().setTextSelection({ from, to }).scrollIntoView().run();
+          found = true;
+        }
+      });
+    }
+  }, [countMatches, editor, searchText]);
+
+  const handleSearchNext = useCallback(() => {
+    if (!editor || !searchText) return;
+    const { doc, selection } = editor.state;
+    const searchLower = searchText.toLowerCase();
+    const startFrom = selection.to;
+    let found = false;
+
+    doc.descendants((node, pos) => {
+      if (found || !node.isText || !node.text) return;
+      const text = node.text.toLowerCase();
+      const idx =
+        pos >= startFrom ? text.indexOf(searchLower) : text.indexOf(searchLower, startFrom - pos);
+      if (idx !== -1 && pos + idx >= startFrom) {
+        const from = pos + idx;
+        const to = from + searchText.length;
+        editor.chain().setTextSelection({ from, to }).scrollIntoView().run();
+        found = true;
+      }
+    });
+
+    if (!found) {
+      doc.descendants((node, pos) => {
+        if (found || !node.isText || !node.text) return;
+        const text = node.text.toLowerCase();
+        const idx = text.indexOf(searchLower);
+        if (idx !== -1) {
+          const from = pos + idx;
+          const to = from + searchText.length;
+          editor.chain().setTextSelection({ from, to }).scrollIntoView().run();
+          found = true;
+        }
+      });
+    }
+  }, [editor, searchText]);
+
+  const handleSearchPrev = useCallback(() => {
+    if (!editor || !searchText) return;
+    const { doc, selection } = editor.state;
+    const searchLower = searchText.toLowerCase();
+    const startBefore = selection.from;
+    let lastMatch: { from: number; to: number } | null = null;
+
+    doc.descendants((node, pos) => {
+      if (!node.isText || !node.text) return;
+      const text = node.text.toLowerCase();
+      let idx = text.indexOf(searchLower);
+      while (idx !== -1) {
+        const from = pos + idx;
+        if (from < startBefore) {
+          lastMatch = { from, to: from + searchText.length };
+        }
+        idx = text.indexOf(searchLower, idx + searchText.length);
+      }
+    });
+
+    if (lastMatch) {
+      editor.chain().setTextSelection(lastMatch).scrollIntoView().run();
+    } else {
+      doc.descendants((node, pos) => {
+        if (!node.isText || !node.text) return;
+        const text = node.text.toLowerCase();
+        let idx = text.indexOf(searchLower);
+        while (idx !== -1) {
+          const from = pos + idx;
+          lastMatch = { from, to: from + searchText.length };
+          idx = text.indexOf(searchLower, idx + searchText.length);
+        }
+      });
+      if (lastMatch) {
+        editor.chain().setTextSelection(lastMatch).scrollIntoView().run();
+      }
+    }
+  }, [editor, searchText]);
+
+  const handleReplaceCurrent = useCallback(() => {
+    if (!editor || !searchText) return;
+    const { from, to } = editor.state.selection;
+    const selectedText = editor.state.doc.textBetween(from, to).toLowerCase();
+    if (selectedText === searchText.toLowerCase()) {
+      editor.chain().deleteSelection().insertContent(replaceText).run();
+      countMatches();
+      handleSearchNext();
+    } else {
+      handleSearchNext();
+    }
+  }, [editor, searchText, replaceText, countMatches, handleSearchNext]);
+
+  const handleReplaceAll = useCallback(() => {
+    if (!editor || !searchText) return;
+    const { doc, tr } = editor.state;
+    const searchLower = searchText.toLowerCase();
+    let replaced = 0;
+
+    doc.descendants((node, pos) => {
+      if (!node.isText || !node.text) return;
+      const text = node.text.toLowerCase();
+      let idx = text.indexOf(searchLower);
+      while (idx !== -1) {
+        const from = pos + idx;
+        const to = from + searchText.length;
+        tr.replaceWith(
+          from + replaced * (replaceText.length - searchText.length),
+          to + replaced * (replaceText.length - searchText.length),
+          editor.state.schema.text(replaceText),
+        );
+        replaced++;
+        idx = text.indexOf(searchLower, idx + searchText.length);
+      }
+    });
+
+    if (replaced > 0) {
+      editor.view.dispatch(tr);
+      countMatches();
+    }
+  }, [editor, searchText, replaceText, countMatches]);
+
+  const openFindReplace = useCallback((el: HTMLElement) => {
+    setSearchAnchorEl(el);
+  }, []);
+
+  const closeFindReplace = useCallback(() => {
+    setSearchAnchorEl(null);
+    setSearchText("");
+    setReplaceText("");
+  }, []);
+
+  return {
+    searchAnchorEl,
+    openFindReplace,
+    closeFindReplace,
+    searchText,
+    setSearchText,
+    replaceText,
+    setReplaceText,
+    searchMatchCount,
+    handleSearchNext,
+    handleSearchPrev,
+    handleReplaceCurrent,
+    handleReplaceAll,
+  };
+}

--- a/Clients/src/presentation/pages/PolicyDashboard/PolicyEditorPage.tsx
+++ b/Clients/src/presentation/pages/PolicyDashboard/PolicyEditorPage.tsx
@@ -1,10 +1,8 @@
 import React, { useEffect, useState, useCallback, useRef, useMemo } from "react";
 import { useParams, useSearchParams, useNavigate } from "react-router-dom";
 import { sanitizeRichText } from "../../../application/utils/richTextSanitizer";
-import { useEditor, EditorContent, Extension } from "@tiptap/react";
+import { useEditor, EditorContent } from "@tiptap/react";
 import { BubbleMenu } from "@tiptap/react/menus";
-import { Plugin, PluginKey } from "@tiptap/pm/state";
-import { Decoration, DecorationSet } from "@tiptap/pm/view";
 import StarterKit from "@tiptap/starter-kit";
 import TipTapUnderline from "@tiptap/extension-underline";
 import Highlight from "@tiptap/extension-highlight";
@@ -114,112 +112,11 @@ import { store } from "../../../application/redux/store";
 import { PageBreadcrumbs } from "../../components/breadcrumbs/PageBreadcrumbs";
 import { AuthImageExtension } from "./PolicyEditor/AuthImage";
 import { normalizeSlateHtml } from "./PolicyEditor/normalizeSlateHtml";
-
-// ── Toolbar key type ──────────────────────────────────────────────────
-type ToolbarKey =
-  | "bold"
-  | "italic"
-  | "underline"
-  | "undo"
-  | "redo"
-  | "strike"
-  | "ol"
-  | "ul"
-  | "align-left"
-  | "align-center"
-  | "align-right"
-  | "link"
-  | "image"
-  | "highlight"
-  | "blockquote"
-  | "table"
-  | "code"
-  | "hr"
-  | "taskList"
-  | "superscript"
-  | "subscript"
-  | "color"
-  | "search";
-
-const defaultToolbarState: Record<ToolbarKey, boolean> = {
-  "bold": false,
-  "italic": false,
-  "underline": false,
-  "undo": false,
-  "redo": false,
-  "strike": false,
-  "ol": false,
-  "ul": false,
-  "align-left": false,
-  "align-center": false,
-  "align-right": false,
-  "link": false,
-  "image": false,
-  "highlight": false,
-  "blockquote": false,
-  "table": false,
-  "code": false,
-  "hr": false,
-  "taskList": false,
-  "superscript": false,
-  "subscript": false,
-  "color": false,
-  "search": false,
-};
-
-// ── Search highlight extension ─────────────────────────────────────────
-const searchHighlightKey = new PluginKey("searchHighlight");
-
-function createSearchHighlightExtension() {
-  return Extension.create({
-    name: "searchHighlight",
-    addProseMirrorPlugins() {
-      return [
-        new Plugin({
-          key: searchHighlightKey,
-          state: {
-            init() {
-              return { term: "", decorations: DecorationSet.empty };
-            },
-            apply(tr, prev) {
-              const meta = tr.getMeta(searchHighlightKey);
-              if (meta !== undefined) {
-                const term = meta as string;
-                if (!term) return { term: "", decorations: DecorationSet.empty };
-                const decorations: Decoration[] = [];
-                const searchLower = term.toLowerCase();
-                tr.doc.descendants((node, pos) => {
-                  if (!node.isText || !node.text) return;
-                  const text = node.text.toLowerCase();
-                  let idx = text.indexOf(searchLower);
-                  while (idx !== -1) {
-                    decorations.push(
-                      Decoration.inline(pos + idx, pos + idx + term.length, {
-                        class: "search-highlight",
-                      }),
-                    );
-                    idx = text.indexOf(searchLower, idx + term.length);
-                  }
-                });
-                return { term, decorations: DecorationSet.create(tr.doc, decorations) };
-              }
-              // Remap existing decorations on doc change
-              if (tr.docChanged && prev.decorations !== DecorationSet.empty) {
-                return { ...prev, decorations: prev.decorations.map(tr.mapping, tr.doc) };
-              }
-              return prev;
-            },
-          },
-          props: {
-            decorations(state) {
-              return this.getState(state)?.decorations ?? DecorationSet.empty;
-            },
-          },
-        }),
-      ];
-    },
-  });
-}
+import {
+  createSearchHighlightExtension,
+  searchHighlightKey,
+} from "./PolicyEditor/searchHighlightExtension";
+import { type ToolbarKey, defaultToolbarState } from "./PolicyEditor/toolbarTypes";
 
 // ── Component ─────────────────────────────────────────────────────────
 export default function PolicyEditorPage() {

--- a/Clients/src/presentation/pages/PolicyDashboard/PolicyEditorPage.tsx
+++ b/Clients/src/presentation/pages/PolicyDashboard/PolicyEditorPage.tsx
@@ -1,14 +1,7 @@
 import React, { useEffect, useState, useCallback, useRef, useMemo } from "react";
 import { useParams, useSearchParams, useNavigate } from "react-router-dom";
 import { sanitizeRichText } from "../../../application/utils/richTextSanitizer";
-import {
-  useEditor,
-  EditorContent,
-  NodeViewWrapper,
-  NodeViewProps,
-  ReactNodeViewRenderer,
-  Extension,
-} from "@tiptap/react";
+import { useEditor, EditorContent, Extension } from "@tiptap/react";
 import { BubbleMenu } from "@tiptap/react/menus";
 import { Plugin, PluginKey } from "@tiptap/pm/state";
 import { Decoration, DecorationSet } from "@tiptap/pm/view";
@@ -17,7 +10,6 @@ import TipTapUnderline from "@tiptap/extension-underline";
 import Highlight from "@tiptap/extension-highlight";
 import TextAlign from "@tiptap/extension-text-align";
 import TipTapLink from "@tiptap/extension-link";
-import TipTapImage from "@tiptap/extension-image";
 import {
   Table as TipTapTable,
   TableRow as TipTapTableRow,
@@ -120,156 +112,8 @@ import { checkStringValidation } from "../../../application/validations/stringVa
 import { useFormValidation } from "../../../application/hooks/useFormValidation";
 import { store } from "../../../application/redux/store";
 import { PageBreadcrumbs } from "../../components/breadcrumbs/PageBreadcrumbs";
-
-// ── Auth image node view with resize ─────────────────────────────────
-const AuthImage: React.FC<NodeViewProps> = ({ node, updateAttributes, selected }) => {
-  const src = node.attrs.src || "";
-  const alt = node.attrs.alt || "";
-  const width = node.attrs.width as number | null;
-  const isApiUrl = src.startsWith("/api/") || src.includes("/api/file-manager/");
-  const [blobUrl, setBlobUrl] = useState<string | null>(null);
-  const [error, setError] = useState(false);
-  const imgRef = useRef<HTMLImageElement>(null);
-  const startXRef = useRef(0);
-  const startWidthRef = useRef(0);
-
-  useEffect(() => {
-    if (!isApiUrl || !src) return;
-    let cancelled = false;
-    const controller = new AbortController();
-    (async () => {
-      try {
-        const token = store.getState().auth.authToken;
-        const res = await fetch(src, {
-          headers: { Authorization: `Bearer ${token}` },
-          signal: controller.signal,
-        });
-        if (!res.ok) throw new Error(`HTTP ${res.status}`);
-        const blob = await res.blob();
-        if (!cancelled) setBlobUrl(URL.createObjectURL(blob));
-      } catch (e: any) {
-        if (e.name !== "AbortError" && !cancelled) setError(true);
-      }
-    })();
-    return () => {
-      cancelled = true;
-      controller.abort();
-    };
-  }, [src, isApiUrl]);
-
-  const handleResizeStart = useCallback(
-    (e: React.MouseEvent) => {
-      e.preventDefault();
-      e.stopPropagation();
-      startXRef.current = e.clientX;
-      startWidthRef.current = imgRef.current?.offsetWidth || 300;
-
-      const onMove = (ev: MouseEvent) => {
-        const diff = ev.clientX - startXRef.current;
-        const newWidth = Math.max(100, startWidthRef.current + diff);
-        updateAttributes({ width: newWidth });
-      };
-      const onUp = () => {
-        document.removeEventListener("mousemove", onMove);
-        document.removeEventListener("mouseup", onUp);
-      };
-      document.addEventListener("mousemove", onMove);
-      document.addEventListener("mouseup", onUp);
-    },
-    [updateAttributes],
-  );
-
-  const displaySrc = isApiUrl ? blobUrl : src;
-
-  return (
-    <NodeViewWrapper>
-      {error ? (
-        <div
-          style={{
-            background: "#fee2e2",
-            color: "#991b1b",
-            padding: "8px 12px",
-            borderRadius: 6,
-            fontSize: "0.9rem",
-            textAlign: "center",
-            margin: "12px 0",
-          }}
-        >
-          Image not found
-        </div>
-      ) : displaySrc ? (
-        <div
-          style={{
-            position: "relative",
-            display: "inline-block",
-            margin: "12px 0",
-            outline: selected ? "2px solid brand.primary" : "none",
-            borderRadius: 8,
-          }}
-        >
-          <img
-            ref={imgRef}
-            src={displaySrc}
-            alt={alt}
-            style={{
-              display: "block",
-              width: width ? `${width}px` : undefined,
-              maxWidth: "100%",
-              borderRadius: 8,
-            }}
-          />
-          {selected && (
-            <div
-              onMouseDown={handleResizeStart}
-              style={{
-                position: "absolute",
-                right: -5,
-                bottom: -5,
-                width: 12,
-                height: 12,
-                backgroundColor: "brand.primary",
-                border: "2px solid background.main",
-                borderRadius: 2,
-                cursor: "nwse-resize",
-                boxShadow: "0 1px 3px rgba(0,0,0,0.3)",
-              }}
-            />
-          )}
-        </div>
-      ) : (
-        <div
-          style={{
-            background: "#f0f0f0",
-            color: "#666",
-            padding: "16px 24px",
-            borderRadius: 6,
-            textAlign: "center",
-            fontSize: "0.9rem",
-            margin: "12px 0",
-          }}
-        >
-          Loading image...
-        </div>
-      )}
-    </NodeViewWrapper>
-  );
-};
-
-const AuthImageExtension = TipTapImage.extend({
-  addAttributes() {
-    return {
-      ...this.parent?.(),
-      width: {
-        default: null,
-        parseHTML: (el) => (el.getAttribute("width") ? Number(el.getAttribute("width")) : null),
-        renderHTML: (attrs) => (attrs.width ? { width: attrs.width } : {}),
-      },
-    };
-  },
-  addNodeView() {
-    return ReactNodeViewRenderer(AuthImage);
-  },
-});
+import { AuthImageExtension } from "./PolicyEditor/AuthImage";
+import { normalizeSlateHtml } from "./PolicyEditor/normalizeSlateHtml";
 
 // ── Toolbar key type ──────────────────────────────────────────────────
 type ToolbarKey =
@@ -322,28 +166,6 @@ const defaultToolbarState: Record<ToolbarKey, boolean> = {
   "color": false,
   "search": false,
 };
-
-// ── Normalize legacy Slate HTML ───────────────────────────────────────
-function normalizeSlateHtml(html: string): string {
-  let n = html.replace(
-    /<div([^>]*?)data-slate-type="(h[1-6]|p|blockquote)"([^>]*)>/gi,
-    (_m, before, tag, after) => `<${tag}${before}${after}>`,
-  );
-  n = n.replace(/<div[^>]*class="slate-editor"[^>]*>/gi, "");
-  n = n.replace(/<span[^>]*data-slate-string="true"[^>]*>([^<]*)<\/span>/gi, "$1");
-  n = n.replace(/<span[^>]*data-slate-leaf="true"[^>]*>/gi, "");
-  n = n.replace(/<span[^>]*data-slate-node="text"[^>]*>/gi, "");
-  n = n.replace(/\s*data-slate-[a-z-]+="[^"]*"/gi, "");
-  n = n.replace(/\s*data-block-id="[^"]*"/gi, "");
-  n = n.replace(/\s*class="slate-[^"]*"/gi, "");
-  n = n.replace(/\s*style="position:\s*relative\s*;?\s*"/gi, "");
-  n = n.replace(/\s*style=""/gi, "");
-  n = n.replace(/\s*class=""/gi, "");
-  n = n.replace(/<div>\s*([^<])/gi, "<p>$1");
-  n = n.replace(/<\/div>/gi, "</p>");
-  n = n.replace(/<\/p>\s*<\/p>/gi, "</p>");
-  return n;
-}
 
 // ── Search highlight extension ─────────────────────────────────────────
 const searchHighlightKey = new PluginKey("searchHighlight");

--- a/Clients/src/presentation/pages/PolicyDashboard/PolicyEditorPage.tsx
+++ b/Clients/src/presentation/pages/PolicyDashboard/PolicyEditorPage.tsx
@@ -78,14 +78,11 @@ import {
   Check,
   Pencil,
   Palette,
-  ChevronDown as ChevronDownIcon,
-  ChevronUp as ChevronUpIcon,
   Search,
   Upload,
 } from "lucide-react";
 
 import Select from "../../components/Inputs/Select";
-import Field from "../../components/Inputs/Field";
 import { CustomizableButton } from "../../components/button/customizable-button";
 import { HistorySidebar } from "../../components/Common/HistorySidebar";
 import CustomFieldsSection, {
@@ -113,12 +110,11 @@ import { store } from "../../../application/redux/store";
 import { PageBreadcrumbs } from "../../components/breadcrumbs/PageBreadcrumbs";
 import { AuthImageExtension } from "./PolicyEditor/AuthImage";
 import { normalizeSlateHtml } from "./PolicyEditor/normalizeSlateHtml";
-import {
-  createSearchHighlightExtension,
-  searchHighlightKey,
-} from "./PolicyEditor/searchHighlightExtension";
+import { createSearchHighlightExtension } from "./PolicyEditor/searchHighlightExtension";
 import { type ToolbarKey, defaultToolbarState } from "./PolicyEditor/toolbarTypes";
 import { policyEditorStyles } from "./PolicyEditor/editorStyles";
+import { usePolicyFindReplace } from "./PolicyEditor/usePolicyFindReplace";
+import { FindReplacePopover } from "./PolicyEditor/FindReplacePopover";
 
 // ── Component ─────────────────────────────────────────────────────────
 export default function PolicyEditorPage() {
@@ -183,12 +179,6 @@ export default function PolicyEditorPage() {
 
   // Color picker state
   const [colorAnchorEl, setColorAnchorEl] = useState<HTMLElement | null>(null);
-
-  // Search & replace state
-  const [searchAnchorEl, setSearchAnchorEl] = useState<HTMLElement | null>(null);
-  const [searchText, setSearchText] = useState("");
-  const [replaceText, setReplaceText] = useState("");
-  const [searchMatchCount, setSearchMatchCount] = useState(0);
 
   const validators = useMemo(
     () => ({
@@ -583,171 +573,20 @@ export default function PolicyEditorPage() {
     "#9333ea",
   ];
 
-  // ── Search & replace ───────────────────────────────────────────
-  const countMatches = useCallback(() => {
-    if (!editor || !searchText) {
-      setSearchMatchCount(0);
-      return;
-    }
-    const searchLower = searchText.toLowerCase();
-    let count = 0;
-    editor.state.doc.descendants((node) => {
-      if (!node.isText || !node.text) return;
-      const text = node.text.toLowerCase();
-      let idx = text.indexOf(searchLower);
-      while (idx !== -1) {
-        count++;
-        idx = text.indexOf(searchLower, idx + searchText.length);
-      }
-    });
-    setSearchMatchCount(count);
-  }, [editor, searchText]);
-
-  // Count matches, update decorations, and auto-find first match when searchText changes
-  useEffect(() => {
-    countMatches();
-    if (!editor) return;
-    // Update search highlight decorations
-    const tr = editor.state.tr.setMeta(searchHighlightKey, searchText || "");
-    editor.view.dispatch(tr);
-    // Auto-jump to first match
-    if (searchText) {
-      const searchLower = searchText.toLowerCase();
-      let found = false;
-      editor.state.doc.descendants((node, pos) => {
-        if (found || !node.isText || !node.text) return;
-        const text = node.text.toLowerCase();
-        const idx = text.indexOf(searchLower);
-        if (idx !== -1) {
-          const from = pos + idx;
-          const to = from + searchText.length;
-          editor.chain().setTextSelection({ from, to }).scrollIntoView().run();
-          found = true;
-        }
-      });
-    }
-  }, [countMatches, editor, searchText]);
-
-  const handleSearchNext = useCallback(() => {
-    if (!editor || !searchText) return;
-    const { doc, selection } = editor.state;
-    const searchLower = searchText.toLowerCase();
-    const startFrom = selection.to;
-    let found = false;
-
-    doc.descendants((node, pos) => {
-      if (found || !node.isText || !node.text) return;
-      const text = node.text.toLowerCase();
-      const idx =
-        pos >= startFrom ? text.indexOf(searchLower) : text.indexOf(searchLower, startFrom - pos);
-      if (idx !== -1 && pos + idx >= startFrom) {
-        const from = pos + idx;
-        const to = from + searchText.length;
-        editor.chain().setTextSelection({ from, to }).scrollIntoView().run();
-        found = true;
-      }
-    });
-
-    // Wrap around if not found after cursor
-    if (!found) {
-      doc.descendants((node, pos) => {
-        if (found || !node.isText || !node.text) return;
-        const text = node.text.toLowerCase();
-        const idx = text.indexOf(searchLower);
-        if (idx !== -1) {
-          const from = pos + idx;
-          const to = from + searchText.length;
-          editor.chain().setTextSelection({ from, to }).scrollIntoView().run();
-          found = true;
-        }
-      });
-    }
-  }, [editor, searchText]);
-
-  const handleSearchPrev = useCallback(() => {
-    if (!editor || !searchText) return;
-    const { doc, selection } = editor.state;
-    const searchLower = searchText.toLowerCase();
-    const startBefore = selection.from;
-    let lastMatch: { from: number; to: number } | null = null;
-
-    // Find the last match before cursor
-    doc.descendants((node, pos) => {
-      if (!node.isText || !node.text) return;
-      const text = node.text.toLowerCase();
-      let idx = text.indexOf(searchLower);
-      while (idx !== -1) {
-        const from = pos + idx;
-        if (from < startBefore) {
-          lastMatch = { from, to: from + searchText.length };
-        }
-        idx = text.indexOf(searchLower, idx + searchText.length);
-      }
-    });
-
-    if (lastMatch) {
-      editor.chain().setTextSelection(lastMatch).scrollIntoView().run();
-    } else {
-      // Wrap around: find last match in the whole doc
-      doc.descendants((node, pos) => {
-        if (!node.isText || !node.text) return;
-        const text = node.text.toLowerCase();
-        let idx = text.indexOf(searchLower);
-        while (idx !== -1) {
-          const from = pos + idx;
-          lastMatch = { from, to: from + searchText.length };
-          idx = text.indexOf(searchLower, idx + searchText.length);
-        }
-      });
-      if (lastMatch) {
-        editor.chain().setTextSelection(lastMatch).scrollIntoView().run();
-      }
-    }
-  }, [editor, searchText]);
-
-  const handleReplaceCurrent = useCallback(() => {
-    if (!editor || !searchText) return;
-    const { from, to } = editor.state.selection;
-    const selectedText = editor.state.doc.textBetween(from, to).toLowerCase();
-    if (selectedText === searchText.toLowerCase()) {
-      editor.chain().deleteSelection().insertContent(replaceText).run();
-      countMatches();
-      // Find next match after replacement
-      handleSearchNext();
-    } else {
-      // No current selection matching — find next first
-      handleSearchNext();
-    }
-  }, [editor, searchText, replaceText, countMatches, handleSearchNext]);
-
-  const handleReplaceAll = useCallback(() => {
-    if (!editor || !searchText) return;
-    const { doc, tr } = editor.state;
-    const searchLower = searchText.toLowerCase();
-    let replaced = 0;
-
-    doc.descendants((node, pos) => {
-      if (!node.isText || !node.text) return;
-      const text = node.text.toLowerCase();
-      let idx = text.indexOf(searchLower);
-      while (idx !== -1) {
-        const from = pos + idx;
-        const to = from + searchText.length;
-        tr.replaceWith(
-          from + replaced * (replaceText.length - searchText.length),
-          to + replaced * (replaceText.length - searchText.length),
-          editor.state.schema.text(replaceText),
-        );
-        replaced++;
-        idx = text.indexOf(searchLower, idx + searchText.length);
-      }
-    });
-
-    if (replaced > 0) {
-      editor.view.dispatch(tr);
-      countMatches();
-    }
-  }, [editor, searchText, replaceText, countMatches]);
+  const {
+    searchAnchorEl,
+    openFindReplace,
+    closeFindReplace,
+    searchText,
+    setSearchText,
+    replaceText,
+    setReplaceText,
+    searchMatchCount,
+    handleSearchNext,
+    handleSearchPrev,
+    handleReplaceCurrent,
+    handleReplaceAll,
+  } = usePolicyFindReplace(editor);
 
   // ── Toolbar config ────────────────────────────────────────────────
   const toolbarConfig: Array<{
@@ -1671,7 +1510,7 @@ export default function PolicyEditorPage() {
                       return;
                     }
                     if (key === "search") {
-                      setSearchAnchorEl(e.currentTarget);
+                      openFindReplace(e.currentTarget);
                       return;
                     }
                     action?.();
@@ -1761,157 +1600,19 @@ export default function PolicyEditorPage() {
             </Box>
           </Popover>
 
-          {/* ── Find & replace popover (Google Docs style) ────────────── */}
-          <Popover
-            open={Boolean(searchAnchorEl)}
+          <FindReplacePopover
             anchorEl={searchAnchorEl}
-            onClose={() => {
-              setSearchAnchorEl(null);
-              setSearchText("");
-              setReplaceText("");
-            }}
-            anchorOrigin={{ vertical: "bottom", horizontal: "right" }}
-            transformOrigin={{ vertical: "top", horizontal: "right" }}
-            disableAutoFocus
-            disableEnforceFocus
-            slotProps={{
-              paper: {
-                sx: {
-                  width: 340,
-                  borderRadius: "4px",
-                  border: "1px solid #d0d5dd",
-                  boxShadow: "0 4px 16px rgba(0,0,0,0.12)",
-                  p: "16px",
-                },
-              },
-            }}
-          >
-            {/* Find row */}
-            <Stack gap="12px">
-              <Stack direction="row" gap="8px" alignItems="center">
-                <Box sx={{ flex: 1 }}>
-                  <Field
-                    id="search-find-input"
-                    placeholder="Find in document..."
-                    value={searchText}
-                    onChange={(e) => setSearchText(e.target.value)}
-                    onKeyDown={(e) => {
-                      if (e.key === "Enter") handleSearchNext();
-                    }}
-                    autoFocus
-                    sx={{
-                      "& .field-input": { height: 34 },
-                      "& input": { padding: "0 10px", fontSize: 13 },
-                    }}
-                  />
-                </Box>
-                <Tooltip title="Previous" arrow>
-                  <IconButton
-                    onClick={handleSearchPrev}
-                    disabled={searchMatchCount === 0}
-                    size="small"
-                    sx={{
-                      "padding": "6px",
-                      "borderRadius": "4px",
-                      "border": "1px solid #d0d5dd",
-                      "color": "text.secondary",
-                      "&:hover": { backgroundColor: "background.accent" },
-                      "&:disabled": { color: "border.dark", borderColor: "border.light" },
-                    }}
-                  >
-                    <ChevronUpIcon size={16} />
-                  </IconButton>
-                </Tooltip>
-                <Tooltip title="Next" arrow>
-                  <IconButton
-                    onClick={handleSearchNext}
-                    disabled={searchMatchCount === 0}
-                    size="small"
-                    sx={{
-                      "padding": "6px",
-                      "borderRadius": "4px",
-                      "border": "1px solid #d0d5dd",
-                      "color": "text.secondary",
-                      "&:hover": { backgroundColor: "background.accent" },
-                      "&:disabled": { color: "border.dark", borderColor: "border.light" },
-                    }}
-                  >
-                    <ChevronDownIcon size={16} />
-                  </IconButton>
-                </Tooltip>
-              </Stack>
-
-              {/* Match count */}
-              {searchText && (
-                <Typography sx={{ fontSize: 11, color: "text.muted", mt: "-4px" }}>
-                  {searchMatchCount === 0
-                    ? "No matches found"
-                    : `${searchMatchCount} match${searchMatchCount !== 1 ? "es" : ""} found`}
-                </Typography>
-              )}
-
-              {/* Replace row */}
-              <Stack direction="row" gap="8px" alignItems="center">
-                <Box sx={{ flex: 1 }}>
-                  <Field
-                    id="search-replace-input"
-                    placeholder="Replace with..."
-                    value={replaceText}
-                    onChange={(e) => setReplaceText(e.target.value)}
-                    onKeyDown={(e) => {
-                      if (e.key === "Enter") handleReplaceCurrent();
-                    }}
-                    sx={{
-                      "& .field-input": { height: 34 },
-                      "& input": { padding: "0 10px", fontSize: 13 },
-                    }}
-                  />
-                </Box>
-                <Tooltip title="Replace" arrow>
-                  <span>
-                    <CustomizableButton
-                      variant="outlined"
-                      text="Replace"
-                      onClick={handleReplaceCurrent}
-                      isDisabled={searchMatchCount === 0}
-                      sx={{
-                        "minWidth": "auto",
-                        "height": 34,
-                        "px": "10px",
-                        "fontSize": 12,
-                        "backgroundColor": "background.main",
-                        "border": "1px solid #d0d5dd",
-                        "color": "text.secondary",
-                        "whiteSpace": "nowrap",
-                        "&:hover": { backgroundColor: "background.accent" },
-                      }}
-                    />
-                  </span>
-                </Tooltip>
-              </Stack>
-
-              {/* Replace all */}
-              <Box sx={{ display: "flex", justifyContent: "flex-end" }}>
-                <CustomizableButton
-                  variant="outlined"
-                  text="Replace all"
-                  onClick={handleReplaceAll}
-                  isDisabled={searchMatchCount === 0}
-                  sx={{
-                    "minWidth": "auto",
-                    "height": 34,
-                    "px": "10px",
-                    "fontSize": 12,
-                    "backgroundColor": "background.main",
-                    "border": "1px solid #d0d5dd",
-                    "color": "text.secondary",
-                    "whiteSpace": "nowrap",
-                    "&:hover": { backgroundColor: "background.accent" },
-                  }}
-                />
-              </Box>
-            </Stack>
-          </Popover>
+            onClose={closeFindReplace}
+            searchText={searchText}
+            onSearchTextChange={setSearchText}
+            replaceText={replaceText}
+            onReplaceTextChange={setReplaceText}
+            searchMatchCount={searchMatchCount}
+            onSearchNext={handleSearchNext}
+            onSearchPrev={handleSearchPrev}
+            onReplaceCurrent={handleReplaceCurrent}
+            onReplaceAll={handleReplaceAll}
+          />
 
           {/* ── Editor + History sidebar ────────────────────────────── */}
           <Stack direction="row" sx={{ flex: 1, minHeight: 0, overflow: "hidden" }}>

--- a/Clients/src/presentation/pages/PolicyDashboard/PolicyEditorPage.tsx
+++ b/Clients/src/presentation/pages/PolicyDashboard/PolicyEditorPage.tsx
@@ -36,6 +36,7 @@ import {
   Snackbar,
   Alert,
   TextField,
+  GlobalStyles,
 } from "@mui/material";
 import {
   Underline as UnderlineIcon,
@@ -117,6 +118,7 @@ import {
   searchHighlightKey,
 } from "./PolicyEditor/searchHighlightExtension";
 import { type ToolbarKey, defaultToolbarState } from "./PolicyEditor/toolbarTypes";
+import { policyEditorStyles } from "./PolicyEditor/editorStyles";
 
 // ── Component ─────────────────────────────────────────────────────────
 export default function PolicyEditorPage() {
@@ -1979,191 +1981,7 @@ export default function PolicyEditorPage() {
                   </Box>
                 </BubbleMenu>
               )}
-              <style>{`
-              .policy-tiptap-editor .ProseMirror {
-                height: 100%;
-                min-height: 300px;
-                overflow-y: auto;
-                padding: 20px 24px;
-                border: none;
-                border-radius: 4px;
-                background-color: #FFFFFF;
-                font-size: ${theme.typography.fontSize}px;
-                color: ${theme.palette.text.primary};
-                outline: none;
-              }
-              .policy-tiptap-editor .ProseMirror:focus {
-                outline: none;
-              }
-              .policy-tiptap-editor .ProseMirror p.is-editor-empty:first-child::before {
-                content: attr(data-placeholder);
-                float: left;
-                color: #adb5bd;
-                pointer-events: none;
-                height: 0;
-              }
-              .policy-tiptap-editor .ProseMirror mark {
-                background-color: #fef08a;
-                padding: 0 2px;
-                border-radius: 2px;
-              }
-              .policy-tiptap-editor .ProseMirror blockquote {
-                border-left: 3px solid #d0d5dd;
-                margin: 8px 0;
-                padding: 8px 16px;
-                color: #475467;
-                background-color: #f9fafb;
-                border-radius: 0 4px 4px 0;
-              }
-              .policy-tiptap-editor .ProseMirror pre {
-                background-color: #1e1e1e;
-                color: #d4d4d4;
-                padding: 12px 16px;
-                border-radius: 6px;
-                font-family: 'JetBrains Mono', 'Fira Code', monospace;
-                font-size: 0.9em;
-                overflow-x: auto;
-                margin: 12px 0;
-              }
-              .policy-tiptap-editor .ProseMirror pre code {
-                background: none;
-                color: inherit;
-                padding: 0;
-              }
-              .policy-tiptap-editor .ProseMirror code {
-                background-color: #f1f3f5;
-                padding: 2px 4px;
-                border-radius: 3px;
-                font-size: 0.9em;
-              }
-              .policy-tiptap-editor .ProseMirror hr {
-                border: none;
-                border-top: 1px solid #d0d5dd;
-                margin: 16px 0;
-              }
-              .policy-tiptap-editor .ProseMirror table {
-                border-collapse: collapse;
-                width: 100%;
-                margin: 12px 0;
-                table-layout: fixed;
-                overflow: hidden;
-              }
-              .policy-tiptap-editor .ProseMirror th,
-              .policy-tiptap-editor .ProseMirror td {
-                border: 1px solid #d0d5dd;
-                padding: 8px 12px;
-                text-align: left;
-                vertical-align: top;
-                min-width: 80px;
-                position: relative;
-                box-sizing: border-box;
-              }
-              .policy-tiptap-editor .ProseMirror th {
-                background-color: #f0f4f2;
-                font-weight: 600;
-              }
-              /* Selected cell highlight */
-              .policy-tiptap-editor .ProseMirror .selectedCell {
-                background-color: #e6f0ec !important;
-                border-color: #13715B !important;
-              }
-              .policy-tiptap-editor .ProseMirror .selectedCell::after {
-                content: '';
-                position: absolute;
-                inset: 0;
-                background: rgba(19, 113, 91, 0.08);
-                pointer-events: none;
-              }
-              /* Column resize handle */
-              .policy-tiptap-editor .ProseMirror .column-resize-handle {
-                position: absolute;
-                right: -2px;
-                top: 0;
-                bottom: -2px;
-                width: 4px;
-                background-color: #13715B;
-                cursor: col-resize;
-                z-index: 10;
-              }
-              .policy-tiptap-editor .ProseMirror.resize-cursor {
-                cursor: col-resize;
-              }
-              /* Subtle hover on rows (only when no cell is selected) */
-              .policy-tiptap-editor .ProseMirror td:hover {
-                background-color: #fafbfc;
-              }
-              .policy-tiptap-editor .ProseMirror img {
-                max-width: 100%;
-                border-radius: 8px;
-                margin: 12px 0;
-              }
-              .policy-tiptap-editor .ProseMirror a {
-                color: #3182ce;
-                text-decoration: underline;
-                cursor: pointer;
-              }
-              .policy-tiptap-editor .ProseMirror ul,
-              .policy-tiptap-editor .ProseMirror ol {
-                padding-left: 24px;
-              }
-              .policy-tiptap-editor .ProseMirror h1 {
-                font-size: 1.75em;
-                font-weight: 700;
-                margin: 16px 0 8px;
-              }
-              .policy-tiptap-editor .ProseMirror h2 {
-                font-size: 1.4em;
-                font-weight: 600;
-                margin: 12px 0 6px;
-              }
-              .policy-tiptap-editor .ProseMirror h3 {
-                font-size: 1.15em;
-                font-weight: 600;
-                margin: 10px 0 4px;
-              }
-              .policy-tiptap-editor .ProseMirror ul[data-type="taskList"] {
-                list-style: none;
-                padding-left: 4px;
-              }
-              .policy-tiptap-editor .ProseMirror ul[data-type="taskList"] li {
-                display: flex;
-                align-items: flex-start;
-                gap: 8px;
-                margin: 4px 0;
-              }
-              .policy-tiptap-editor .ProseMirror ul[data-type="taskList"] li label {
-                display: flex;
-                align-items: center;
-                flex-shrink: 0;
-                margin-top: 2px;
-              }
-              .policy-tiptap-editor .ProseMirror ul[data-type="taskList"] li label input[type="checkbox"] {
-                width: 16px;
-                height: 16px;
-                cursor: pointer;
-                accent-color: #13715B;
-              }
-              .policy-tiptap-editor .ProseMirror ul[data-type="taskList"] li > div {
-                flex: 1;
-              }
-              .policy-tiptap-editor .ProseMirror ul[data-type="taskList"] li[data-checked="true"] > div > p {
-                text-decoration: line-through;
-                color: #98A2B3;
-              }
-              .policy-tiptap-editor .ProseMirror sup {
-                font-size: 0.75em;
-                vertical-align: super;
-              }
-              .policy-tiptap-editor .ProseMirror sub {
-                font-size: 0.75em;
-                vertical-align: sub;
-              }
-              .policy-tiptap-editor .ProseMirror .search-highlight {
-                background-color: #fef08a;
-                border-radius: 2px;
-                box-shadow: 0 0 0 1px #eab308;
-              }
-            `}</style>
+              <GlobalStyles styles={policyEditorStyles} />
             </Box>
 
             {displayErrors.content && (

--- a/Clients/src/presentation/pages/PolicyDashboard/PolicyEditorPage.tsx
+++ b/Clients/src/presentation/pages/PolicyDashboard/PolicyEditorPage.tsx
@@ -2,7 +2,6 @@ import React, { useEffect, useState, useCallback, useRef, useMemo } from "react"
 import { useParams, useSearchParams, useNavigate } from "react-router-dom";
 import { sanitizeRichText } from "../../../application/utils/richTextSanitizer";
 import { useEditor, EditorContent } from "@tiptap/react";
-import { BubbleMenu } from "@tiptap/react/menus";
 import StarterKit from "@tiptap/starter-kit";
 import TipTapUnderline from "@tiptap/extension-underline";
 import Highlight from "@tiptap/extension-highlight";
@@ -31,7 +30,6 @@ import {
   Tooltip,
   useTheme,
   Skeleton,
-  Divider,
   Popover,
   Snackbar,
   Alert,
@@ -63,14 +61,7 @@ import {
   Loader2,
   Code,
   Minus,
-  Rows3,
-  Columns3,
-  TableCellsMerge,
-  TableCellsSplit,
-  Trash2,
-  Plus,
   X,
-  ToggleLeft,
   ArrowLeft,
   ListChecks,
   SuperscriptIcon,
@@ -115,6 +106,7 @@ import { type ToolbarKey, defaultToolbarState } from "./PolicyEditor/toolbarType
 import { policyEditorStyles } from "./PolicyEditor/editorStyles";
 import { usePolicyFindReplace } from "./PolicyEditor/usePolicyFindReplace";
 import { FindReplacePopover } from "./PolicyEditor/FindReplacePopover";
+import { PolicyTableBubbleMenu } from "./PolicyEditor/PolicyTableBubbleMenu";
 
 // ── Component ─────────────────────────────────────────────────────────
 export default function PolicyEditorPage() {
@@ -744,88 +736,6 @@ export default function PolicyEditorPage() {
       title: "Find & replace",
       icon: <Search size={16} />,
       action: () => {}, // handled via popover click
-    },
-  ];
-
-  // ── Table context toolbar config ──────────────────────────────────
-  const tableToolbarConfig: Array<{
-    key: string;
-    title: string;
-    icon: React.ReactNode;
-    action: () => void;
-    separator?: boolean;
-    danger?: boolean;
-  }> = [
-    {
-      key: "addRowBefore",
-      title: "Add row above",
-      icon: <Plus size={14} />,
-      action: () => editor?.chain().focus().addRowBefore().run(),
-    },
-    {
-      key: "addRowAfter",
-      title: "Add row below",
-      icon: <Rows3 size={14} />,
-      action: () => editor?.chain().focus().addRowAfter().run(),
-    },
-    {
-      key: "deleteRow",
-      title: "Delete row",
-      icon: <X size={14} />,
-      action: () => editor?.chain().focus().deleteRow().run(),
-      separator: true,
-    },
-    {
-      key: "addColumnBefore",
-      title: "Add column left",
-      icon: <Plus size={14} />,
-      action: () => editor?.chain().focus().addColumnBefore().run(),
-    },
-    {
-      key: "addColumnAfter",
-      title: "Add column right",
-      icon: <Columns3 size={14} />,
-      action: () => editor?.chain().focus().addColumnAfter().run(),
-    },
-    {
-      key: "deleteColumn",
-      title: "Delete column",
-      icon: <X size={14} />,
-      action: () => editor?.chain().focus().deleteColumn().run(),
-      separator: true,
-    },
-    {
-      key: "mergeCells",
-      title: "Merge cells",
-      icon: <TableCellsMerge size={14} />,
-      action: () => editor?.chain().focus().mergeCells().run(),
-    },
-    {
-      key: "splitCell",
-      title: "Split cell",
-      icon: <TableCellsSplit size={14} />,
-      action: () => editor?.chain().focus().splitCell().run(),
-      separator: true,
-    },
-    {
-      key: "toggleHeaderRow",
-      title: "Toggle header row",
-      icon: <ToggleLeft size={14} />,
-      action: () => editor?.chain().focus().toggleHeaderRow().run(),
-    },
-    {
-      key: "toggleHeaderColumn",
-      title: "Toggle header column",
-      icon: <ToggleLeft size={14} />,
-      action: () => editor?.chain().focus().toggleHeaderColumn().run(),
-      separator: true,
-    },
-    {
-      key: "deleteTable",
-      title: "Delete table",
-      icon: <Trash2 size={14} />,
-      action: () => editor?.chain().focus().deleteTable().run(),
-      danger: true,
     },
   ];
 
@@ -1628,60 +1538,7 @@ export default function PolicyEditorPage() {
               }}
             >
               <EditorContent editor={editor} className="policy-tiptap-editor" />
-
-              {/* ── Floating table toolbar ────────────────────────── */}
-              {editor && (
-                <BubbleMenu
-                  editor={editor}
-                  pluginKey="tableMenu"
-                  shouldShow={({ editor: e }) => e.isActive("table")}
-                  updateDelay={100}
-                >
-                  <Box
-                    sx={{
-                      display: "flex",
-                      gap: "2px",
-                      p: "4px",
-                      alignItems: "center",
-                      backgroundColor: "background.main",
-                      border: "1px solid #d0d5dd",
-                      borderRadius: "6px",
-                      boxShadow: "0 4px 12px rgba(0,0,0,0.12), 0 1px 3px rgba(0,0,0,0.08)",
-                    }}
-                  >
-                    {tableToolbarConfig.map(({ key, title, icon, action, separator, danger }) => (
-                      <React.Fragment key={key}>
-                        <Tooltip title={title} placement="top" arrow>
-                          <IconButton
-                            onMouseDown={(e) => {
-                              e.preventDefault();
-                              action();
-                            }}
-                            size="small"
-                            sx={{
-                              "padding": "5px",
-                              "borderRadius": "4px",
-                              "color": danger ? "#dc2626" : "#374151",
-                              "&:hover": {
-                                backgroundColor: danger ? "#fef2f2" : "background.hover",
-                              },
-                            }}
-                          >
-                            {icon}
-                          </IconButton>
-                        </Tooltip>
-                        {separator && (
-                          <Divider
-                            orientation="vertical"
-                            flexItem
-                            sx={{ mx: "2px", borderColor: "status.default.border" }}
-                          />
-                        )}
-                      </React.Fragment>
-                    ))}
-                  </Box>
-                </BubbleMenu>
-              )}
+              {editor && <PolicyTableBubbleMenu editor={editor} />}
               <GlobalStyles styles={policyEditorStyles} />
             </Box>
 

--- a/Clients/src/presentation/pages/PolicyDashboard/PolicyEditorPage.tsx
+++ b/Clients/src/presentation/pages/PolicyDashboard/PolicyEditorPage.tsx
@@ -37,43 +37,18 @@ import {
   GlobalStyles,
 } from "@mui/material";
 import {
-  Underline as UnderlineIcon,
-  Bold,
-  Italic,
   SaveIcon,
-  Strikethrough,
-  ListOrdered,
-  List,
-  AlignLeft,
-  AlignCenter,
-  AlignRight,
-  Link,
-  Unlink,
-  Image,
-  Redo2,
-  Undo2,
   History as HistoryIcon,
-  Quote,
-  Highlighter,
-  Table,
   FileText,
   FileDown,
   Loader2,
-  Code,
-  Minus,
   X,
   ArrowLeft,
-  ListChecks,
-  SuperscriptIcon,
-  SubscriptIcon,
   Check,
   Pencil,
-  Palette,
-  Search,
   Upload,
 } from "lucide-react";
 
-import Select from "../../components/Inputs/Select";
 import { CustomizableButton } from "../../components/button/customizable-button";
 import { HistorySidebar } from "../../components/Common/HistorySidebar";
 import CustomFieldsSection, {
@@ -102,11 +77,11 @@ import { PageBreadcrumbs } from "../../components/breadcrumbs/PageBreadcrumbs";
 import { AuthImageExtension } from "./PolicyEditor/AuthImage";
 import { normalizeSlateHtml } from "./PolicyEditor/normalizeSlateHtml";
 import { createSearchHighlightExtension } from "./PolicyEditor/searchHighlightExtension";
-import { type ToolbarKey, defaultToolbarState } from "./PolicyEditor/toolbarTypes";
 import { policyEditorStyles } from "./PolicyEditor/editorStyles";
 import { usePolicyFindReplace } from "./PolicyEditor/usePolicyFindReplace";
 import { FindReplacePopover } from "./PolicyEditor/FindReplacePopover";
 import { PolicyTableBubbleMenu } from "./PolicyEditor/PolicyTableBubbleMenu";
+import { PolicyEditorToolbar } from "./PolicyEditor/PolicyEditorToolbar";
 
 // ── Component ─────────────────────────────────────────────────────────
 export default function PolicyEditorPage() {
@@ -162,15 +137,10 @@ export default function PolicyEditorPage() {
   const [editedTitle, setEditedTitle] = useState("");
   const [isSavingTitle, setIsSavingTitle] = useState(false);
   const [titleSaveError, setTitleSaveError] = useState<string | null>(null);
-  const [toolbarState, setToolbarState] = useState(defaultToolbarState);
-  const [currentBlockType, setCurrentBlockType] = useState<string>("p");
   const imageInputRef = useRef<HTMLInputElement>(null);
   const isLoadingContentRef = useRef(false);
   const formRef = useRef<HTMLDivElement>(null);
   const [validationSnackbar, setValidationSnackbar] = useState(false);
-
-  // Color picker state
-  const [colorAnchorEl, setColorAnchorEl] = useState<HTMLElement | null>(null);
 
   const validators = useMemo(
     () => ({
@@ -352,48 +322,6 @@ export default function PolicyEditorPage() {
     }
   }, [policy, template, users]);
 
-  // ── Toolbar state sync ────────────────────────────────────────────
-  const updateToolbarState = useCallback(() => {
-    if (!editor) return;
-    try {
-      let blockType = "p";
-      if (editor.isActive("heading", { level: 1 })) blockType = "h1";
-      else if (editor.isActive("heading", { level: 2 })) blockType = "h2";
-      else if (editor.isActive("heading", { level: 3 })) blockType = "h3";
-      else if (editor.isActive("blockquote")) blockType = "blockquote";
-
-      setCurrentBlockType(blockType);
-      setToolbarState({
-        "bold": editor.isActive("bold"),
-        "italic": editor.isActive("italic"),
-        "underline": editor.isActive("underline"),
-        "strike": editor.isActive("strike"),
-        "ol": editor.isActive("orderedList"),
-        "ul": editor.isActive("bulletList"),
-        "align-left": editor.isActive({ textAlign: "left" }),
-        "align-center": editor.isActive({ textAlign: "center" }),
-        "align-right": editor.isActive({ textAlign: "right" }),
-        "link": editor.isActive("link"),
-        "highlight": editor.isActive("highlight"),
-        "blockquote": blockType === "blockquote",
-        "code": editor.isActive("codeBlock"),
-        "undo": false,
-        "redo": false,
-        "image": false,
-        "table": editor.isActive("table"),
-        "hr": false,
-        "taskList": editor.isActive("taskList"),
-        "superscript": editor.isActive("superscript"),
-        "subscript": editor.isActive("subscript"),
-        "color": false,
-        "search": false,
-      });
-    } catch {
-      // ignore
-    }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
-
   // ── Compute initial editor content ──────────────────────────────
   const initialContent = (() => {
     const raw = policy?.content_html || template?.content || "";
@@ -435,9 +363,7 @@ export default function PolicyEditorPage() {
       onUpdate: ({ editor: e }) => {
         if (isLoadingContentRef.current) return;
         setFormData((prev) => ({ ...prev, content: e.getHTML() }));
-        updateToolbarState();
       },
-      onSelectionUpdate: () => updateToolbarState(),
       editorProps: {
         handleDrop: (view, event, _slice, moved) => {
           if (moved || !event.dataTransfer?.files?.length) return false;
@@ -533,38 +459,6 @@ export default function PolicyEditorPage() {
     }
   };
 
-  // ── Block type change ─────────────────────────────────────────────
-  const handleBlockTypeChange = (event: { target: { value: string | number } }) => {
-    const newType = String(event.target.value);
-    setCurrentBlockType(newType);
-    if (!editor) return;
-    if (newType === "p") editor.chain().focus().setParagraph().run();
-    else if (newType === "h1") editor.chain().focus().toggleHeading({ level: 1 }).run();
-    else if (newType === "h2") editor.chain().focus().toggleHeading({ level: 2 }).run();
-    else if (newType === "h3") editor.chain().focus().toggleHeading({ level: 3 }).run();
-    setTimeout(() => updateToolbarState(), 0);
-  };
-
-  // ── Color palette ────────────────────────────────────────────────
-  const colorPalette = [
-    "text.black",
-    "text.secondary",
-    "text.tertiary",
-    "text.icon",
-    "#dc2626",
-    "#ea580c",
-    "#d97706",
-    "#ca8a04",
-    "#16a34a",
-    "#059669",
-    "#0d9488",
-    "#0891b2",
-    "#2563eb",
-    "#4f46e5",
-    "#7c3aed",
-    "#9333ea",
-  ];
-
   const {
     searchAnchorEl,
     openFindReplace,
@@ -579,165 +473,6 @@ export default function PolicyEditorPage() {
     handleReplaceCurrent,
     handleReplaceAll,
   } = usePolicyFindReplace(editor);
-
-  // ── Toolbar config ────────────────────────────────────────────────
-  const toolbarConfig: Array<{
-    key: ToolbarKey;
-    title: string;
-    icon: React.ReactNode;
-    action: () => void;
-  }> = [
-    {
-      key: "undo",
-      title: "Undo",
-      icon: <Undo2 size={16} />,
-      action: () => editor?.chain().focus().undo().run(),
-    },
-    {
-      key: "redo",
-      title: "Redo",
-      icon: <Redo2 size={16} />,
-      action: () => editor?.chain().focus().redo().run(),
-    },
-    {
-      key: "bold",
-      title: "Bold",
-      icon: <Bold size={16} />,
-      action: () => editor?.chain().focus().toggleBold().run(),
-    },
-    {
-      key: "italic",
-      title: "Italic",
-      icon: <Italic size={16} />,
-      action: () => editor?.chain().focus().toggleItalic().run(),
-    },
-    {
-      key: "underline",
-      title: "Underline",
-      icon: <UnderlineIcon size={16} />,
-      action: () => editor?.chain().focus().toggleUnderline().run(),
-    },
-    {
-      key: "strike",
-      title: "Strikethrough",
-      icon: <Strikethrough size={16} />,
-      action: () => editor?.chain().focus().toggleStrike().run(),
-    },
-    {
-      key: "superscript",
-      title: "Superscript",
-      icon: <SuperscriptIcon size={16} />,
-      action: () => editor?.chain().focus().toggleSuperscript().run(),
-    },
-    {
-      key: "subscript",
-      title: "Subscript",
-      icon: <SubscriptIcon size={16} />,
-      action: () => editor?.chain().focus().toggleSubscript().run(),
-    },
-    {
-      key: "highlight",
-      title: "Highlight",
-      icon: <Highlighter size={16} />,
-      action: () => editor?.chain().focus().toggleHighlight().run(),
-    },
-    {
-      key: "code",
-      title: "Code block",
-      icon: <Code size={16} />,
-      action: () => editor?.chain().focus().toggleCodeBlock().run(),
-    },
-    {
-      key: "ol",
-      title: "Numbered list",
-      icon: <ListOrdered size={16} />,
-      action: () => editor?.chain().focus().toggleOrderedList().run(),
-    },
-    {
-      key: "ul",
-      title: "Bulleted list",
-      icon: <List size={16} />,
-      action: () => editor?.chain().focus().toggleBulletList().run(),
-    },
-    {
-      key: "taskList",
-      title: "Task list",
-      icon: <ListChecks size={16} />,
-      action: () => editor?.chain().focus().toggleTaskList().run(),
-    },
-    {
-      key: "blockquote",
-      title: "Blockquote",
-      icon: <Quote size={16} />,
-      action: () => editor?.chain().focus().toggleBlockquote().run(),
-    },
-    {
-      key: "hr",
-      title: "Horizontal rule",
-      icon: <Minus size={16} />,
-      action: () => editor?.chain().focus().setHorizontalRule().run(),
-    },
-    {
-      key: "align-left",
-      title: "Align left",
-      icon: <AlignLeft size={16} />,
-      action: () => editor?.chain().focus().setTextAlign("left").run(),
-    },
-    {
-      key: "align-center",
-      title: "Align center",
-      icon: <AlignCenter size={16} />,
-      action: () => editor?.chain().focus().setTextAlign("center").run(),
-    },
-    {
-      key: "align-right",
-      title: "Align right",
-      icon: <AlignRight size={16} />,
-      action: () => editor?.chain().focus().setTextAlign("right").run(),
-    },
-    {
-      key: "link",
-      title: editor?.isActive("link") ? "Remove link" : "Insert link",
-      icon: editor?.isActive("link") ? <Unlink size={16} /> : <Link size={16} />,
-      action: () => {
-        if (!editor) return;
-        if (editor.isActive("link")) {
-          editor.chain().focus().unsetLink().run();
-          return;
-        }
-        const { from, to } = editor.state.selection;
-        setSelectedTextForLink(from !== to ? editor.state.doc.textBetween(from, to) : "");
-        setOpenLink(true);
-      },
-    },
-    {
-      key: "image",
-      title: isUploadingImage ? "Uploading..." : "Insert image",
-      icon: <Image size={16} />,
-      action: () => {
-        if (!isUploadingImage) imageInputRef.current?.click();
-      },
-    },
-    {
-      key: "table",
-      title: "Insert table",
-      icon: <Table size={16} />,
-      action: () =>
-        editor?.chain().focus().insertTable({ rows: 3, cols: 4, withHeaderRow: true }).run(),
-    },
-    {
-      key: "color",
-      title: "Text color",
-      icon: <Palette size={16} />,
-      action: () => {}, // handled via popover click
-    },
-    {
-      key: "search",
-      title: "Find & replace",
-      icon: <Search size={16} />,
-      action: () => {}, // handled via popover click
-    },
-  ];
 
   // ── Save ──────────────────────────────────────────────────────────
   const save = async () => {
@@ -1384,131 +1119,16 @@ export default function PolicyEditorPage() {
             />
           </Stack>
 
-          {/* ── Toolbar ──────────────────────────────────────────────── */}
-          <Box
-            sx={{
-              display: "flex",
-              flexWrap: "wrap",
-              gap: 0.5,
-              mb: "8px",
-              alignItems: "center",
-              flexShrink: 0,
+          <PolicyEditorToolbar
+            editor={editor}
+            isUploadingImage={isUploadingImage}
+            onInsertImage={() => imageInputRef.current?.click()}
+            onOpenLink={(selectedText) => {
+              setSelectedTextForLink(selectedText);
+              setOpenLink(true);
             }}
-          >
-            {/* Block type dropdown */}
-            <Box sx={{ mr: 2 }}>
-              <Select
-                id="block-type-select"
-                value={currentBlockType}
-                onChange={handleBlockTypeChange}
-                items={[
-                  { _id: "p", name: "Text" },
-                  { _id: "h1", name: "Header 1" },
-                  { _id: "h2", name: "Header 2" },
-                  { _id: "h3", name: "Header 3" },
-                ]}
-                sx={{ width: 120, height: "34px" }}
-              />
-            </Box>
-
-            {toolbarConfig.map(({ key, title, icon, action }) => (
-              <Tooltip key={key} title={title}>
-                <IconButton
-                  onClick={(e) => {
-                    if (key === "color") {
-                      setColorAnchorEl(e.currentTarget);
-                      return;
-                    }
-                    if (key === "search") {
-                      openFindReplace(e.currentTarget);
-                      return;
-                    }
-                    action?.();
-                    setTimeout(() => updateToolbarState(), 0);
-                  }}
-                  size="small"
-                  sx={{
-                    "padding": "6px",
-                    "borderRadius": "3px",
-                    "backgroundColor": toolbarState[key] ? "#E0F7FA" : "background.main",
-                    "border": "1px solid",
-                    "borderColor": toolbarState[key] ? "brand.primary" : "transparent",
-                    "&:hover": { backgroundColor: "background.surface" },
-                  }}
-                >
-                  {icon}
-                </IconButton>
-              </Tooltip>
-            ))}
-
-            {/* Character / word count */}
-            {editor && (
-              <Box sx={{ ml: "auto", display: "flex", gap: 2, alignItems: "center" }}>
-                <Typography sx={{ fontSize: 11, color: "text.muted" }}>
-                  {editor.storage.characterCount.words()} words
-                </Typography>
-                <Typography sx={{ fontSize: 11, color: "text.muted" }}>
-                  {editor.storage.characterCount.characters()} characters
-                </Typography>
-              </Box>
-            )}
-          </Box>
-
-          {/* ── Color picker popover ────────────────────────────────── */}
-          <Popover
-            open={Boolean(colorAnchorEl)}
-            anchorEl={colorAnchorEl}
-            onClose={() => setColorAnchorEl(null)}
-            anchorOrigin={{ vertical: "bottom", horizontal: "left" }}
-            transformOrigin={{ vertical: "top", horizontal: "left" }}
-            slotProps={{
-              paper: {
-                sx: {
-                  p: 1.5,
-                  borderRadius: "6px",
-                  border: "1px solid #d0d5dd",
-                  boxShadow: "0 4px 12px rgba(0,0,0,0.1)",
-                },
-              },
-            }}
-          >
-            <Box sx={{ display: "grid", gridTemplateColumns: "repeat(8, 1fr)", gap: "4px" }}>
-              {colorPalette.map((c) => (
-                <Box
-                  key={c}
-                  onClick={() => {
-                    editor?.chain().focus().setColor(c).run();
-                    setColorAnchorEl(null);
-                  }}
-                  sx={{
-                    "width": 24,
-                    "height": 24,
-                    "borderRadius": "4px",
-                    "backgroundColor": c,
-                    "cursor": "pointer",
-                    "border": "1px solid rgba(0,0,0,0.1)",
-                    "&:hover": { transform: "scale(1.15)", transition: "transform 0.1s" },
-                  }}
-                />
-              ))}
-            </Box>
-            <Box
-              onClick={() => {
-                editor?.chain().focus().unsetColor().run();
-                setColorAnchorEl(null);
-              }}
-              sx={{
-                "mt": 1,
-                "textAlign": "center",
-                "fontSize": 11,
-                "color": "text.icon",
-                "cursor": "pointer",
-                "&:hover": { color: "text.secondary" },
-              }}
-            >
-              Reset to default
-            </Box>
-          </Popover>
+            onOpenFindReplace={openFindReplace}
+          />
 
           <FindReplacePopover
             anchorEl={searchAnchorEl}

--- a/Clients/src/presentation/pages/PolicyDashboard/PolicyEditorPage.tsx
+++ b/Clients/src/presentation/pages/PolicyDashboard/PolicyEditorPage.tsx
@@ -26,28 +26,12 @@ import {
   Box,
   Stack,
   Typography,
-  IconButton,
-  Tooltip,
   useTheme,
   Skeleton,
-  Popover,
   Snackbar,
   Alert,
-  TextField,
   GlobalStyles,
 } from "@mui/material";
-import {
-  SaveIcon,
-  History as HistoryIcon,
-  FileText,
-  FileDown,
-  Loader2,
-  X,
-  ArrowLeft,
-  Check,
-  Pencil,
-  Upload,
-} from "lucide-react";
 
 import { CustomizableButton } from "../../components/button/customizable-button";
 import { HistorySidebar } from "../../components/Common/HistorySidebar";
@@ -82,6 +66,7 @@ import { usePolicyFindReplace } from "./PolicyEditor/usePolicyFindReplace";
 import { FindReplacePopover } from "./PolicyEditor/FindReplacePopover";
 import { PolicyTableBubbleMenu } from "./PolicyEditor/PolicyTableBubbleMenu";
 import { PolicyEditorToolbar } from "./PolicyEditor/PolicyEditorToolbar";
+import { PolicyEditorHeader } from "./PolicyEditor/PolicyEditorHeader";
 
 // ── Component ─────────────────────────────────────────────────────────
 export default function PolicyEditorPage() {
@@ -127,9 +112,7 @@ export default function PolicyEditorPage() {
   const [exportError, setExportError] = useState<string | null>(null);
   const [isImporting, setIsImporting] = useState(false);
   const [importError, setImportError] = useState<string | null>(null);
-  const [exportAnchorEl, setExportAnchorEl] = useState<HTMLElement | null>(null);
   const [pendingImportFile, setPendingImportFile] = useState<File | null>(null);
-  const docxInputRef = useRef<HTMLInputElement>(null);
   const [isSaving, setIsSaving] = useState(false);
   const [saveSuccess, setSaveSuccess] = useState(false);
   const [serverErrors, setServerErrors] = useState<PolicyFormErrors>({});
@@ -765,329 +748,41 @@ export default function PolicyEditorPage() {
             overflow: "hidden",
           }}
         >
-          <Stack
-            direction="row"
-            justifyContent="space-between"
-            alignItems="center"
-            sx={{ mb: "8px", flexShrink: 0 }}
-          >
-            <Stack direction="row" alignItems="center" gap={1}>
-              <Tooltip title="Back to policies" arrow>
-                <IconButton
-                  onClick={() => navigate("/policies")}
-                  size="small"
-                  sx={{
-                    "padding": "4px",
-                    "borderRadius": "4px",
-                    "color": "text.muted",
-                    "&:hover": { backgroundColor: "#F2F4F7", color: "text.secondary" },
-                  }}
-                >
-                  <ArrowLeft size={18} />
-                </IconButton>
-              </Tooltip>
-              <Box
-                sx={{
-                  "display": "inline-flex",
-                  "alignItems": "center",
-                  "gap": 0.5,
-                  "&:hover .edit-title-icon": {
-                    opacity: 1,
-                  },
-                }}
-              >
-                {isEditingTitle ? (
-                  <>
-                    <TextField
-                      value={editedTitle}
-                      onChange={(e) => setEditedTitle(e.target.value)}
-                      onKeyDown={(e) => {
-                        if (e.key === "Enter") handleSaveTitle();
-                        if (e.key === "Escape") handleCancelEditTitle();
-                      }}
-                      placeholder="Policy title"
-                      variant="outlined"
-                      size="small"
-                      autoFocus
-                      disabled={isSavingTitle}
-                      error={!!displayErrors.title}
-                      helperText={displayErrors.title}
-                      inputProps={{ maxLength: 128 }}
-                      sx={{
-                        "minWidth": "400px",
-                        "& .MuiOutlinedInput-root": {
-                          fontSize: "16px",
-                          fontWeight: 600,
-                        },
-                      }}
-                    />
-                    <IconButton
-                      size="small"
-                      onClick={handleSaveTitle}
-                      disabled={!editedTitle.trim() || isSavingTitle}
-                      sx={{ color: "brand.primary" }}
-                    >
-                      {isSavingTitle ? (
-                        <Loader2 size={18} style={{ animation: "spin 1s linear infinite" }} />
-                      ) : (
-                        <Check size={18} />
-                      )}
-                    </IconButton>
-                    <IconButton
-                      size="small"
-                      onClick={handleCancelEditTitle}
-                      disabled={isSavingTitle}
-                      sx={{ color: "text.disabled" }}
-                    >
-                      <X size={18} />
-                    </IconButton>
-                  </>
-                ) : (
-                  <>
-                    <Typography sx={{ fontSize: 16, color: "text.secondary", fontWeight: 600 }}>
-                      {pageTitle}
-                    </Typography>
-                    <IconButton
-                      size="small"
-                      onClick={handleStartEditTitle}
-                      className="edit-title-icon"
-                      sx={{
-                        // "opacity": 0,
-                        "transition": "opacity 0.2s",
-                        "color": "text.disabled",
-                        "&:hover": {
-                          color: "brand.primary",
-                          backgroundColor: "rgba(19, 113, 91, 0.1)",
-                        },
-                      }}
-                    >
-                      <Pencil size={14} />
-                    </IconButton>
-                  </>
-                )}
-              </Box>
-            </Stack>
-
-            <Stack direction="row" gap="8px" alignItems="center">
-              {/* Export error */}
-              {exportError && (
-                <Typography
-                  sx={{
-                    fontSize: 12,
-                    color: theme.palette.status?.error?.text || "#f04438",
-                    backgroundColor: theme.palette.status?.error?.bg || "#f9eced",
-                    px: 1.5,
-                    py: 0.75,
-                    borderRadius: "4px",
-                  }}
-                >
-                  {exportError}
-                </Typography>
-              )}
-
-              {/* History toggle */}
-              {!isNew && policy?.id && (
-                <Tooltip title="Activity history" arrow>
-                  <IconButton
-                    onClick={() => setIsHistorySidebarOpen((prev) => !prev)}
-                    size="small"
-                    sx={{
-                      "color": isHistorySidebarOpen ? "brand.primary" : "text.muted",
-                      "padding": "4px",
-                      "borderRadius": "4px",
-                      "backgroundColor": isHistorySidebarOpen ? "#E6F4F1" : "transparent",
-                      "&:hover": {
-                        backgroundColor: isHistorySidebarOpen ? "#D1EDE6" : "#F2F4F7",
-                      },
-                    }}
-                  >
-                    <HistoryIcon size={16} />
-                  </IconButton>
-                </Tooltip>
-              )}
-
-              {/* Export dropdown + Import button */}
-              {!isNew && policy?.id && (
-                <>
-                  <CustomizableButton
-                    variant="outlined"
-                    text={
-                      isExportingPDF
-                        ? "Exporting PDF..."
-                        : isExportingDOCX
-                          ? "Exporting Word..."
-                          : "Export"
-                    }
-                    isDisabled={isExportingPDF || isExportingDOCX}
-                    sx={{
-                      "backgroundColor": "background.main",
-                      "border": "1px solid #d0d5dd",
-                      "color": "text.secondary",
-                      "gap": 1,
-                      "minWidth": "90px",
-                      "&:hover": {
-                        backgroundColor: "background.accent",
-                        borderColor: "text.muted",
-                      },
-                      "&:disabled": {
-                        backgroundColor: "background.accent",
-                        borderColor: "#E4E7EC",
-                        color: "text.muted",
-                      },
-                    }}
-                    onClick={(e: React.MouseEvent<HTMLElement>) =>
-                      setExportAnchorEl(e.currentTarget)
-                    }
-                    icon={
-                      isExportingPDF || isExportingDOCX ? (
-                        <Loader2 size={16} style={{ animation: "spin 1s linear infinite" }} />
-                      ) : (
-                        <FileDown size={16} />
-                      )
-                    }
-                  />
-                  <Popover
-                    open={Boolean(exportAnchorEl)}
-                    anchorEl={exportAnchorEl}
-                    onClose={() => setExportAnchorEl(null)}
-                    anchorOrigin={{ vertical: "bottom", horizontal: "left" }}
-                    transformOrigin={{ vertical: "top", horizontal: "left" }}
-                    slotProps={{
-                      paper: {
-                        sx: {
-                          mt: 0.5,
-                          borderRadius: "4px",
-                          border: "1px solid #E4E7EC",
-                          boxShadow: "0 4px 12px rgba(0,0,0,0.08)",
-                          minWidth: 140,
-                          p: 0.5,
-                          display: "flex",
-                          flexDirection: "column",
-                        },
-                      },
-                    }}
-                  >
-                    {[
-                      {
-                        icon: <FileText size={14} />,
-                        label: "Download as PDF",
-                        format: "pdf" as const,
-                      },
-                      {
-                        icon: <FileDown size={14} />,
-                        label: "Download as Word",
-                        format: "docx" as const,
-                      },
-                    ].map(({ icon, label, format }) => (
-                      <Box
-                        key={format}
-                        component="button"
-                        onClick={() => {
-                          setExportAnchorEl(null);
-                          downloadExport(format);
-                        }}
-                        sx={{
-                          "display": "flex",
-                          "alignItems": "center",
-                          "gap": 1,
-                          "px": 1.5,
-                          "py": 1,
-                          "border": "none",
-                          "background": "none",
-                          "cursor": "pointer",
-                          "borderRadius": "4px",
-                          "fontSize": 13,
-                          "color": "text.secondary",
-                          "width": "100%",
-                          "textAlign": "left",
-                          "&:hover": { backgroundColor: "#F2F4F7" },
-                        }}
-                      >
-                        {icon}
-                        {label}
-                      </Box>
-                    ))}
-                  </Popover>
-                </>
-              )}
-
-              {/* Import DOCX */}
-              <CustomizableButton
-                variant="outlined"
-                text={isImporting ? "Importing..." : "Import"}
-                isDisabled={isImporting}
-                sx={{
-                  "backgroundColor": "background.main",
-                  "border": "1px solid #d0d5dd",
-                  "color": "text.secondary",
-                  "gap": 1,
-                  "minWidth": "90px",
-                  "&:hover": {
-                    backgroundColor: "background.accent",
-                    borderColor: "text.muted",
-                  },
-                  "&:disabled": {
-                    backgroundColor: "background.accent",
-                    borderColor: "#E4E7EC",
-                    color: "text.muted",
-                  },
-                }}
-                onClick={() => docxInputRef.current?.click()}
-                icon={
-                  isImporting ? (
-                    <Loader2 size={16} style={{ animation: "spin 1s linear infinite" }} />
-                  ) : (
-                    <Upload size={16} />
-                  )
-                }
-              />
-              <input
-                ref={docxInputRef}
-                type="file"
-                accept=".docx"
-                style={{ display: "none" }}
-                onChange={handleDocxFileSelect}
-              />
-
-              {/* Save */}
-              <CustomizableButton
-                variant="contained"
-                text={
-                  isSaving
-                    ? "Saving..."
-                    : saveSuccess
-                      ? "Saved"
-                      : isNew && template
-                        ? "Save in organizational policies"
-                        : "Save"
-                }
-                isDisabled={isSaving || customFieldsGate.blocked}
-                sx={{
-                  "backgroundColor": saveSuccess ? "#079455" : "brand.primary",
-                  "border": `1px solid ${saveSuccess ? "#079455" : "#13715B"}`,
-                  "gap": 2,
-                  "&:hover": {
-                    backgroundColor: saveSuccess ? "#079455" : "#0F5B4D",
-                    borderColor: saveSuccess ? "#079455" : "#0F5B4D",
-                  },
-                  "&:disabled": {
-                    backgroundColor: "brand.primary",
-                    opacity: 0.7,
-                  },
-                }}
-                onClick={save}
-                icon={
-                  isSaving ? (
-                    <Loader2 size={16} style={{ animation: "spin 1s linear infinite" }} />
-                  ) : saveSuccess ? (
-                    <Check size={16} />
-                  ) : (
-                    <SaveIcon size={16} />
-                  )
-                }
-              />
-            </Stack>
-          </Stack>
+          <PolicyEditorHeader
+            pageTitle={pageTitle}
+            isEditingTitle={isEditingTitle}
+            editedTitle={editedTitle}
+            isSavingTitle={isSavingTitle}
+            titleError={displayErrors.title}
+            onBack={() => navigate("/policies")}
+            onStartEditTitle={handleStartEditTitle}
+            onEditedTitleChange={setEditedTitle}
+            onSaveTitle={handleSaveTitle}
+            onCancelEditTitle={handleCancelEditTitle}
+            isNew={isNew}
+            hasPolicyId={Boolean(policy?.id)}
+            isHistorySidebarOpen={isHistorySidebarOpen}
+            onToggleHistorySidebar={() => setIsHistorySidebarOpen((prev) => !prev)}
+            isExportingPDF={isExportingPDF}
+            isExportingDOCX={isExportingDOCX}
+            exportError={exportError}
+            onDownloadExport={downloadExport}
+            isImporting={isImporting}
+            onDocxFileSelect={handleDocxFileSelect}
+            isSaving={isSaving}
+            saveSuccess={saveSuccess}
+            isSaveDisabled={isSaving || customFieldsGate.blocked}
+            saveButtonText={
+              isSaving
+                ? "Saving..."
+                : saveSuccess
+                  ? "Saved"
+                  : isNew && template
+                    ? "Save in organizational policies"
+                    : "Save"
+            }
+            onSave={save}
+          />
 
           {/* ── Metadata form ────────────────────────────────────────── */}
           <Box


### PR DESCRIPTION
## Describe your changes

Finish splitting PolicyEditorPage by extracting the page header chrome into co-located components, with no intended UX or behavior changes. Depends on part 2 (refactor/policy-editor-split-2).

What moved

Header wrapper (PolicyEditorHeader)
Title area: back control + inline title editing (PolicyEditorTitleArea)
Actions bar: history, export, import, save (PolicyEditorActionsBar)

## Write your issue number after "Fixes "

Fixes #4340 

## Please ensure all items are checked off before requesting a review:

- [x] I deployed the code locally.
- [x] I have performed a self-review of my code.
- [x] I have included the issue # in the PR.
- [x] I have labelled the PR correctly.
- [x] The issue I am working on is assigned to me.
- [x] I have avoided using hardcoded values to ensure scalability and maintain consistency across the application.
- [x] I have ensured that font sizes, color choices, and other UI elements are referenced from the theme.
- [x] My pull request is focused and addresses a single, specific feature.
- [ ] If there are UI changes, I have attached a screenshot or video to this PR.
- [ ] If I added or modified an API endpoint, the change is reflected in the generated OpenAPI spec (`npm run generate:swagger`).
- [ ] If the endpoint requires authentication, it uses `authenticateJWT` and the generated spec declares `bearerAuth` security.
- [ ] I ran `npm run check:api-drift` and committed the regenerated `swagger.yaml` and `endpoints.ts`.
- [ ] If this PR adds or modifies an organization-scoped table, the [tenant isolation registry](Servers/tests/integration/tenant-isolation/tenantIsolation.registry.ts) and [test matrix](Servers/tests/integration/tenant-isolation) are updated. See the [tenant isolation runbook](docs/technical/security/tenant-isolation.md) for details.
