### PR TITLE
Policy Editor: Optional Team Member's Input

### DIFF
--- a/Clients/src/presentation/pages/PolicyDashboard/PolicyEditorPage.tsx
+++ b/Clients/src/presentation/pages/PolicyDashboard/PolicyEditorPage.tsx
@@ -142,12 +142,7 @@ export default function PolicyEditorPage() {
         const r = checkStringValidation("Next review date", (v as string) || "", 1);
         return r.accepted ? "" : r.message;
       },
-      assignedReviewers: (v: unknown) => {
-        const reviewers = v as PolicyFormData["assignedReviewers"];
-        return reviewers.filter((u) => u.id !== undefined).length === 0
-          ? "At least one reviewer is required."
-          : "";
-      },
+      assignedReviewers: () => "",
     }),
     [],
   );


### PR DESCRIPTION
## Policy Editor: Optional Team Member's Input

When trying to test the editor and saving a new record, although the "Team members" field was not set as required, validations didn't let the user to save. Now it is fixed

## Please ensure all items are checked off before requesting a review:

- [x] I deployed the code locally.
- [x] I have performed a self-review of my code.
- [x] I have included the issue # in the PR.
- [x] I have labelled the PR correctly.
- [x] The issue I am working on is assigned to me.
- [x] I have avoided using hardcoded values to ensure scalability and maintain consistency across the application.
- [x] I have ensured that font sizes, color choices, and other UI elements are referenced from the theme.
- [x] My pull request is focused and addresses a single, specific feature.
- [x] If there are UI changes, I have attached a screenshot or video to this PR.
- [x] If I added or modified an API endpoint, the change is reflected in the generated OpenAPI spec (`npm run generate:swagger`).
- [x] If the endpoint requires authentication, it uses `authenticateJWT` and the generated spec declares `bearerAuth` security.
- [x] I ran `npm run check:api-drift` and committed the regenerated `swagger.yaml` and `endpoints.ts`.
- [x] If this PR adds or modifies an organization-scoped table, the [tenant isolation registry](Servers/tests/integration/tenant-isolation/tenantIsolation.registry.ts) and [test matrix](Servers/tests/integration/tenant-isolation) are updated. See the [tenant isolation runbook](docs/technical/security/tenant-isolation.md) for details.

<img width="1361" height="342" alt="image" src="https://github.com/user-attachments/assets/bae2f05d-c580-49bd-9db9-3658de38720d" />
