### PR TITLE
Potential fix for code scanning alert no. 1181: Server-side request forgery

### DIFF
--- a/Servers/routes/plugin.route.ts
+++ b/Servers/routes/plugin.route.ts
@@ -44,8 +44,18 @@ router.post("/:key/test-connection", authenticateJWT, testPluginConnection);
 
 // Serve plugin UI bundles from temp/plugins/{key}/ui/dist/
 // If bundle doesn't exist locally, download it from the marketplace
+const isValidPluginKey = (value: string) => /^[a-z0-9_-]+$/.test(value);
+const isValidBundleFilename = (value: string) =>
+  /^[A-Za-z0-9._-]+$/.test(value) && !value.includes("..") && !value.includes("/") && !value.includes("\\");
+
 router.get("/:key/ui/dist/:filename", async (req, res) => {
   const { key, filename } = req.params;
+
+  if (!isValidPluginKey(key) || !isValidBundleFilename(filename)) {
+    res.status(400).json({ error: "Invalid plugin key or bundle filename" });
+    return;
+  }
+
   const bundlePath = path.join(__dirname, "../../temp/plugins", key, "ui", "dist", filename);
   console.log(
     "[Plugin UI] Requested:",
@@ -61,7 +71,10 @@ router.get("/:key/ui/dist/:filename", async (req, res) => {
   if (!fs.existsSync(bundlePath)) {
     try {
       console.log(`[Plugin UI] Bundle not found locally, downloading from marketplace...`);
-      const bundleUrl = `${PLUGIN_MARKETPLACE_BASE_URL}/plugins/${key}/ui/dist/${filename}`;
+      const bundleUrl = new URL(
+        `/plugins/${encodeURIComponent(key)}/ui/dist/${encodeURIComponent(filename)}`,
+        PLUGIN_MARKETPLACE_BASE_URL,
+      ).toString();
 
       const response = await axios.get(bundleUrl, {
         timeout: 30000,

--- a/Servers/routes/plugin.route.ts
+++ b/Servers/routes/plugin.route.ts
@@ -46,7 +46,10 @@ router.post("/:key/test-connection", authenticateJWT, testPluginConnection);
 // If bundle doesn't exist locally, download it from the marketplace
 const isValidPluginKey = (value: string) => /^[a-z0-9_-]+$/.test(value);
 const isValidBundleFilename = (value: string) =>
-  /^[A-Za-z0-9._-]+$/.test(value) && !value.includes("..") && !value.includes("/") && !value.includes("\\");
+  /^[A-Za-z0-9._-]+$/.test(value) &&
+  !value.includes("..") &&
+  !value.includes("/") &&
+  !value.includes("\\");
 
 router.get("/:key/ui/dist/:filename", async (req, res) => {
   const { key, filename } = req.params;


### PR DESCRIPTION
Potential fix for [https://github.com/verifywise-ai/verifywise/security/code-scanning/1181](https://github.com/verifywise-ai/verifywise/security/code-scanning/1181)

To fix this without changing intended functionality, validate `key` and `filename` against strict, server-defined patterns before using them in either remote URL construction or local filesystem paths, and construct the remote URL using `URL` + `encodeURIComponent` for path segments.

**Best approach for this file (`Servers/routes/plugin.route.ts`):**
1. Add small helper validators near the route:
   - `isValidPluginKey`: allow only expected plugin key chars (e.g. lowercase letters, digits, `_`, `-`).
   - `isValidBundleFilename`: allow only JS bundle-style names (`[A-Za-z0-9._-]+`) and explicitly reject `..`, `/`, `\`.
2. In `router.get("/:key/ui/dist/:filename", ...)`, validate params immediately after extraction; return `400` on invalid input.
3. Replace string interpolation for `bundleUrl` with `new URL(...)` and encoded path segments:
   - `new URL(\`/plugins/${encodeURIComponent(key)}/ui/dist/${encodeURIComponent(filename)}\`, PLUGIN_MARKETPLACE_BASE_URL).toString()`
4. Keep existing behavior otherwise (same timeout, responseType, save logic, response headers).

This single change addresses both variants (`key` and `filename` taint to request URL sink) and also hardens the local file path usage.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
