### PR TITLE
refactor(evals): extract pure helpers from NewExperimentModal

### DIFF
--- a/Clients/src/presentation/pages/EvalsDashboard/NewExperiment/experimentIcons.tsx
+++ b/Clients/src/presentation/pages/EvalsDashboard/NewExperiment/experimentIcons.tsx
@@ -1,0 +1,26 @@
+/**
+ * @fileoverview Inline provider/icon wrappers used by the New Experiment wizard.
+ * Large SVGs are loaded from public/ to avoid bundling them into the JS chunk.
+ *
+ * @module pages/EvalsDashboard/NewExperiment/experimentIcons
+ */
+
+export const HuggingFaceLogo = (props: React.SVGProps<SVGSVGElement>) => (
+  <img
+    src="/assets/icons/huggingface_logo.svg"
+    alt="Hugging Face"
+    width={props.width || 24}
+    height={props.height || 24}
+    style={{ display: "inline-block" }}
+  />
+);
+
+export const BuildIcon = (props: React.SVGProps<SVGSVGElement>) => (
+  <img
+    src="/assets/icons/build.svg"
+    alt="Build"
+    width={props.width || 24}
+    height={props.height || 24}
+    style={{ display: "inline-block" }}
+  />
+);

--- a/Clients/src/presentation/pages/EvalsDashboard/NewExperiment/experimentNameHelpers.ts
+++ b/Clients/src/presentation/pages/EvalsDashboard/NewExperiment/experimentNameHelpers.ts
@@ -1,0 +1,56 @@
+/**
+ * @fileoverview Pure helpers for deriving default experiment and dataset names.
+ *
+ * @module pages/EvalsDashboard/NewExperiment/experimentNameHelpers
+ */
+
+/**
+ * Strip noise from a model identifier so it reads cleanly as part of an
+ * experiment name:
+ *   "openai/gpt-4o-mini"            -> "gpt-4o-mini"
+ *   "mistralai/mistral-medium-3-5"  -> "mistral-medium-3-5"
+ *   "claude-3-5-sonnet-20241022"    -> "claude-3-5-sonnet"
+ */
+export const shortenForExperimentName = (s?: string | null): string => {
+  if (!s) return "";
+  const dateless = s.replace(/-\d{8}$/, "").replace(/-\d{4}-\d{2}-\d{2}$/, "");
+  const slashIdx = dateless.lastIndexOf("/");
+  return slashIdx >= 0 ? dateless.slice(slashIdx + 1) : dateless;
+};
+
+/**
+ * Build the default name for a new experiment as `<model> × <dataset>`.
+ * If that exact name is already used in this project, append #2, #3, ...
+ * until we hit one that's free.
+ */
+export const generateDefaultExperimentName = (
+  modelName: string,
+  datasetName: string,
+  existing: readonly string[],
+): string => {
+  const m = shortenForExperimentName(modelName) || "model";
+  const d = (datasetName || "dataset").trim() || "dataset";
+  const base = `${m} × ${d}`;
+  if (!existing.includes(base)) return base;
+  let n = 2;
+  while (existing.includes(`${base} #${n}`)) n++;
+  return `${base} #${n}`;
+};
+
+/**
+ * Derive a human-friendly dataset name from a preset filename like
+ * "chatbot/chatbot_coding_helper.json" -> "Chatbot Coding Helper".
+ */
+export const datasetNameFromPresetPath = (path?: string | null): string => {
+  if (!path) return "";
+  const fileName =
+    path
+      .split("/")
+      .pop()
+      ?.replace(/\.json$/i, "") || "";
+  return fileName
+    .split("_")
+    .filter(Boolean)
+    .map((w) => w.charAt(0).toUpperCase() + w.slice(1))
+    .join(" ");
+};

--- a/Clients/src/presentation/pages/EvalsDashboard/NewExperiment/newExperimentConfig.ts
+++ b/Clients/src/presentation/pages/EvalsDashboard/NewExperiment/newExperimentConfig.ts
@@ -1,0 +1,34 @@
+/**
+ * @fileoverview Shared constants for the New Experiment wizard.
+ *
+ * @module pages/EvalsDashboard/NewExperiment/newExperimentConfig
+ */
+
+export type ProviderType =
+  | "openai"
+  | "anthropic"
+  | "google"
+  | "xai"
+  | "huggingface"
+  | "mistral"
+  | "ollama"
+  | "local"
+  | "custom_api"
+  | "openrouter";
+
+export type JudgeMode = "scorer" | "standard" | "both";
+
+/** Step labels shown in the StepperModal header. */
+export const WIZARD_STEPS = ["Model", "Dataset", "Scorer / Judge", "Metrics"] as const;
+
+/**
+ * Model-under-evaluation providers that do not require a cloud API key
+ * (local runtimes / on-prem). Used by step-0 gating.
+ */
+export const MODEL_PROVIDERS_WITHOUT_API_KEY = ["ollama", "local"] as const;
+
+/**
+ * Scorer judge-model providers that do not require a saved org API key.
+ * Used when computing missing keys for custom scorers.
+ */
+export const SCORER_PROVIDERS_WITHOUT_API_KEY = ["self-hosted", "ollama"] as const;

--- a/Clients/src/presentation/pages/EvalsDashboard/NewExperiment/stepValidation.ts
+++ b/Clients/src/presentation/pages/EvalsDashboard/NewExperiment/stepValidation.ts
@@ -1,0 +1,163 @@
+/**
+ * @fileoverview Pure gating helpers for the New Experiment wizard Next button.
+ *
+ * @module pages/EvalsDashboard/NewExperiment/stepValidation
+ */
+
+import {
+  JudgeMode,
+  MODEL_PROVIDERS_WITHOUT_API_KEY,
+  SCORER_PROVIDERS_WITHOUT_API_KEY,
+} from "./newExperimentConfig";
+
+export interface ScorerForValidation {
+  id: string;
+  config?: {
+    judgeModel?: { provider?: string } | string | null;
+  } | null;
+}
+
+export interface ApiKeyForValidation {
+  provider: string;
+}
+
+export interface ModelConfigForValidation {
+  name: string;
+  accessMethod: string;
+  endpointUrl: string;
+  apiKey: string;
+}
+
+export interface JudgeLlmConfigForValidation {
+  provider: string;
+  model: string;
+  endpointUrl: string;
+}
+
+export interface ModelProviderForValidation {
+  needsUrl?: boolean;
+}
+
+/**
+ * Providers required by selected scorers that have no saved API key in org
+ * settings. Self-hosted / Ollama scorers are excluded since they don't need a
+ * cloud key.
+ */
+export function getMissingKeyProviders(params: {
+  judgeMode: JudgeMode;
+  selectedScorerIds: string[];
+  userScorers: ScorerForValidation[];
+  configuredApiKeys: ApiKeyForValidation[];
+}): string[] {
+  const { judgeMode, selectedScorerIds, userScorers, configuredApiKeys } = params;
+  if (judgeMode !== "scorer" && judgeMode !== "both") return [];
+
+  const scorersToCheck =
+    selectedScorerIds.length > 0
+      ? userScorers.filter((s) => selectedScorerIds.includes(s.id))
+      : userScorers;
+
+  const missing: string[] = [];
+  for (const scorer of scorersToCheck) {
+    const judgeModel = scorer.config?.judgeModel;
+    if (typeof judgeModel === "object" && judgeModel?.provider) {
+      const provider = judgeModel.provider.toLowerCase();
+      if (
+        !(SCORER_PROVIDERS_WITHOUT_API_KEY as readonly string[]).includes(provider) &&
+        !configuredApiKeys.some((k) => k.provider === provider) &&
+        !missing.includes(provider)
+      ) {
+        missing.push(provider);
+      }
+    }
+  }
+  return missing;
+}
+
+export function canProceedToNextStep(params: {
+  activeStep: number;
+  selectedSavedModelId: string | null;
+  model: ModelConfigForValidation;
+  selectedModelProvider?: ModelProviderForValidation | null;
+  hasApiKey: (providerId: string) => boolean;
+  datasetPromptCount: number;
+  judgeMode: JudgeMode;
+  userScorersCount: number;
+  missingKeyProviders: string[];
+  judgeLlm: JudgeLlmConfigForValidation;
+}): boolean {
+  const {
+    activeStep,
+    selectedSavedModelId,
+    model,
+    selectedModelProvider,
+    hasApiKey,
+    datasetPromptCount,
+    judgeMode,
+    userScorersCount,
+    missingKeyProviders,
+    judgeLlm,
+  } = params;
+
+  if (activeStep === 0) {
+    // A saved model selection is always sufficient to proceed
+    if (selectedSavedModelId) return true;
+
+    // Step 1: Model validation
+    const hasName = !!model.name;
+    const hasAccessMethod = !!model.accessMethod;
+    if (!hasName || !hasAccessMethod) return false;
+
+    // Check conditional fields based on access method
+    if (selectedModelProvider?.needsUrl && !model.endpointUrl) return false;
+
+    // For all cloud providers (including custom_api), require either a saved
+    // API key OR an entered API key
+    if (!(MODEL_PROVIDERS_WITHOUT_API_KEY as readonly string[]).includes(model.accessMethod)) {
+      // Map custom_api to "custom" for checking saved keys
+      const providerForKeyCheck =
+        model.accessMethod === "custom_api" ? "custom" : model.accessMethod;
+      const hasSavedKey = hasApiKey(providerForKeyCheck);
+      const hasEnteredKey = !!model.apiKey;
+      if (!hasSavedKey && !hasEnteredKey) return false;
+    }
+
+    return true;
+  }
+
+  if (activeStep === 1) {
+    // Step 2: Dataset validation - must have loaded prompts
+    return datasetPromptCount > 0;
+  }
+
+  if (activeStep === 2) {
+    // Step 3: Scorer / Judge validation
+    if (judgeMode === "scorer") {
+      // Custom scorer only - must have at least one scorer and all required API keys
+      if (userScorersCount === 0) return false;
+      if (missingKeyProviders.length > 0) return false;
+      return true;
+    }
+
+    if (judgeMode === "standard") {
+      // Standard judge only - must have provider and model (API key is from saved settings)
+      const hasBase = !!(judgeLlm.provider && judgeLlm.model);
+      // Custom / Self-hosted also requires endpoint URL
+      if (judgeLlm.provider === "custom_api") {
+        return hasBase && !!judgeLlm.endpointUrl;
+      }
+      return hasBase;
+    }
+
+    // Both mode - scorers exist, all scorer API keys present, AND standard judge configured
+    const hasScorers = userScorersCount > 0;
+    if (missingKeyProviders.length > 0) return false;
+    let hasJudge = !!(judgeLlm.provider && judgeLlm.model);
+    if (judgeLlm.provider === "custom_api") {
+      hasJudge = hasJudge && !!judgeLlm.endpointUrl;
+    }
+    return hasScorers && hasJudge;
+  }
+
+  return true;
+}

--- a/Clients/src/presentation/pages/EvalsDashboard/NewExperimentModal.tsx
+++ b/Clients/src/presentation/pages/EvalsDashboard/NewExperimentModal.tsx
@@ -50,26 +50,6 @@ import { ReactComponent as MistralLogo } from "../../assets/icons/mistral_logo.s
 import { ReactComponent as XAILogo } from "../../assets/icons/xai_logo.svg";
 import { ReactComponent as OpenRouterLogo } from "../../assets/icons/openrouter_logo.svg";
 import { ReactComponent as FolderFilledIcon } from "../../assets/icons/folder_filled.svg";
-
-// Large SVGs loaded from public/ to avoid bundling
-const HuggingFaceLogo = (props: React.SVGProps<SVGSVGElement>) => (
-  <img
-    src="/assets/icons/huggingface_logo.svg"
-    alt="Hugging Face"
-    width={props.width || 24}
-    height={props.height || 24}
-    style={{ display: "inline-block" }}
-  />
-);
-const BuildIcon = (props: React.SVGProps<SVGSVGElement>) => (
-  <img
-    src="/assets/icons/build.svg"
-    alt="Build"
-    width={props.width || 24}
-    height={props.height || 24}
-    style={{ display: "inline-block" }}
-  />
-);
 import {
   createExperiment,
   listDatasets,
@@ -88,6 +68,17 @@ import { getAllEntities } from "../../../application/repository/entity.repositor
 import { PROVIDERS, type ModelInfo } from "../../utils/providers";
 import { evalModelsService, type SavedModel } from "../../../infrastructure/api/evalModelsService";
 import { useModelPreferences } from "../../../application/hooks/useModelPreferences";
+import { BuildIcon, HuggingFaceLogo } from "./NewExperiment/experimentIcons";
+import {
+  datasetNameFromPresetPath,
+  generateDefaultExperimentName,
+} from "./NewExperiment/experimentNameHelpers";
+import {
+  type JudgeMode,
+  type ProviderType,
+  WIZARD_STEPS,
+} from "./NewExperiment/newExperimentConfig";
+import { canProceedToNextStep, getMissingKeyProviders } from "./NewExperiment/stepValidation";
 
 interface NewExperimentModalProps {
   isOpen: boolean;
@@ -111,59 +102,6 @@ interface NewExperimentModalProps {
    */
   existingExperimentNames?: string[];
 }
-
-const steps = ["Model", "Dataset", "Scorer / Judge", "Metrics"];
-
-/**
- * Strip noise from a model identifier so it reads cleanly as part of an
- * experiment name:
- *   "openai/gpt-4o-mini"            -> "gpt-4o-mini"
- *   "mistralai/mistral-medium-3-5"  -> "mistral-medium-3-5"
- *   "claude-3-5-sonnet-20241022"    -> "claude-3-5-sonnet"
- */
-const shortenForExperimentName = (s?: string | null): string => {
-  if (!s) return "";
-  const dateless = s.replace(/-\d{8}$/, "").replace(/-\d{4}-\d{2}-\d{2}$/, "");
-  const slashIdx = dateless.lastIndexOf("/");
-  return slashIdx >= 0 ? dateless.slice(slashIdx + 1) : dateless;
-};
-
-/**
- * Build the default name for a new experiment as `<model> × <dataset>`.
- * If that exact name is already used in this project, append #2, #3, ...
- * until we hit one that's free.
- */
-const generateDefaultExperimentName = (
-  modelName: string,
-  datasetName: string,
-  existing: readonly string[],
-): string => {
-  const m = shortenForExperimentName(modelName) || "model";
-  const d = (datasetName || "dataset").trim() || "dataset";
-  const base = `${m} × ${d}`;
-  if (!existing.includes(base)) return base;
-  let n = 2;
-  while (existing.includes(`${base} #${n}`)) n++;
-  return `${base} #${n}`;
-};
-
-/**
- * Derive a human-friendly dataset name from a preset filename like
- * "chatbot/chatbot_coding_helper.json" -> "Chatbot Coding Helper".
- */
-const datasetNameFromPresetPath = (path?: string | null): string => {
-  if (!path) return "";
-  const fileName =
-    path
-      .split("/")
-      .pop()
-      ?.replace(/\.json$/i, "") || "";
-  return fileName
-    .split("_")
-    .filter(Boolean)
-    .map((w) => w.charAt(0).toUpperCase() + w.slice(1))
-    .join(" ");
-};
 
 export default function NewExperimentModal({
   isOpen,
@@ -223,7 +161,7 @@ export default function NewExperimentModal({
   const [selectedPresetPath, setSelectedPresetPath] = useState<string>("");
 
   // Scorer / Judge mode state: scorer = custom only, standard = judge only, both = run both
-  const [judgeMode, setJudgeMode] = useState<"scorer" | "standard" | "both">("standard");
+  const [judgeMode, setJudgeMode] = useState<JudgeMode>("standard");
   const [userScorers, setUserScorers] = useState<DeepEvalScorer[]>([]);
   const [selectedScorer, setSelectedScorer] = useState<DeepEvalScorer | null>(null);
   const [selectedScorerIds, setSelectedScorerIds] = useState<string[]>([]); // Multi-select scorer IDs
@@ -1091,18 +1029,6 @@ export default function NewExperimentModal({
       },
     });
   };
-
-  type ProviderType =
-    | "openai"
-    | "anthropic"
-    | "google"
-    | "xai"
-    | "huggingface"
-    | "mistral"
-    | "ollama"
-    | "local"
-    | "custom_api"
-    | "openrouter";
 
   // Check if a provider has a configured API key
   const hasApiKey = (providerId: string): boolean => {
@@ -3840,99 +3766,29 @@ export default function NewExperimentModal({
   };
 
   // Providers required by selected scorers that have no saved API key in org settings.
-  // Self-hosted / Ollama scorers are excluded since they don't need a cloud key.
-  const missingKeyProviders = useMemo(() => {
-    if (judgeMode !== "scorer" && judgeMode !== "both") return [];
-    const scorersToCheck =
-      selectedScorerIds.length > 0
-        ? userScorers.filter((s) => selectedScorerIds.includes(s.id))
-        : userScorers;
-    const missing: string[] = [];
-    for (const scorer of scorersToCheck) {
-      const judgeModel = scorer.config?.judgeModel;
-      if (typeof judgeModel === "object" && judgeModel?.provider) {
-        const provider = judgeModel.provider.toLowerCase();
-        if (provider !== "self-hosted" && provider !== "ollama") {
-          const hasKey = configuredApiKeys.some((k) => k.provider === provider);
-          if (!hasKey && !missing.includes(provider)) {
-            missing.push(provider);
-          }
-        }
-      }
-    }
-    return missing;
-  }, [judgeMode, selectedScorerIds, userScorers, configuredApiKeys]);
+  const missingKeyProviders = useMemo(
+    () =>
+      getMissingKeyProviders({
+        judgeMode,
+        selectedScorerIds,
+        userScorers,
+        configuredApiKeys,
+      }),
+    [judgeMode, selectedScorerIds, userScorers, configuredApiKeys],
+  );
 
-  const canProceed = (() => {
-    if (activeStep === 0) {
-      // A saved model selection is always sufficient to proceed
-      if (selectedSavedModelId) return true;
-
-      // Step 1: Model validation
-      const hasName = !!config.model.name;
-      const hasAccessMethod = !!config.model.accessMethod;
-
-      if (!hasName || !hasAccessMethod) return false;
-
-      // Check conditional fields based on access method
-      if (
-        selectedModelProvider &&
-        "needsUrl" in selectedModelProvider &&
-        selectedModelProvider.needsUrl &&
-        !config.model.endpointUrl
-      )
-        return false;
-
-      // Providers that don't need API keys
-      const noApiKeyNeeded = ["ollama", "local"];
-
-      // For all cloud providers (including custom_api), require either a saved API key OR an entered API key
-      if (!noApiKeyNeeded.includes(config.model.accessMethod)) {
-        // Map custom_api to "custom" for checking saved keys
-        const providerForKeyCheck =
-          config.model.accessMethod === "custom_api" ? "custom" : config.model.accessMethod;
-        const hasSavedKey = hasApiKey(providerForKeyCheck);
-        const hasEnteredKey = !!config.model.apiKey;
-        if (!hasSavedKey && !hasEnteredKey) return false;
-      }
-
-      return true;
-    }
-
-    if (activeStep === 1) {
-      // Step 2: Dataset validation - must have loaded prompts
-      return datasetPrompts.length > 0;
-    }
-
-    if (activeStep === 2) {
-      // Step 3: Scorer / Judge validation
-      if (judgeMode === "scorer") {
-        // Custom scorer only - must have at least one scorer and all required API keys
-        if (userScorers.length === 0) return false;
-        if (missingKeyProviders.length > 0) return false;
-        return true;
-      } else if (judgeMode === "standard") {
-        // Standard judge only - must have provider and model (API key is from saved settings)
-        const hasBase = !!(config.judgeLlm.provider && config.judgeLlm.model);
-        // Custom / Self-hosted also requires endpoint URL
-        if (config.judgeLlm.provider === "custom_api") {
-          return hasBase && !!config.judgeLlm.endpointUrl;
-        }
-        return hasBase;
-      } else {
-        // Both mode - scorers exist, all scorer API keys present, AND standard judge configured
-        const hasScorers = userScorers.length > 0;
-        if (missingKeyProviders.length > 0) return false;
-        let hasJudge = !!(config.judgeLlm.provider && config.judgeLlm.model);
-        if (config.judgeLlm.provider === "custom_api") {
-          hasJudge = hasJudge && !!config.judgeLlm.endpointUrl;
-        }
-        return hasScorers && hasJudge;
-      }
-    }
-
-    return true;
-  })();
+  const canProceed = canProceedToNextStep({
+    activeStep,
+    selectedSavedModelId,
+    model: config.model,
+    selectedModelProvider,
+    hasApiKey,
+    datasetPromptCount: datasetPrompts.length,
+    judgeMode,
+    userScorersCount: userScorers.length,
+    missingKeyProviders,
+    judgeLlm: config.judgeLlm,
+  });
 
   return (
     <>
@@ -3944,7 +3800,7 @@ export default function NewExperimentModal({
           setAlert(null);
         }}
         title="Create new experiment"
-        steps={steps}
+        steps={[...WIZARD_STEPS]}
         activeStep={activeStep}
         onNext={handleNext}
         onBack={handleBack}


### PR DESCRIPTION
Move wizard icons, experiment-name helpers, config constants, and step gating logic into co-located NewExperiment/ modules so validation can be reasoned about and tested in isolation.

First of three planned splits for this modal; no behavior change.

## Describe your changes

First of three planned splits of `NewExperimentModal.tsx` (4014 lines), which is one of the largest presentation files in `Clients/`. This part extracts only pure, low-risk code into a new co-located `EvalsDashboard/NewExperiment/` folder, so the riskier state and JSX extraction in the follow-ups lands against a smaller, already-reviewed parent.

## Write your issue number after "Fixes "

Fixes #4387 

## Please ensure all items are checked off before requesting a review:

- [ ] I deployed the code locally.
- [ ] I have performed a self-review of my code.
- [ ] I have included the issue # in the PR.
- [ ] I have labelled the PR correctly.
- [ ] The issue I am working on is assigned to me.
- [ ] I have avoided using hardcoded values to ensure scalability and maintain consistency across the application.
- [ ] I have ensured that font sizes, color choices, and other UI elements are referenced from the theme.
- [ ] My pull request is focused and addresses a single, specific feature.
- [ ] If there are UI changes, I have attached a screenshot or video to this PR.
- [ ] If I added or modified an API endpoint, the change is reflected in the generated OpenAPI spec (`npm run generate:swagger`).
- [ ] If the endpoint requires authentication, it uses `authenticateJWT` and the generated spec declares `bearerAuth` security.
- [ ] I ran `npm run check:api-drift` and committed the regenerated `swagger.yaml` and `endpoints.ts`.
- [ ] If this PR adds or modifies an organization-scoped table, the [tenant isolation registry](Servers/tests/integration/tenant-isolation/tenantIsolation.registry.ts) and [test matrix](Servers/tests/integration/tenant-isolation) are updated. See the [tenant isolation runbook](docs/technical/security/tenant-isolation.md) for details.
