### PR TITLE
Remediate CodeQL polynomial ReDoS Alerts

### DIFF
--- a/Servers/controllers/aiDetectionRepository.ctrl.ts
+++ b/Servers/controllers/aiDetectionRepository.ctrl.ts
@@ -26,13 +26,45 @@ import { ScheduleFrequency } from "../domain.layer/interfaces/i.aiDetectionRepos
 import { generateWebhookSecret } from "../services/webhook.service";
 
 import { translateError } from "../utils/i18n.utils";
+const GITHUB_SSH_PREFIX = "git@github.com:";
+const MAX_GITHUB_URL_LENGTH = 500;
+
 /**
- * Parse GitHub URL to extract owner and repo name
+ * Parse a GitHub URL (HTTPS or SSH) to extract owner and repo name.
+ *
+ * Implemented without ambiguous regexes to avoid ReDoS on long/pathological
+ * inputs.
  */
 function parseGitHubUrl(url: string): { owner: string; name: string } | null {
-  const match = url.match(/github\.com[/:]([^/]+)\/([^/.]+)/);
-  if (!match) return null;
-  return { owner: match[1], name: match[2].replace(/\.git$/, "") };
+  if (typeof url !== "string" || url.length > MAX_GITHUB_URL_LENGTH) {
+    return null;
+  }
+
+  const trimmed = url.trim();
+  let path = "";
+
+  if (trimmed.toLowerCase().startsWith(GITHUB_SSH_PREFIX)) {
+    path = trimmed.slice(GITHUB_SSH_PREFIX.length);
+  } else {
+    try {
+      const parsed = new URL(trimmed);
+      if (!/^(?:www\.)?github\.com$/i.test(parsed.hostname)) {
+        return null;
+      }
+      path = parsed.pathname;
+    } catch {
+      return null;
+    }
+  }
+
+  // Strip optional .git suffix.
+  path = path.replace(/\.git$/i, "");
+  const parts = path.split("/").filter(Boolean);
+  if (parts.length < 2) return null;
+
+  const [owner, name] = parts;
+  if (!owner || !name) return null;
+  return { owner, name };
 }
 
 // ============================================================================

--- a/Servers/controllers/aiTrustIndex.ctrl.ts
+++ b/Servers/controllers/aiTrustIndex.ctrl.ts
@@ -11,8 +11,8 @@ import {
   getSettingsQuery,
   upsertSettingsQuery,
 } from "../utils/aiTrustIndex.utils";
+import { isEmail } from "../utils/validations/email.utils";
 
-const EMAIL_RE = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
 const isAdmin = (role?: string) => role === "Admin" || role === "SuperAdmin";
 
 export async function getApps(req: Request, res: Response): Promise<any> {
@@ -222,9 +222,7 @@ export async function updateSettings(req: Request, res: Response): Promise<any> 
     const badUserId = recipientUserIds.find((id: unknown) => !Number.isInteger(id));
     if (badUserId !== undefined)
       return res.status(400).json(STATUS_CODE[400](`Invalid user id: ${String(badUserId)}`));
-    const badEmail = recipientEmails.find(
-      (e: unknown) => typeof e !== "string" || !EMAIL_RE.test(e),
-    );
+    const badEmail = recipientEmails.find((e: unknown) => !isEmail(e));
     if (badEmail !== undefined)
       return res.status(400).json(STATUS_CODE[400](`Invalid email: ${String(badEmail)}`));
     await upsertSettingsQuery(req.organizationId!, req.userId!, recipientUserIds, recipientEmails);

--- a/Servers/controllers/intakeForm.ctrl.ts
+++ b/Servers/controllers/intakeForm.ctrl.ts
@@ -50,6 +50,7 @@ import { generateSuggestedQuestions, generateFieldGuidance } from "../services/i
 import { getCompanyLogoQuery } from "../utils/aiTrustCentre.utils";
 
 import { translateError } from "../utils/i18n.utils";
+import { isEmail } from "../utils/validations/email.utils";
 /** Safely extract a single string from req.params (which may be string | string[]). */
 const paramStr = (val: string | string[]): string => (Array.isArray(val) ? val[0] : val);
 
@@ -132,8 +133,7 @@ function validateFormData(formData: Record<string, unknown>, schema: IIntakeForm
     // Type-specific validation
     switch (field.type) {
       case "email": {
-        const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
-        if (typeof value !== "string" || !emailRegex.test(value)) {
+        if (!isEmail(value)) {
           errors.push(`"${field.label}" must be a valid email address`);
         }
         break;
@@ -1494,8 +1494,7 @@ export async function submitPublicFormByPublicId(req: Request, res: Response) {
     if (!submitterEmail) {
       return res.status(400).json(STATUS_CODE[400](req.t!("Submitter email is required")));
     }
-    const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
-    if (!emailRegex.test(submitterEmail)) {
+    if (!isEmail(submitterEmail)) {
       return res.status(400).json(STATUS_CODE[400](req.t!("Invalid email format")));
     }
 
@@ -1817,8 +1816,7 @@ export async function submitPublicForm(req: Request, res: Response) {
     if (!submitterEmail) {
       return res.status(400).json(STATUS_CODE[400](req.t!("Submitter email is required")));
     }
-    const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
-    if (!emailRegex.test(submitterEmail)) {
+    if (!isEmail(submitterEmail)) {
       return res.status(400).json(STATUS_CODE[400](req.t!("Invalid email format")));
     }
 

--- a/Servers/controllers/shadowAiIngestion.ctrl.ts
+++ b/Servers/controllers/shadowAiIngestion.ctrl.ts
@@ -25,6 +25,7 @@ import { ShadowAiIngestionRequest } from "../domain.layer/interfaces/i.shadowAi"
 import { getSettingsQuery } from "../utils/shadowAiConfig.utils";
 
 import { translateError } from "../utils/i18n.utils";
+import { isEmail } from "../utils/validations/email.utils";
 const MAX_EVENTS_PER_REQUEST = 10000;
 
 // ─── In-memory sliding window rate limiter ─────────────────────────────
@@ -136,7 +137,6 @@ export async function ingestEvents(req: Request, res: Response) {
   }
 
   // Validate required fields and basic formats
-  const EMAIL_REGEX = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
   for (let i = 0; i < body.events.length; i++) {
     const evt = body.events[i];
     if (!evt.user_email || !evt.destination || !evt.timestamp) {
@@ -151,7 +151,7 @@ export async function ingestEvents(req: Request, res: Response) {
           ),
         );
     }
-    if (!EMAIL_REGEX.test(evt.user_email)) {
+    if (!isEmail(evt.user_email)) {
       return res
         .status(400)
         .json(STATUS_CODE[400](req.t!("Event at index {i} has invalid user_email format", { i })));

--- a/Servers/documentation/validations/email.md
+++ b/Servers/documentation/validations/email.md
@@ -35,7 +35,7 @@ function emailValidation(email: string): boolean;
 The function uses the following regular expression pattern:
 
 ```typescript
-/^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+/^[^\s@]+@[^\s@.]+(?:\.[^\s@.]+)+$/;
 ```
 
 Pattern explanation:
@@ -43,10 +43,13 @@ Pattern explanation:
 - `^`: Start of string
 - `[^\s@]+`: One or more characters that are not whitespace or @
 - `@`: Literal @ symbol
-- `[^\s@]+`: One or more characters that are not whitespace or @
-- `\.`: Literal dot
-- `[^\s@]+`: One or more characters that are not whitespace or @
+- `[^\s@.]+`: One or more characters that are not whitespace, @, or dot
+- `(?:\.[^\s@.]+)+`: One or more dot-separated domain labels
 - `$`: End of string
+
+The domain labels are separated by fixed `.` characters, so the regex engine
+cannot partition the domain in multiple ways. This avoids polynomial-time
+backtracking (ReDoS) on pathological inputs.
 
 ## Usage Example
 

--- a/Servers/package-lock.json
+++ b/Servers/package-lock.json
@@ -15136,9 +15136,9 @@
       "license": "MIT"
     },
     "node_modules/npm-run-all/node_modules/brace-expansion": {
-      "version": "1.1.17",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.17.tgz",
-      "integrity": "sha512-w+aeW/mkgM4PyRMOJCgi3fOrTm5Q8QY1OSfn2TO2iuDj3ezIHqejmuxbjfPrqUkgqRew1iqkyAn0tr0ZwHD9+w==",
+      "version": "1.1.18",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+      "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -18053,9 +18053,9 @@
       "license": "MIT"
     },
     "node_modules/sequelize-typescript/node_modules/brace-expansion": {
-      "version": "1.1.17",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.17.tgz",
-      "integrity": "sha512-w+aeW/mkgM4PyRMOJCgi3fOrTm5Q8QY1OSfn2TO2iuDj3ezIHqejmuxbjfPrqUkgqRew1iqkyAn0tr0ZwHD9+w==",
+      "version": "1.1.18",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+      "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0",
@@ -19123,9 +19123,9 @@
       "license": "MIT"
     },
     "node_modules/test-exclude/node_modules/brace-expansion": {
-      "version": "1.1.17",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.17.tgz",
-      "integrity": "sha512-w+aeW/mkgM4PyRMOJCgi3fOrTm5Q8QY1OSfn2TO2iuDj3ezIHqejmuxbjfPrqUkgqRew1iqkyAn0tr0ZwHD9+w==",
+      "version": "1.1.18",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+      "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -20640,9 +20640,9 @@
       "license": "MIT"
     },
     "node_modules/yamljs/node_modules/brace-expansion": {
-      "version": "1.1.17",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.17.tgz",
-      "integrity": "sha512-w+aeW/mkgM4PyRMOJCgi3fOrTm5Q8QY1OSfn2TO2iuDj3ezIHqejmuxbjfPrqUkgqRew1iqkyAn0tr0ZwHD9+w==",
+      "version": "1.1.18",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+      "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0",

--- a/Servers/package.json
+++ b/Servers/package.json
@@ -160,7 +160,7 @@
     "tar": "^7.5.22",
     "@hono/node-server": "^2.0.5",
     "minimatch@9": "9.0.8",
-    "brace-expansion@1": "1.1.17",
+    "brace-expansion@1": "1.1.18",
     "brace-expansion@5": "^5.0.8"
   }
 }

--- a/Servers/utils/devAutoBootstrap.ts
+++ b/Servers/utils/devAutoBootstrap.ts
@@ -1,6 +1,7 @@
 import { sequelize } from "../database/db";
 import { createOrganizationQuery } from "./organization.utils";
 import { createNewUserWrapper } from "../controllers/user.ctrl";
+import { isEmail } from "./validations/email.utils";
 
 const REQUIRED_VARS = [
   "DEV_ORG_NAME",
@@ -9,8 +10,6 @@ const REQUIRED_VARS = [
   "DEV_ADMIN_NAME",
   "DEV_ADMIN_SURNAME",
 ] as const;
-
-const EMAIL_RE = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
 
 /**
  * Dev-only bootstrap: on first startup, create initial organization and admin user
@@ -63,7 +62,7 @@ export async function devAutoBootstrap(): Promise<void> {
   const name = process.env.DEV_ADMIN_NAME!;
   const surname = process.env.DEV_ADMIN_SURNAME!;
 
-  if (!EMAIL_RE.test(email)) {
+  if (!isEmail(email)) {
     throw new Error(`[dev-bootstrap] DEV_ADMIN_EMAIL is not a valid email: ${email}`);
   }
 

--- a/Servers/utils/intakeForm.utils.ts
+++ b/Servers/utils/intakeForm.utils.ts
@@ -793,12 +793,18 @@ export const checkRateLimitQuery = async (
  * Generate slug from name
  */
 export function generateSlug(name: string): string {
-  return name
+  let slug = name
     .toLowerCase()
     .trim()
     .replace(/[^\w\s-]/g, "")
-    .replace(/[\s_-]+/g, "-")
-    .replace(/^-+|-+$/g, "");
+    .replace(/[\s_-]+/g, "-");
+
+  // Trim leading/trailing hyphens without using the ambiguous /-+$/ regex.
+  let start = 0;
+  let end = slug.length;
+  while (start < end && slug[start] === "-") start++;
+  while (end > start && slug[end - 1] === "-") end--;
+  return slug.slice(start, end);
 }
 
 /**

--- a/Servers/utils/validations/aiTrustCentreValidation.utils.ts
+++ b/Servers/utils/validations/aiTrustCentreValidation.utils.ts
@@ -317,8 +317,8 @@ export const validateOverviewTermsAndContact = (value: any): ValidationResult =>
       return emailValidation;
     }
 
-    // Basic email format validation
-    const emailPattern = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+    // Basic email format validation (safe regex, no ambiguous repetitions)
+    const emailPattern = /^[^\s@]+@[^\s@.]+(?:\.[^\s@.]+)+$/;
     if (!emailPattern.test(value.email_text.trim())) {
       return {
         isValid: false,

--- a/Servers/utils/validations/email.utils.ts
+++ b/Servers/utils/validations/email.utils.ts
@@ -1,0 +1,22 @@
+/**
+ * Email validation helpers
+ *
+ * These regexes are intentionally written to avoid polynomial backtracking
+ * (ReDoS). The local and domain labels are separated by fixed characters so
+ * the engine cannot partition the string in multiple ways.
+ */
+
+const SAFE_EMAIL_RE = /^[^\s@]+@[^\s@.]+(?:\.[^\s@.]+)+$/;
+const MAX_EMAIL_LENGTH = 320; // RFC 5321 maximum total length
+
+/**
+ * Type guard that returns true when the value is a syntactically valid email.
+ */
+export function isEmail(value: unknown): value is string {
+  return (
+    typeof value === "string" &&
+    value.length > 0 &&
+    value.length <= MAX_EMAIL_LENGTH &&
+    SAFE_EMAIL_RE.test(value)
+  );
+}

--- a/Servers/utils/validations/mailValidation.utils.ts
+++ b/Servers/utils/validations/mailValidation.utils.ts
@@ -24,7 +24,9 @@ export const MAIL_VALIDATION_LIMITS = {
 /**
  * Email validation pattern
  */
-const EMAIL_PATTERN = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+// Safe regex: labels are separated by fixed "." characters so the engine
+// cannot partition the domain in multiple ways (avoids polynomial ReDoS).
+const EMAIL_PATTERN = /^[^\s@]+@[^\s@.]+(?:\.[^\s@.]+)+$/;
 
 /**
  * Validates email address field

--- a/Servers/utils/validations/userValidation.utils.ts
+++ b/Servers/utils/validations/userValidation.utils.ts
@@ -10,6 +10,7 @@ import {
   ValidationResult,
   ValidationError,
 } from "./validation.utils";
+import { isEmail } from "./email.utils";
 
 /**
  * Email validation using regex pattern
@@ -23,7 +24,6 @@ const validateEmail = (
     trimWhitespace?: boolean;
   } = {},
 ): ValidationResult => {
-  const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
   const { required = false, maxLength = 128, trimWhitespace = true } = options;
 
   // First validate as string
@@ -41,7 +41,7 @@ const validateEmail = (
   // If value is provided, validate email format
   if (value !== undefined && value !== null && String(value).trim() !== "") {
     const emailValue = trimWhitespace ? String(value).trim() : String(value);
-    if (!emailRegex.test(emailValue)) {
+    if (!isEmail(emailValue)) {
       return {
         isValid: false,
         message: `${fieldName} must be a valid email address`,

--- a/Servers/utils/validations/validation.utils.ts
+++ b/Servers/utils/validations/validation.utils.ts
@@ -502,7 +502,9 @@ export const sanitizeString = (
  * Common validation patterns
  */
 export const VALIDATION_PATTERNS = {
-  EMAIL: /^[^\s@]+@[^\s@]+\.[^\s@]+$/,
+  // Safe regex: labels are separated by fixed "." characters so the engine
+  // cannot partition the domain in multiple ways (avoids polynomial ReDoS).
+  EMAIL: /^[^\s@]+@[^\s@.]+(?:\.[^\s@.]+)+$/,
   PHONE: /^\+?[\d\s\-\(\)]{10,}$/,
   URL: /^https?:\/\/.+/,
   ALPHANUMERIC: /^[a-zA-Z0-9]+$/,

--- a/agent.md
+++ b/agent.md
@@ -1,136 +1,26 @@
-# VerifyWise — Dependency Security Patch Report
+# VerifyWise — Vulnerability Patch Report
 
 **Date:** 2026-08-03  
-**Branch:** `mo-380-aug-3-dependency-security-patch` (pushed to origin)  
-**Scope:** Security updates for React Router, `brace-expansion`, `sharp`, `sanitize-html`, and `dompurify` transitive dependencies.
+**Branch:** `mo-381-aug-3-vulnerability-issues` (pushed to origin)
 
----
+## Changes
 
-## 1. What We Did
+Fixed six CodeQL `js/polynomial-redos` alerts (#1194–#1199) in `Servers`:
 
-### 1.1 React Router — `docs/api-docs` & `GRSModule/ui/frontend`
+- **`utils/intakeForm.utils.ts`** — rewrote `generateSlug()` to trim leading/trailing hyphens manually instead of using the ambiguous `/^-+|-+$/g` regex.
+- **`controllers/intakeForm.ctrl.ts`** — replaced three inline email regexes with the shared `isEmail()` helper.
+- **`controllers/aiTrustIndex.ctrl.ts`** — replaced `EMAIL_RE` with `isEmail()`.
+- **`controllers/aiDetectionRepository.ctrl.ts`** — rewrote `parseGitHubUrl()` using `URL` parsing and string splitting to avoid the ambiguous `github.com[/:]([^/]+)/([^/.]+)` regex.
 
-Both modules declared `react-router-dom@^7.0.0` and locked `react-router@7.0.0`, which was affected by multiple Dependabot alerts:
+Also updated the same unsafe email pattern in `validation.utils.ts`, `mailValidation.utils.ts`, `aiTrustCentreValidation.utils.ts`, `userValidation.utils.ts`, `shadowAiIngestion.ctrl.ts`, `devAutoBootstrap.ts`, and `documentation/validations/email.md`.
 
-- DoS via inefficient route matching (#511, #499) — patched in 7.18.0
-- Pre-render data spoofing (#505, #493) — patched in 7.5.2
-- XSS via open redirects (#503, #491) — patched in 7.12.0
-- SSR XSS in `ScrollRestoration` (#502, #490) — patched in 7.12.0
-- vendored `turbo-stream` RCE (#507, #495) — patched in 7.14.2
-- XSS in `meta()` / `<Meta>` (#500, #488) — patched in 7.9.0
-- `__manifest` DoS (#508, #496) — patched in 7.15.0
-- Single-fetch DoS via `react-router` (#509, #497) — patched in 7.14.0
-- Single-fetch DoS via `turbo-stream` (#510, #498) — patched in 3.0.0
+New helper: `Servers/utils/validations/email.utils.ts` uses the safe pattern `^[^\s@]+@[^\s@.]+(?:\.[^\s@.]+)+$` with a 320-character length guard.
 
-**Action:** bumped `react-router-dom` to `^7.18.0` in both `package.json` files and regenerated lockfiles. The resolved version is `7.18.2`, which covers every alert above.
+## Verification
 
-**Commits:**
-- `security(docs/api-docs): bump react-router-dom to ^7.18.0`
-- `fix(docs/api-docs): resolve pre-existing TypeScript build errors`
-- `security(grs-frontend): bump react-router-dom to ^7.18.0`
-- `fix(grs-frontend): resolve lint errors surfaced by updated eslint-plugin-react-hooks`
+- `npm run build` in `Servers` ✅
+- `npm test` in `Servers` ✅ — **231 suites passed, 3,448 tests passed**
 
-### 1.2 `brace-expansion` — `Servers`
+## Commit
 
-`Servers/package-lock.json` contained vulnerable `brace-expansion` versions (`5.0.7` and nested `1.1.16`) via `minimatch`, `jest`, `mjml`, `sequelize-cli`, `swagger-jsdoc`, and `@e2b/code-interpreter` (Dependabot alert #513).
-
-**Action:** added npm overrides to `Servers/package.json`:
-
-```json
-"brace-expansion@1": "1.1.17",
-"brace-expansion@5": "^5.0.8"
-```
-
-Regenerated `Servers/package-lock.json`. All `brace-expansion` instances now resolve to `1.1.17` or `5.0.9`.
-
-**Commit:**
-- `security(servers): patch brace-expansion DoS via overrides`
-
-### 1.3 `sharp` — root `package-lock.json`
-
-Root devDependency `webreel@^0.1.4` transitively depended on `sharp@0.34.5`, which bundles vulnerable `libvips` versions (Dependabot alert #474).
-
-**Action:** added an npm override in root `package.json`:
-
-```json
-"overrides": {
-  "sharp": ">=0.35.0"
-}
-```
-
-Regenerated root `package-lock.json`. `sharp` now resolves to `0.35.3`.
-
-**Commit:**
-- `security(root): override transitive sharp to >=0.35.0`
-
-### 1.4 `sanitize-html` — `Servers`
-
-`Servers` directly depended on `sanitize-html@^2.17.4`, which has incomplete URI scheme validation for attributes like `action`, `formaction`, `data`, `poster`, and `background` (Dependabot alert #512).
-
-**Action:** pinned `sanitize-html` to `2.17.5` in `Servers/package.json` and regenerated `Servers/package-lock.json`.
-
-> Note: `2.17.6` pulls in `htmlparser2@12` (ESM-only), which Jest cannot transform because `node_modules` is ignored by default. `2.17.5` still satisfies the security fix and uses `htmlparser2@10` (CommonJS), so tests pass without a Jest config change.
-
-**Commit:**
-- `security(servers): bump sanitize-html to ^2.17.5`
-
-### 1.5 `dompurify` — `GRSModule/ui/frontend`
-
-`GRSModule/ui/frontend` did not directly depend on `dompurify`; it was pulled in by `monaco-editor` (via `@monaco-editor/react`) at `dompurify@3.2.7`. The affected range is `<=3.4.11` (Dependabot alert #466).
-
-**Action:** added an npm override in `GRSModule/ui/frontend/package.json`:
-
-```json
-"overrides": {
-  "dompurify": ">=3.4.12"
-}
-```
-
-Regenerated the lockfile. `dompurify` now resolves to `3.4.12`.
-
-**Commit:**
-- `security(grs-frontend): override dompurify to >=3.4.12`
-
-### 1.6 React Router RSC-mode CSRF — `docs/api-docs`, `GRSModule/ui/frontend`, `Clients`
-
-New Dependabot alerts #515, #514, and #478 are additional instances of the same RSC-mode CSRF advisory (`GHSA-qwww-vcr4-c8h2`). The patched version is 8.3.0.
-
-**Decision:** all three modules use React Router in **Declarative/Data mode** (`BrowserRouter` / `<Routes>`). They do **not** use unstable RSC/server-action APIs, so the vector is not reachable. No upgrade to React Router v8 was performed; migration is tracked separately.
-
-The GitHub Dependency Review action (`actions/dependency-review-action@v5`) already allowlists `GHSA-qwww-vcr4-c8h2` in both `.github/workflows/backend-checks.yml` and `.github/workflows/frontend-checks.yml` alongside the `brace-expansion` exception (`GHSA-mh99-v99m-4gvg`).
-
-**Commit:**
-- `ci: allow GHSA-qwww-vcr4-c8h2 in dependency-review`
-
----
-
-## 2. Verification
-
-| Module | Command | Result |
-|--------|---------|--------|
-| `docs/api-docs` | `npm run build` | ✅ |
-| `GRSModule/ui/frontend` | `npm run build` | ✅ |
-| `GRSModule/ui/frontend` | `npm run lint` | ✅ |
-| `Servers` | `npm run build` | ✅ |
-| Root | `npm ls sharp` | `0.35.3` ✅ |
-| `Servers` | `npm ls sanitize-html` | `2.17.5` ✅ |
-| `GRSModule/ui/frontend` | `npm ls dompurify` | `3.4.12` ✅ |
-| `docs/api-docs` | `npm audit` (React Router) | Only non-exploitable RSC CSRF remains |
-| `GRSModule/ui/frontend` | `npm audit` (React Router) | Only non-exploitable RSC CSRF remains |
-| `Servers` | `npm audit` (`brace-expansion`, `sanitize-html`) | No findings for either |
-
----
-
-## 3. Pull Request
-
-Compare URL for `develop ← mo-380-aug-3-dependency-security-patch`:
-
-https://github.com/verifywise-ai/verifywise/compare/develop...mo-380-aug-3-dependency-security-patch
-
----
-
-## 4. Outcome
-
-- All listed React Router Dependabot alerts for `docs/api-docs` and `GRSModule/ui/frontend` are resolved.
-- The `brace-expansion`, `sanitize-html`, `sharp`, and `dompurify` alerts are resolved via targeted version bumps and overrides.
-- Residual React Router RSC-mode CSRF alerts (#515, #514, #478) are accepted/documented as non-exploitable in the current BrowserRouter/Data-mode deployments and allowlisted in CI.
+`02c71cbd7 fix(servers): remediate CodeQL polynomial ReDoS alerts (#1194-#1199)`

--- a/agent.md
+++ b/agent.md
@@ -16,11 +16,17 @@ Also updated the same unsafe email pattern in `validation.utils.ts`, `mailValida
 
 New helper: `Servers/utils/validations/email.utils.ts` uses the safe pattern `^[^\s@]+@[^\s@.]+(?:\.[^\s@.]+)+$` with a 320-character length guard.
 
+## Dependency audit gate fix
+
+The `Lint and Build` job failed because `brace-expansion@1.1.17` is affected by a new high-severity advisory (`GHSA-rgw5-rvv9-x895`). Bumped the `brace-expansion@1` npm override to `1.1.18` in `Servers/package.json` and regenerated `Servers/package-lock.json`. The audit gate now passes; `xlsx` remains the only waived high-severity advisory.
+
 ## Verification
 
 - `npm run build` in `Servers` ✅
 - `npm test` in `Servers` ✅ — **231 suites passed, 3,448 tests passed**
+- `node scripts/security/npm-audit-gate.js .` in `Servers` ✅ — passed (xlsx waived)
 
-## Commit
+## Commits
 
-`02c71cbd7 fix(servers): remediate CodeQL polynomial ReDoS alerts (#1194-#1199)`
+- `02c71cbd7 fix(servers): remediate CodeQL polynomial ReDoS alerts (#1194-#1199)`
+- `02f244380 docs(agent.md): add brief report for ReDoS fixes (#1194-#1199)`


### PR DESCRIPTION
## Remediate CodeQL polynomial ReDoS Alerts (#1194-#1199)

- Replace ambiguous email regex ^[^\s@]+@[^\s@]+\.[^\s@]+$ with a safe pattern where domain labels are separated by fixed dots, eliminating overlapping repetitions.
- Introduce shared isEmail() helper in utils/validations/email.utils.ts and adopt it in aiTrustIndex, intakeForm, shadowAiIngestion and devAutoBootstrap.
- Rewrite generateSlug() to trim leading/trailing hyphens manually instead of using the ambiguous /^-+|-+$/g regex.
- Rewrite parseGitHubUrl() using URL parsing and string splitting to avoid the ambiguous github.com[/:]([^/]+)/([^/.]+) regex.
- Update remaining VALIDATION_PATTERNS.EMAIL, mailValidation and aiTrustCentreValidation copies, plus documentation, to the safe pattern.

## Please ensure all items are checked off before requesting a review:

- [x] I deployed the code locally.
- [x] I have performed a self-review of my code.
- [x] I have included the issue # in the PR.
- [x] I have labelled the PR correctly.
- [x] The issue I am working on is assigned to me.
- [x] I have avoided using hardcoded values to ensure scalability and maintain consistency across the application.
- [x] I have ensured that font sizes, color choices, and other UI elements are referenced from the theme.
- [x] My pull request is focused and addresses a single, specific feature.
- [x] If there are UI changes, I have attached a screenshot or video to this PR.
- [x] If I added or modified an API endpoint, the change is reflected in the generated OpenAPI spec (`npm run generate:swagger`).
- [x] If the endpoint requires authentication, it uses `authenticateJWT` and the generated spec declares `bearerAuth` security.
- [x] I ran `npm run check:api-drift` and committed the regenerated `swagger.yaml` and `endpoints.ts`.
- [x] If this PR adds or modifies an organization-scoped table, the [tenant isolation registry](Servers/tests/integration/tenant-isolation/tenantIsolation.registry.ts) and [test matrix](Servers/tests/integration/tenant-isolation) are updated. See the [tenant isolation runbook](docs/technical/security/tenant-isolation.md) for details.
