### PR TITLE
refactor(evals): extract Dataset step from NewExperimentModal

### DIFF
--- a/Clients/src/presentation/pages/EvalsDashboard/NewExperiment/DatasetStep.tsx
+++ b/Clients/src/presentation/pages/EvalsDashboard/NewExperiment/DatasetStep.tsx
@@ -1,0 +1,90 @@
+/**
+ * @fileoverview Dataset wizard step — upload, my datasets, and templates.
+ *
+ * Parent owns all dataset state; this step only renders and fires callbacks.
+ *
+ * @module pages/EvalsDashboard/NewExperiment/DatasetStep
+ */
+
+import { Stack, Typography } from "@mui/material";
+import { palette } from "../../../themes/palette";
+import type { DatasetPrompt, TaskType, UserDataset } from "./newExperimentConfig";
+import DatasetUploadZone from "./DatasetUploadZone";
+import MyDatasetsSection from "./MyDatasetsSection";
+import TemplateDatasetsSection from "./TemplateDatasetsSection";
+
+export interface DatasetStepProps {
+  taskType: TaskType;
+  useBuiltin: boolean;
+  userDatasets: UserDataset[];
+  selectedUserDataset: UserDataset | null;
+  loadingUserDatasets: boolean;
+  uploadingDataset: boolean;
+  selectedPresetPath: string;
+  datasetPromptCount: number;
+  orgId?: string | null;
+  projectId: string;
+  onUploadingChange: (uploading: boolean) => void;
+  onAlert: (alert: {
+    variant: "success" | "error" | "info" | "warning";
+    title: string;
+    body: string;
+    autoHideMs: number;
+  }) => void;
+  onUploadComplete: (dataset: UserDataset, prompts: DatasetPrompt[] | null) => void;
+  onUserDatasetSelect: (dataset: UserDataset, prompts: DatasetPrompt[] | null) => void;
+  onPresetSelect: (path: string, prompts: DatasetPrompt[] | null) => void;
+}
+
+export default function DatasetStep({
+  taskType,
+  useBuiltin,
+  userDatasets,
+  selectedUserDataset,
+  loadingUserDatasets,
+  uploadingDataset,
+  selectedPresetPath,
+  datasetPromptCount,
+  orgId,
+  projectId,
+  onUploadingChange,
+  onAlert,
+  onUploadComplete,
+  onUserDatasetSelect,
+  onPresetSelect,
+}: DatasetStepProps) {
+  return (
+    <Stack spacing="16px">
+      <Typography sx={{ fontSize: "13px", color: palette.text.tertiary, lineHeight: 1.5 }}>
+        Choose a dataset containing prompts and expected outputs. Upload your own JSON file, select
+        from saved datasets, or use a template.
+      </Typography>
+
+      <DatasetUploadZone
+        uploading={uploadingDataset}
+        orgId={orgId}
+        onUploadingChange={onUploadingChange}
+        onAlert={onAlert}
+        onUploadComplete={onUploadComplete}
+      />
+
+      <MyDatasetsSection
+        projectId={projectId}
+        loading={loadingUserDatasets}
+        userDatasets={userDatasets}
+        selectedUserDataset={selectedUserDataset}
+        useBuiltin={useBuiltin}
+        datasetPromptCount={datasetPromptCount}
+        onSelect={onUserDatasetSelect}
+      />
+
+      <TemplateDatasetsSection
+        taskType={taskType}
+        selectedPresetPath={selectedPresetPath}
+        useBuiltin={useBuiltin}
+        datasetPromptCount={datasetPromptCount}
+        onSelect={onPresetSelect}
+      />
+    </Stack>
+  );
+}

--- a/Clients/src/presentation/pages/EvalsDashboard/NewExperiment/DatasetTypeChip.tsx
+++ b/Clients/src/presentation/pages/EvalsDashboard/NewExperiment/DatasetTypeChip.tsx
@@ -1,0 +1,70 @@
+/**
+ * @fileoverview Turn-type chip for dataset cards (user uploads and templates).
+ *
+ * @module pages/EvalsDashboard/NewExperiment/DatasetTypeChip
+ */
+
+import Chip from "../../../components/Chip";
+import { palette } from "../../../themes/palette";
+import type { DatasetTurnType } from "./newExperimentConfig";
+
+interface DatasetTypeChipProps {
+  /** Underlying turn type; omit / undefined treated as single-turn. */
+  turnType?: DatasetTurnType | "single-turn" | "multi-turn";
+  /** When true and promptCount > 0, label shows the loaded prompt count. */
+  isSelected?: boolean;
+  promptCount?: number;
+  /** Force the Empty chip (user datasets with promptCount === 0). */
+  isEmpty?: boolean;
+}
+
+export default function DatasetTypeChip({
+  turnType,
+  isSelected = false,
+  promptCount = 0,
+  isEmpty = false,
+}: DatasetTypeChipProps) {
+  if (isEmpty) {
+    return (
+      <Chip
+        label="Empty"
+        backgroundColor={palette.status.error.bg}
+        textColor={palette.status.error.text}
+        uppercase={false}
+      />
+    );
+  }
+
+  const countLabel = isSelected && promptCount > 0 ? `${promptCount} prompts` : undefined;
+
+  if (turnType === "multi-turn") {
+    return (
+      <Chip
+        label={countLabel ?? "Multi-Turn"}
+        backgroundColor={palette.accent.blue.bg}
+        textColor={palette.accent.blue.text}
+        uppercase={false}
+      />
+    );
+  }
+
+  if (turnType === "simulated") {
+    return (
+      <Chip
+        label={countLabel ?? "Simulated"}
+        backgroundColor={palette.accent.purple.bg}
+        textColor={palette.accent.purple.text}
+        uppercase={false}
+      />
+    );
+  }
+
+  return (
+    <Chip
+      label={countLabel ?? "Single-Turn"}
+      backgroundColor={palette.status.warning.bg}
+      textColor={palette.status.warning.text}
+      uppercase={false}
+    />
+  );
+}

--- a/Clients/src/presentation/pages/EvalsDashboard/NewExperiment/DatasetUploadZone.tsx
+++ b/Clients/src/presentation/pages/EvalsDashboard/NewExperiment/DatasetUploadZone.tsx
@@ -1,0 +1,149 @@
+/**
+ * @fileoverview Compact drop-zone for uploading a custom dataset JSON file.
+ *
+ * @module pages/EvalsDashboard/NewExperiment/DatasetUploadZone
+ */
+
+import { Box, Typography } from "@mui/material";
+import { Upload } from "lucide-react";
+import { palette } from "../../../themes/palette";
+import { readDataset, uploadDataset } from "../../../../application/repository/deepEval.repository";
+import type { DatasetPrompt, UserDataset } from "./newExperimentConfig";
+import { validateDatasetFileContent } from "./datasetUpload";
+
+export interface DatasetUploadZoneProps {
+  uploading: boolean;
+  orgId?: string | null;
+  onUploadingChange: (uploading: boolean) => void;
+  onAlert: (alert: {
+    variant: "success" | "error" | "info" | "warning";
+    title: string;
+    body: string;
+    autoHideMs: number;
+  }) => void;
+  /**
+   * Called after a successful upload. `prompts` is null when the follow-up
+   * read fails (selection still updates; loaded flag is left alone).
+   */
+  onUploadComplete: (dataset: UserDataset, prompts: DatasetPrompt[] | null) => void;
+}
+
+export default function DatasetUploadZone({
+  uploading,
+  orgId,
+  onUploadingChange,
+  onAlert,
+  onUploadComplete,
+}: DatasetUploadZoneProps) {
+  return (
+    <Box>
+      <Typography
+        sx={{
+          fontSize: "12px",
+          fontWeight: 600,
+          color: palette.text.disabled,
+          textTransform: "uppercase",
+          letterSpacing: "0.5px",
+          mb: "8px",
+        }}
+      >
+        Option 1: Use custom dataset
+      </Typography>
+      <Box
+        component="label"
+        sx={{
+          "display": "flex",
+          "alignItems": "center",
+          "gap": "8px",
+          "p": "8px",
+          "border": "1px dashed",
+          "borderColor": uploading ? palette.brand.primary : palette.border.dark,
+          "borderRadius": "4px",
+          "backgroundColor": palette.background.accent,
+          "cursor": uploading ? "wait" : "pointer",
+          "transition": "all 0.15s ease",
+          "&:hover": {
+            borderColor: palette.brand.primary,
+            backgroundColor: palette.status.success.bg,
+          },
+        }}
+      >
+        <Box
+          sx={{
+            width: 32,
+            height: 32,
+            borderRadius: "6px",
+            backgroundColor: palette.brand.primary,
+            display: "flex",
+            alignItems: "center",
+            justifyContent: "center",
+            flexShrink: 0,
+          }}
+        >
+          <Upload size={16} color={palette.background.main} />
+        </Box>
+        <Box sx={{ flex: 1 }}>
+          <Typography sx={{ fontSize: "13px", fontWeight: 500, color: palette.text.secondary }}>
+            {uploading ? "Uploading..." : "Upload dataset"}
+          </Typography>
+          <Typography sx={{ fontSize: "11px", color: palette.text.disabled }}>
+            JSON file with prompts and expected outputs
+          </Typography>
+        </Box>
+        <input
+          type="file"
+          accept="application/json"
+          hidden
+          disabled={uploading}
+          onChange={async (e) => {
+            const file = e.target.files?.[0];
+            if (!file) return;
+            try {
+              onUploadingChange(true);
+              const fileContent = await file.text();
+              const validation = validateDatasetFileContent(fileContent);
+              if (!validation.ok) {
+                onAlert({
+                  variant: "error",
+                  title: validation.title,
+                  body: validation.body,
+                  autoHideMs: 15000,
+                });
+                return;
+              }
+              const resp = await uploadDataset(file, "chatbot", "single-turn", orgId || undefined);
+              const newDataset: UserDataset = {
+                id: resp.path,
+                name: file.name.replace(/\.json$/i, ""),
+                path: resp.path,
+                promptCount: validation.validPromptCount,
+              };
+              try {
+                const { prompts } = await readDataset(resp.path);
+                onUploadComplete(newDataset, (prompts || []) as DatasetPrompt[]);
+              } catch {
+                onUploadComplete(newDataset, null);
+              }
+              onAlert({
+                variant: "success",
+                title: "Uploaded!",
+                body: `${file.name} is ready to use`,
+                autoHideMs: 5000,
+              });
+            } catch (err) {
+              onAlert({
+                variant: "error",
+                title: "Upload failed",
+                body: err instanceof Error ? err.message : "Failed to upload",
+                autoHideMs: 15000,
+              });
+            } finally {
+              onUploadingChange(false);
+              e.target.value = "";
+            }
+          }}
+        />
+      </Box>
+    </Box>
+  );
+}

--- a/Clients/src/presentation/pages/EvalsDashboard/NewExperiment/MyDatasetsSection.tsx
+++ b/Clients/src/presentation/pages/EvalsDashboard/NewExperiment/MyDatasetsSection.tsx
@@ -1,0 +1,127 @@
+/**
+ * @fileoverview "Option 2: Your datasets" list for the Dataset wizard step.
+ *
+ * @module pages/EvalsDashboard/NewExperiment/MyDatasetsSection
+ */
+
+import { Box, Button, Stack, Typography } from "@mui/material";
+import { Database, ExternalLink } from "lucide-react";
+import SelectableCard from "../../../components/SelectableCard";
+import { palette } from "../../../themes/palette";
+import { readDataset } from "../../../../application/repository/deepEval.repository";
+import type { DatasetPrompt, UserDataset } from "./newExperimentConfig";
+import DatasetTypeChip from "./DatasetTypeChip";
+
+export interface MyDatasetsSectionProps {
+  projectId: string;
+  loading: boolean;
+  userDatasets: UserDataset[];
+  selectedUserDataset: UserDataset | null;
+  useBuiltin: boolean;
+  datasetPromptCount: number;
+  /**
+   * `prompts` is null when the dataset read fails (selection still updates;
+   * loaded flag is left alone — matches prior modal behavior).
+   */
+  onSelect: (dataset: UserDataset, prompts: DatasetPrompt[] | null) => void;
+}
+
+export default function MyDatasetsSection({
+  projectId,
+  loading,
+  userDatasets,
+  selectedUserDataset,
+  useBuiltin,
+  datasetPromptCount,
+  onSelect,
+}: MyDatasetsSectionProps) {
+  if (loading) {
+    return (
+      <Box sx={{ py: 2, textAlign: "center" }}>
+        <Typography sx={{ fontSize: "13px", color: palette.text.tertiary }}>
+          Loading your datasets...
+        </Typography>
+      </Box>
+    );
+  }
+
+  if (userDatasets.length === 0) return null;
+
+  return (
+    <Box>
+      <Stack direction="row" alignItems="center" justifyContent="space-between" sx={{ mb: 1 }}>
+        <Typography
+          sx={{
+            fontSize: "12px",
+            fontWeight: 600,
+            color: palette.text.disabled,
+            textTransform: "uppercase",
+            letterSpacing: "0.5px",
+          }}
+        >
+          Option 2: Your datasets
+        </Typography>
+        <Button
+          size="small"
+          variant="text"
+          startIcon={<ExternalLink size={12} />}
+          onClick={() => window.open(`/evals/${projectId}#datasets`, "_blank")}
+          sx={{
+            "textTransform": "none",
+            "fontSize": "11px",
+            "color": palette.text.tertiary,
+            "p": 0.5,
+            "minWidth": "auto",
+            "&:hover": { color: palette.brand.primary },
+          }}
+        >
+          Manage
+        </Button>
+      </Stack>
+      <Stack spacing="8px">
+        {userDatasets.slice(0, 4).map((dataset) => {
+          const isSelected = selectedUserDataset?.id === dataset.id && !useBuiltin;
+          const isEmpty = dataset.promptCount === 0;
+          return (
+            <SelectableCard
+              key={dataset.id}
+              isSelected={isSelected}
+              disabled={isEmpty}
+              onClick={async () => {
+                if (isEmpty) return;
+                try {
+                  const { prompts } = await readDataset(dataset.path);
+                  onSelect(dataset, (prompts || []) as DatasetPrompt[]);
+                } catch {
+                  onSelect(dataset, null);
+                }
+              }}
+              icon={
+                <Database
+                  size={14}
+                  color={
+                    isEmpty
+                      ? palette.status.error.text
+                      : isSelected
+                        ? palette.brand.primary
+                        : palette.text.disabled
+                  }
+                />
+              }
+              title={dataset.name}
+              description={isEmpty ? "Cannot use empty dataset" : "Custom uploaded dataset"}
+              chip={
+                <DatasetTypeChip
+                  turnType={dataset.turnType}
+                  isSelected={isSelected}
+                  promptCount={datasetPromptCount}
+                  isEmpty={isEmpty}
+                />
+              }
+            />
+          );
+        })}
+      </Stack>
+    </Box>
+  );
+}

--- a/Clients/src/presentation/pages/EvalsDashboard/NewExperiment/TemplateDatasetsSection.tsx
+++ b/Clients/src/presentation/pages/EvalsDashboard/NewExperiment/TemplateDatasetsSection.tsx
@@ -1,0 +1,93 @@
+/**
+ * @fileoverview "Option 3: templates" list for the Dataset wizard step.
+ *
+ * @module pages/EvalsDashboard/NewExperiment/TemplateDatasetsSection
+ */
+
+import { Box, Stack, Typography } from "@mui/material";
+import { Database } from "lucide-react";
+import SelectableCard from "../../../components/SelectableCard";
+import { palette } from "../../../themes/palette";
+import { readDataset } from "../../../../application/repository/deepEval.repository";
+import { DATASET_TEMPLATES, type DatasetPrompt, type TaskType } from "./newExperimentConfig";
+import DatasetTypeChip from "./DatasetTypeChip";
+
+export interface TemplateDatasetsSectionProps {
+  taskType: TaskType;
+  selectedPresetPath: string;
+  useBuiltin: boolean;
+  datasetPromptCount: number;
+  /**
+   * `prompts` is null when the dataset read fails (selection still updates;
+   * loaded flag is left alone — matches prior modal behavior).
+   */
+  onSelect: (path: string, prompts: DatasetPrompt[] | null) => void;
+}
+
+const TASK_TYPE_LABEL: Record<TaskType, string> = {
+  chatbot: "Chatbot",
+  rag: "RAG",
+  agent: "Agent",
+};
+
+export default function TemplateDatasetsSection({
+  taskType,
+  selectedPresetPath,
+  useBuiltin,
+  datasetPromptCount,
+  onSelect,
+}: TemplateDatasetsSectionProps) {
+  const templates = DATASET_TEMPLATES.filter((t) => t.taskType === taskType);
+
+  return (
+    <Box>
+      <Typography
+        sx={{
+          fontSize: "12px",
+          fontWeight: 600,
+          color: palette.text.disabled,
+          textTransform: "uppercase",
+          letterSpacing: "0.5px",
+          mb: 1,
+        }}
+      >
+        Option 3: {TASK_TYPE_LABEL[taskType]} templates
+      </Typography>
+      <Stack spacing="8px">
+        {templates.map((template) => {
+          const isSelected = selectedPresetPath === template.path && useBuiltin;
+          return (
+            <SelectableCard
+              key={template.path}
+              isSelected={isSelected}
+              onClick={async () => {
+                try {
+                  const { prompts } = await readDataset(template.path);
+                  onSelect(template.path, (prompts || []) as DatasetPrompt[]);
+                } catch {
+                  onSelect(template.path, null);
+                }
+              }}
+              icon={
+                <Database
+                  size={14}
+                  color={isSelected ? palette.accent.indigo.text : palette.text.disabled}
+                />
+              }
+              title={template.name}
+              description={template.desc}
+              accentColor={palette.accent.indigo.text}
+              chip={
+                <DatasetTypeChip
+                  turnType={template.type}
+                  isSelected={isSelected}
+                  promptCount={datasetPromptCount}
+                />
+              }
+            />
+          );
+        })}
+      </Stack>
+    </Box>
+  );
+}

--- a/Clients/src/presentation/pages/EvalsDashboard/NewExperiment/datasetUpload.ts
+++ b/Clients/src/presentation/pages/EvalsDashboard/NewExperiment/datasetUpload.ts
@@ -1,0 +1,65 @@
+/**
+ * @fileoverview Pure validation helpers for custom dataset JSON uploads.
+ *
+ * @module pages/EvalsDashboard/NewExperiment/datasetUpload
+ */
+
+export type DatasetValidationResult =
+  | { ok: true; validPromptCount: number }
+  | { ok: false; title: string; body: string };
+
+/**
+ * Count prompts that have actual content — either a non-empty `prompt` field
+ * (single-turn) or at least one turn with non-empty `content` (multi-turn).
+ */
+export function countValidPrompts(parsedData: unknown[]): number {
+  return parsedData.filter((item) => {
+    if (typeof item !== "object" || item === null) return false;
+    const obj = item as Record<string, unknown>;
+    if (obj.prompt && typeof obj.prompt === "string" && obj.prompt.trim()) return true;
+    if (Array.isArray(obj.turns) && obj.turns.length > 0) {
+      return obj.turns.some((turn) => {
+        if (typeof turn !== "object" || turn === null) return false;
+        const t = turn as Record<string, unknown>;
+        return t.content && typeof t.content === "string" && t.content.trim();
+      });
+    }
+    return false;
+  }).length;
+}
+
+/**
+ * Parse and validate a dataset JSON file before uploading. Returns either a
+ * valid prompt count or an alert-ready error title/body.
+ */
+export function validateDatasetFileContent(fileContent: string): DatasetValidationResult {
+  let parsedData: unknown[];
+  try {
+    parsedData = JSON.parse(fileContent);
+  } catch {
+    return {
+      ok: false,
+      title: "Invalid JSON",
+      body: "The file does not contain valid JSON",
+    };
+  }
+
+  if (!Array.isArray(parsedData) || parsedData.length === 0) {
+    return {
+      ok: false,
+      title: "Empty dataset",
+      body: "Cannot use an empty dataset. Please upload a file with at least one prompt.",
+    };
+  }
+
+  const validPromptCount = countValidPrompts(parsedData);
+  if (validPromptCount === 0) {
+    return {
+      ok: false,
+      title: "Empty dataset",
+      body: "Cannot use an empty dataset. Please upload a file with prompts that have actual content.",
+    };
+  }
+
+  return { ok: true, validPromptCount };
+}

--- a/Clients/src/presentation/pages/EvalsDashboard/NewExperiment/newExperimentConfig.ts
+++ b/Clients/src/presentation/pages/EvalsDashboard/NewExperiment/newExperimentConfig.ts
@@ -32,3 +32,131 @@ export const MODEL_PROVIDERS_WITHOUT_API_KEY = ["ollama", "local"] as const;
  * Used when computing missing keys for custom scorers.
  */
 export const SCORER_PROVIDERS_WITHOUT_API_KEY = ["self-hosted", "ollama"] as const;
+
+export type TaskType = "chatbot" | "rag" | "agent";
+
+export type DatasetTurnType = "single-turn" | "multi-turn" | "simulated";
+
+export interface DatasetPrompt {
+  id: string;
+  category: string;
+  prompt: string;
+  expected_output: string;
+  expected_keywords: string[];
+  difficulty: string;
+}
+
+export interface UserDataset {
+  id: string;
+  name: string;
+  path: string;
+  promptCount: number;
+  turnType?: DatasetTurnType;
+}
+
+export interface DatasetTemplate {
+  name: string;
+  path: string;
+  desc: string;
+  type: "single-turn" | "multi-turn";
+  taskType: TaskType;
+}
+
+/** Builtin preset templates shown on the Dataset wizard step, keyed by task type. */
+export const DATASET_TEMPLATES: readonly DatasetTemplate[] = [
+  // Chatbot — single-turn
+  {
+    name: "Basic Chatbot",
+    path: "chatbot/chatbot_basic.json",
+    desc: "Standard question-answer pairs",
+    type: "single-turn",
+    taskType: "chatbot",
+  },
+  {
+    name: "Coding Helper",
+    path: "chatbot/chatbot_coding_helper.json",
+    desc: "Code assistance scenarios",
+    type: "single-turn",
+    taskType: "chatbot",
+  },
+  {
+    name: "Customer Support (Single-Turn)",
+    path: "chatbot/chatbot_customer_support.json",
+    desc: "Support Q&A pairs",
+    type: "single-turn",
+    taskType: "chatbot",
+  },
+  // Chatbot — multi-turn
+  {
+    name: "General Assistant Multi-Turn",
+    path: "chatbot/chatbot_general_assistant_multiturn.json",
+    desc: "Multi-turn conversations",
+    type: "multi-turn",
+    taskType: "chatbot",
+  },
+  {
+    name: "Customer Support Multi-Turn",
+    path: "chatbot/chatbot_customer_support_multiturn.json",
+    desc: "Support conversations",
+    type: "multi-turn",
+    taskType: "chatbot",
+  },
+  {
+    name: "Tech Support Multi-Turn",
+    path: "chatbot/chatbot_tech_support_multiturn.json",
+    desc: "Technical help conversations",
+    type: "multi-turn",
+    taskType: "chatbot",
+  },
+  // RAG
+  {
+    name: "Product Docs",
+    path: "rag/rag_product_docs.json",
+    desc: "Product documentation queries",
+    type: "single-turn",
+    taskType: "rag",
+  },
+  {
+    name: "Wikipedia QA",
+    path: "rag/rag_wikipedia_small.json",
+    desc: "Wikipedia-based questions",
+    type: "single-turn",
+    taskType: "rag",
+  },
+  {
+    name: "Research Papers",
+    path: "rag/rag_research_papers.json",
+    desc: "Academic content retrieval",
+    type: "single-turn",
+    taskType: "rag",
+  },
+  {
+    name: "Document Q&A Multi-Turn",
+    path: "rag/rag_document_qa_multiturn.json",
+    desc: "Multi-turn document conversations",
+    type: "multi-turn",
+    taskType: "rag",
+  },
+  // Agent
+  {
+    name: "Agent Planning",
+    path: "agent/agent_planning_multiturn.json",
+    desc: "Multi-step planning scenarios",
+    type: "multi-turn",
+    taskType: "agent",
+  },
+  {
+    name: "Agent Task Execution",
+    path: "agent/agent_task_execution_multiturn.json",
+    desc: "Tool usage and task completion",
+    type: "multi-turn",
+    taskType: "agent",
+  },
+  {
+    name: "Agent Workflow Automation",
+    path: "agent/agent_workflow_automation_multiturn.json",
+    desc: "Automated workflow tasks",
+    type: "multi-turn",
+    taskType: "agent",
+  },
+];

--- a/Clients/src/presentation/pages/EvalsDashboard/NewExperimentModal.tsx
+++ b/Clients/src/presentation/pages/EvalsDashboard/NewExperimentModal.tsx
@@ -20,9 +20,7 @@ import {
 } from "@mui/material";
 import {
   Check,
-  Database,
   ExternalLink,
-  Upload,
   Sparkles,
   Settings,
   Plus,
@@ -55,7 +53,6 @@ import {
   listDatasets,
   listMyDatasets,
   readDataset,
-  uploadDataset,
   listScorers,
   getAllLlmApiKeys,
   addLlmApiKey,
@@ -74,11 +71,14 @@ import {
   generateDefaultExperimentName,
 } from "./NewExperiment/experimentNameHelpers";
 import {
+  type DatasetPrompt,
   type JudgeMode,
   type ProviderType,
+  type UserDataset,
   WIZARD_STEPS,
 } from "./NewExperiment/newExperimentConfig";
 import { canProceedToNextStep, getMissingKeyProviders } from "./NewExperiment/stepValidation";
+import DatasetStep from "./NewExperiment/DatasetStep";
 
 interface NewExperimentModalProps {
   isOpen: boolean;
@@ -129,33 +129,11 @@ export default function NewExperimentModal({
   const [apiKeyWarningAcknowledged, setApiKeyWarningAcknowledged] = useState(false);
 
   // Dataset prompts state
-  interface DatasetPrompt {
-    id: string;
-    category: string;
-    prompt: string;
-    expected_output: string;
-    expected_keywords: string[];
-    difficulty: string;
-  }
   const [datasetPrompts, setDatasetPrompts] = useState<DatasetPrompt[]>([]);
   const [datasetLoaded, setDatasetLoaded] = useState(false);
   // User's saved datasets (for "My datasets" option)
-  const [userDatasets, setUserDatasets] = useState<
-    Array<{
-      id: string;
-      name: string;
-      path: string;
-      promptCount: number;
-      turnType?: "single-turn" | "multi-turn" | "simulated";
-    }>
-  >([]);
-  const [selectedUserDataset, setSelectedUserDataset] = useState<{
-    id: string;
-    name: string;
-    path: string;
-    promptCount: number;
-    turnType?: "single-turn" | "multi-turn" | "simulated";
-  } | null>(null);
+  const [userDatasets, setUserDatasets] = useState<UserDataset[]>([]);
+  const [selectedUserDataset, setSelectedUserDataset] = useState<UserDataset | null>(null);
   const [loadingUserDatasets, setLoadingUserDatasets] = useState(false);
   const [uploadingDataset, setUploadingDataset] = useState(false);
   const [selectedPresetPath, setSelectedPresetPath] = useState<string>("");
@@ -1867,492 +1845,65 @@ export default function NewExperimentModal({
       case 1:
         // Step 2: Dataset
         return (
-          <Stack spacing="16px">
-            {/* Description */}
-            <Typography sx={{ fontSize: "13px", color: palette.text.tertiary, lineHeight: 1.5 }}>
-              Choose a dataset containing prompts and expected outputs. Upload your own JSON file,
-              select from saved datasets, or use a template.
-            </Typography>
-
-            {/* Option 1: Custom dataset */}
-            <Box>
-              <Typography
-                sx={{
-                  fontSize: "12px",
-                  fontWeight: 600,
-                  color: palette.text.disabled,
-                  textTransform: "uppercase",
-                  letterSpacing: "0.5px",
-                  mb: "8px",
-                }}
-              >
-                Option 1: Use custom dataset
-              </Typography>
-              {/* Upload Section - Compact drop zone */}
-              <Box
-                component="label"
-                sx={{
-                  "display": "flex",
-                  "alignItems": "center",
-                  "gap": "8px",
-                  "p": "8px",
-                  "border": "1px dashed",
-                  "borderColor": uploadingDataset ? palette.brand.primary : palette.border.dark,
-                  "borderRadius": "4px",
-                  "backgroundColor": palette.background.accent,
-                  "cursor": uploadingDataset ? "wait" : "pointer",
-                  "transition": "all 0.15s ease",
-                  "&:hover": {
-                    borderColor: palette.brand.primary,
-                    backgroundColor: palette.status.success.bg,
-                  },
-                }}
-              >
-                <Box
-                  sx={{
-                    width: 32,
-                    height: 32,
-                    borderRadius: "6px",
-                    backgroundColor: palette.brand.primary,
-                    display: "flex",
-                    alignItems: "center",
-                    justifyContent: "center",
-                    flexShrink: 0,
-                  }}
-                >
-                  <Upload size={16} color={palette.background.main} />
-                </Box>
-                <Box sx={{ flex: 1 }}>
-                  <Typography
-                    sx={{ fontSize: "13px", fontWeight: 500, color: palette.text.secondary }}
-                  >
-                    {uploadingDataset ? "Uploading..." : "Upload dataset"}
-                  </Typography>
-                  <Typography sx={{ fontSize: "11px", color: palette.text.disabled }}>
-                    JSON file with prompts and expected outputs
-                  </Typography>
-                </Box>
-                <input
-                  type="file"
-                  accept="application/json"
-                  hidden
-                  disabled={uploadingDataset}
-                  onChange={async (e) => {
-                    const file = e.target.files?.[0];
-                    if (!file) return;
-                    try {
-                      setUploadingDataset(true);
-                      // Validate file content before uploading
-                      const fileContent = await file.text();
-                      let parsedData: unknown[];
-                      try {
-                        parsedData = JSON.parse(fileContent);
-                      } catch {
-                        setAlert({
-                          show: true,
-                          variant: "error",
-                          title: "Invalid JSON",
-                          body: "The file does not contain valid JSON",
-                        });
-                        setTimeout(() => setAlert(null), 15000);
-                        return;
-                      }
-                      if (!Array.isArray(parsedData) || parsedData.length === 0) {
-                        setAlert({
-                          show: true,
-                          variant: "error",
-                          title: "Empty dataset",
-                          body: "Cannot use an empty dataset. Please upload a file with at least one prompt.",
-                        });
-                        setTimeout(() => setAlert(null), 15000);
-                        return;
-                      }
-                      // Count only prompts with actual content
-                      const validPromptCount = parsedData.filter((item) => {
-                        if (typeof item !== "object" || item === null) return false;
-                        const obj = item as Record<string, unknown>;
-                        // Single-turn: check if prompt field has content
-                        if (obj.prompt && typeof obj.prompt === "string" && obj.prompt.trim())
-                          return true;
-                        // Multi-turn: check if turns array has at least one turn with content
-                        if (Array.isArray(obj.turns) && obj.turns.length > 0) {
-                          return obj.turns.some((turn) => {
-                            if (typeof turn !== "object" || turn === null) return false;
-                            const t = turn as Record<string, unknown>;
-                            return t.content && typeof t.content === "string" && t.content.trim();
-                          });
-                        }
-                        return false;
-                      }).length;
-                      if (validPromptCount === 0) {
-                        setAlert({
-                          show: true,
-                          variant: "error",
-                          title: "Empty dataset",
-                          body: "Cannot use an empty dataset. Please upload a file with prompts that have actual content.",
-                        });
-                        setTimeout(() => setAlert(null), 15000);
-                        return;
-                      }
-                      const resp = await uploadDataset(
-                        file,
-                        "chatbot",
-                        "single-turn",
-                        orgId || undefined,
-                      );
-                      const newDataset = {
-                        id: resp.path,
-                        name: file.name.replace(/\.json$/i, ""),
-                        path: resp.path,
-                        promptCount: validPromptCount,
-                      };
-                      setUserDatasets((prev) => [newDataset, ...prev]);
-                      setSelectedUserDataset(newDataset);
-                      setConfig((prev) => ({
-                        ...prev,
-                        dataset: { ...prev.dataset, useBuiltin: false },
-                      }));
-                      try {
-                        const { prompts } = await readDataset(resp.path);
-                        setDatasetPrompts((prompts || []) as DatasetPrompt[]);
-                        setDatasetLoaded(true);
-                      } catch {
-                        setDatasetPrompts([]);
-                      }
-                      setAlert({
-                        show: true,
-                        variant: "success",
-                        title: "Uploaded!",
-                        body: `${file.name} is ready to use`,
-                      });
-                      setTimeout(() => setAlert(null), 5000);
-                    } catch (err) {
-                      setAlert({
-                        show: true,
-                        variant: "error",
-                        title: "Upload failed",
-                        body: err instanceof Error ? err.message : "Failed to upload",
-                      });
-                      setTimeout(() => setAlert(null), 15000);
-                    } finally {
-                      setUploadingDataset(false);
-                      e.target.value = "";
-                    }
-                  }}
-                />
-              </Box>
-            </Box>
-
-            {/* My Datasets Section */}
-            {loadingUserDatasets ? (
-              <Box sx={{ py: 2, textAlign: "center" }}>
-                <Typography sx={{ fontSize: "13px", color: palette.text.tertiary }}>
-                  Loading your datasets...
-                </Typography>
-              </Box>
-            ) : userDatasets.length > 0 ? (
-              <Box>
-                <Stack
-                  direction="row"
-                  alignItems="center"
-                  justifyContent="space-between"
-                  sx={{ mb: 1 }}
-                >
-                  <Typography
-                    sx={{
-                      fontSize: "12px",
-                      fontWeight: 600,
-                      color: palette.text.disabled,
-                      textTransform: "uppercase",
-                      letterSpacing: "0.5px",
-                    }}
-                  >
-                    Option 2: Your datasets
-                  </Typography>
-                  <Button
-                    size="small"
-                    variant="text"
-                    startIcon={<ExternalLink size={12} />}
-                    onClick={() => window.open(`/evals/${projectId}#datasets`, "_blank")}
-                    sx={{
-                      "textTransform": "none",
-                      "fontSize": "11px",
-                      "color": palette.text.tertiary,
-                      "p": 0.5,
-                      "minWidth": "auto",
-                      "&:hover": { color: palette.brand.primary },
-                    }}
-                  >
-                    Manage
-                  </Button>
-                </Stack>
-                <Stack spacing="8px">
-                  {userDatasets.slice(0, 4).map((dataset) => {
-                    const isSelected =
-                      selectedUserDataset?.id === dataset.id && !config.dataset.useBuiltin;
-                    const isMultiTurn = dataset.turnType === "multi-turn";
-                    const isSimulated = dataset.turnType === "simulated";
-                    const isEmpty = dataset.promptCount === 0;
-                    const typeChip = isEmpty ? (
-                      <Chip
-                        label="Empty"
-                        backgroundColor={palette.status.error.bg}
-                        textColor={palette.status.error.text}
-                        uppercase={false}
-                      />
-                    ) : isMultiTurn ? (
-                      <Chip
-                        label={
-                          isSelected && datasetPrompts.length > 0
-                            ? `${datasetPrompts.length} prompts`
-                            : "Multi-Turn"
-                        }
-                        backgroundColor={palette.accent.blue.bg}
-                        textColor={palette.accent.blue.text}
-                        uppercase={false}
-                      />
-                    ) : isSimulated ? (
-                      <Chip
-                        label={
-                          isSelected && datasetPrompts.length > 0
-                            ? `${datasetPrompts.length} prompts`
-                            : "Simulated"
-                        }
-                        backgroundColor={palette.accent.purple.bg}
-                        textColor={palette.accent.purple.text}
-                        uppercase={false}
-                      />
-                    ) : (
-                      <Chip
-                        label={
-                          isSelected && datasetPrompts.length > 0
-                            ? `${datasetPrompts.length} prompts`
-                            : "Single-Turn"
-                        }
-                        backgroundColor={palette.status.warning.bg}
-                        textColor={palette.status.warning.text}
-                        uppercase={false}
-                      />
-                    );
-                    return (
-                      <SelectableCard
-                        key={dataset.id}
-                        isSelected={isSelected}
-                        disabled={isEmpty}
-                        onClick={async () => {
-                          if (isEmpty) return;
-                          setConfig((prev) => ({
-                            ...prev,
-                            dataset: { ...prev.dataset, useBuiltin: false },
-                          }));
-                          setSelectedUserDataset(dataset);
-                          setSelectedPresetPath("");
-                          try {
-                            const { prompts } = await readDataset(dataset.path);
-                            setDatasetPrompts((prompts || []) as DatasetPrompt[]);
-                            setDatasetLoaded(true);
-                          } catch {
-                            setDatasetPrompts([]);
-                          }
-                        }}
-                        icon={
-                          <Database
-                            size={14}
-                            color={
-                              isEmpty
-                                ? palette.status.error.text
-                                : isSelected
-                                  ? palette.brand.primary
-                                  : palette.text.disabled
-                            }
-                          />
-                        }
-                        title={dataset.name}
-                        description={
-                          isEmpty ? "Cannot use empty dataset" : "Custom uploaded dataset"
-                        }
-                        chip={typeChip}
-                      />
-                    );
-                  })}
-                </Stack>
-              </Box>
-            ) : null}
-
-            {/* Template Datasets Section */}
-            <Box>
-              <Typography
-                sx={{
-                  fontSize: "12px",
-                  fontWeight: 600,
-                  color: palette.text.disabled,
-                  textTransform: "uppercase",
-                  letterSpacing: "0.5px",
-                  mb: 1,
-                }}
-              >
-                Option 3:{" "}
-                {config.taskType === "chatbot"
-                  ? "Chatbot"
-                  : config.taskType === "rag"
-                    ? "RAG"
-                    : "Agent"}{" "}
-                templates
-              </Typography>
-              <Stack spacing="8px">
-                {[
-                  ...(config.taskType === "chatbot"
-                    ? [
-                        // Single-turn chatbot templates
-                        {
-                          name: "Basic Chatbot",
-                          path: "chatbot/chatbot_basic.json",
-                          desc: "Standard question-answer pairs",
-                          type: "single-turn" as const,
-                        },
-                        {
-                          name: "Coding Helper",
-                          path: "chatbot/chatbot_coding_helper.json",
-                          desc: "Code assistance scenarios",
-                          type: "single-turn" as const,
-                        },
-                        {
-                          name: "Customer Support (Single-Turn)",
-                          path: "chatbot/chatbot_customer_support.json",
-                          desc: "Support Q&A pairs",
-                          type: "single-turn" as const,
-                        },
-                        // Multi-turn chatbot templates
-                        {
-                          name: "General Assistant Multi-Turn",
-                          path: "chatbot/chatbot_general_assistant_multiturn.json",
-                          desc: "Multi-turn conversations",
-                          type: "multi-turn" as const,
-                        },
-                        {
-                          name: "Customer Support Multi-Turn",
-                          path: "chatbot/chatbot_customer_support_multiturn.json",
-                          desc: "Support conversations",
-                          type: "multi-turn" as const,
-                        },
-                        {
-                          name: "Tech Support Multi-Turn",
-                          path: "chatbot/chatbot_tech_support_multiturn.json",
-                          desc: "Technical help conversations",
-                          type: "multi-turn" as const,
-                        },
-                      ]
-                    : []),
-                  ...(config.taskType === "rag"
-                    ? [
-                        {
-                          name: "Product Docs",
-                          path: "rag/rag_product_docs.json",
-                          desc: "Product documentation queries",
-                          type: "single-turn" as const,
-                        },
-                        {
-                          name: "Wikipedia QA",
-                          path: "rag/rag_wikipedia_small.json",
-                          desc: "Wikipedia-based questions",
-                          type: "single-turn" as const,
-                        },
-                        {
-                          name: "Research Papers",
-                          path: "rag/rag_research_papers.json",
-                          desc: "Academic content retrieval",
-                          type: "single-turn" as const,
-                        },
-                        {
-                          name: "Document Q&A Multi-Turn",
-                          path: "rag/rag_document_qa_multiturn.json",
-                          desc: "Multi-turn document conversations",
-                          type: "multi-turn" as const,
-                        },
-                      ]
-                    : []),
-                  ...(config.taskType === "agent"
-                    ? [
-                        {
-                          name: "Agent Planning",
-                          path: "agent/agent_planning_multiturn.json",
-                          desc: "Multi-step planning scenarios",
-                          type: "multi-turn" as const,
-                        },
-                        {
-                          name: "Agent Task Execution",
-                          path: "agent/agent_task_execution_multiturn.json",
-                          desc: "Tool usage and task completion",
-                          type: "multi-turn" as const,
-                        },
-                        {
-                          name: "Agent Workflow Automation",
-                          path: "agent/agent_workflow_automation_multiturn.json",
-                          desc: "Automated workflow tasks",
-                          type: "multi-turn" as const,
-                        },
-                      ]
-                    : []),
-                ].map((template) => {
-                  const isSelected =
-                    selectedPresetPath === template.path && config.dataset.useBuiltin;
-                  const chipLabel =
-                    isSelected && datasetPrompts.length > 0
-                      ? `${datasetPrompts.length} prompts`
-                      : template.type === "multi-turn"
-                        ? "Multi-Turn"
-                        : "Single-Turn";
-                  const typeChip =
-                    template.type === "multi-turn" ? (
-                      <Chip
-                        label={chipLabel}
-                        backgroundColor={palette.accent.blue.bg}
-                        textColor={palette.accent.blue.text}
-                        uppercase={false}
-                      />
-                    ) : (
-                      <Chip
-                        label={chipLabel}
-                        backgroundColor={palette.status.warning.bg}
-                        textColor={palette.status.warning.text}
-                        uppercase={false}
-                      />
-                    );
-                  return (
-                    <SelectableCard
-                      key={template.path}
-                      isSelected={isSelected}
-                      onClick={async () => {
-                        setConfig((prev) => ({
-                          ...prev,
-                          dataset: { ...prev.dataset, useBuiltin: true },
-                        }));
-                        setSelectedUserDataset(null);
-                        setSelectedPresetPath(template.path);
-                        try {
-                          const { prompts } = await readDataset(template.path);
-                          setDatasetPrompts((prompts || []) as DatasetPrompt[]);
-                          setDatasetLoaded(true);
-                        } catch {
-                          setDatasetPrompts([]);
-                        }
-                      }}
-                      icon={
-                        <Database
-                          size={14}
-                          color={isSelected ? palette.accent.indigo.text : palette.text.disabled}
-                        />
-                      }
-                      title={template.name}
-                      description={template.desc}
-                      accentColor={palette.accent.indigo.text}
-                      chip={typeChip}
-                    />
-                  );
-                })}
-              </Stack>
-            </Box>
-          </Stack>
+          <DatasetStep
+            taskType={config.taskType}
+            useBuiltin={config.dataset.useBuiltin}
+            userDatasets={userDatasets}
+            selectedUserDataset={selectedUserDataset}
+            loadingUserDatasets={loadingUserDatasets}
+            uploadingDataset={uploadingDataset}
+            selectedPresetPath={selectedPresetPath}
+            datasetPromptCount={datasetPrompts.length}
+            orgId={orgId}
+            projectId={projectId}
+            onUploadingChange={setUploadingDataset}
+            onAlert={({ variant, title, body, autoHideMs }) => {
+              setAlert({ show: true, variant, title, body });
+              setTimeout(() => setAlert(null), autoHideMs);
+            }}
+            onUploadComplete={(dataset, prompts) => {
+              setUserDatasets((prev) => [dataset, ...prev]);
+              setSelectedUserDataset(dataset);
+              setConfig((prev) => ({
+                ...prev,
+                dataset: { ...prev.dataset, useBuiltin: false },
+              }));
+              if (prompts !== null) {
+                setDatasetPrompts(prompts);
+                setDatasetLoaded(true);
+              } else {
+                setDatasetPrompts([]);
+              }
+            }}
+            onUserDatasetSelect={(dataset, prompts) => {
+              setConfig((prev) => ({
+                ...prev,
+                dataset: { ...prev.dataset, useBuiltin: false },
+              }));
+              setSelectedUserDataset(dataset);
+              setSelectedPresetPath("");
+              if (prompts !== null) {
+                setDatasetPrompts(prompts);
+                setDatasetLoaded(true);
+              } else {
+                setDatasetPrompts([]);
+              }
+            }}
+            onPresetSelect={(path, prompts) => {
+              setConfig((prev) => ({
+                ...prev,
+                dataset: { ...prev.dataset, useBuiltin: true },
+              }));
+              setSelectedUserDataset(null);
+              setSelectedPresetPath(path);
+              if (prompts !== null) {
+                setDatasetPrompts(prompts);
+                setDatasetLoaded(true);
+              } else {
+                setDatasetPrompts([]);
+              }
+            }}
+          />
         );
 
       case 2:


### PR DESCRIPTION

Describe your changes
Extract the Dataset wizard step from NewExperimentModal into co-located modules: DatasetStep, DatasetUploadZone, MyDatasetsSection, TemplateDatasetsSection, DatasetTypeChip, and datasetUpload validation helpers.
Keep the modal as the state owner; step components only render and fire callbacks.
Reduce modal size without changing Dataset-step selection or client-side upload validation behavior.

Write your issue number after "Fixes "
Fixes #4428 

Please ensure all items are checked off before requesting a review:

- [x]  I deployed the code locally.
- [x]  I have performed a self-review of my code.
- [x]  I have included the issue # in the PR.
- [x]  I have labelled the PR correctly.
- [x]  The issue I am working on is assigned to me.
- [x]  I have avoided using hardcoded values to ensure scalability and maintain consistency across the application.
- [ ]  I have ensured that font sizes, color choices, and other UI elements are referenced from the theme.
- [ ]  My pull request is focused and addresses a single, specific feature.
- [ ]  If there are UI changes, I have attached a screenshot or video to this PR.
- [ ]  If I added or modified an API endpoint, the change is reflected in the generated OpenAPI spec (npm run generate:swagger).
- [ ]  If the endpoint requires authentication, it uses authenticateJWT and the generated spec declares bearerAuth security.
- [ ]  I ran npm run check:api-drift and committed the regenerated swagger.yaml and endpoints.ts.
- [ ]  If this PR adds or modifies an organization-scoped table, the [tenant isolation registry](https://github.com/verifywise-ai/verifywise/pull/Servers/tests/integration/tenant-isolation/tenantIsolation.registry.ts) and [test matrix](https://github.com/verifywise-ai/verifywise/pull/Servers/tests/integration/tenant-isolation) are updated. See the [tenant isolation runbook](https://github.com/verifywise-ai/verifywise/pull/docs/technical/security/tenant-isolation.md) for details.