### PR TITLE
docs(claude): add project-specific build, PR, and UI component rules

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -100,6 +100,9 @@ cd EvalServer/src && alembic upgrade head && uvicorn app:app --port 8000 --worke
 
 ### Git Workflow
 
+**Always work on a branch — never commit directly to `main`, `master`, or
+`develop`.** One branch per feature or fix.
+
 ```bash
 # Branch naming
 feature/description    fix/description    docs/description
@@ -113,6 +116,8 @@ fix(dashboard): resolve chart rendering issue
 ### PR Checklist
 
 - [ ] Build passes locally (`cd Servers && npm run build` and `cd Clients && npm run build`)
+- [ ] `npm run format-check` clean in **both** `Servers` and `Clients` — if either
+      reports issues, run `npm run format`, then recommit before opening the PR
 - [ ] Self-review completed
 - [ ] Issue number included
 - [ ] No hardcoded values
@@ -120,6 +125,10 @@ fix(dashboard): resolve chart rendering issue
 - [ ] Tests written/updated
 - [ ] No console.log statements
 - [ ] No sensitive data exposed
+
+**Never open a PR without explicit permission.** "Ship it", "go ahead", "looks
+good" refer to the work in progress, not to opening a PR. Pushing a branch is
+fine unasked; `gh pr create` is not.
 
 ---
 
@@ -157,6 +166,30 @@ fix(dashboard): resolve chart rendering issue
 | Files (Utilities) | camelCase | `formatDate.ts` |
 | Database Tables | snake_case | `user_profiles` |
 | API Endpoints | kebab-case | `/api/user-profiles` |
+
+---
+
+## UI Component Patterns
+
+**Prefer VerifyWise components over MUI where one exists.** MUI is a dependency
+(`@mui/material`, `@mui/lab`, `@mui/x-charts`, `@mui/x-date-pickers`) and is
+fine underneath, but a screen should reach for the house component first so
+behaviour stays consistent.
+
+| Need | Use | In use |
+|------|-----|--------|
+| Modal | `StandardModal` with `useStandardModal` + `onSubmitRef` | ~137 files |
+| Dropdown | `CustomizableButton` + `Popover` | ~220 files |
+| Search input | `SearchBox` | ~57 files |
+
+Check for an existing pattern before implementing a new one — these are already
+used across most of `Clients/src`, so a bespoke version is nearly always a
+duplicate.
+
+House UI rules: sentence case for all screen text; border `#d0d5dd`; border
+radius 4px; green primary `#13715B`; 30px control height on desktop (buttons,
+inputs, selects, dropdown triggers) — mobile/touch primitives keep their larger
+sizes.
 
 ---
 


### PR DESCRIPTION
Adds five conventions to `CLAUDE.md` that were previously held outside the repo, where they were phrased as if they applied to every project. They do not — they are specific to this codebase, and stating them globally caused them to be applied to an unrelated project with a different stack and a different branch policy.

Documentation only. No code, config, or dependency changes.

## Rules added

- **Branch policy** — never commit directly to `main` / `master` / `develop`; one branch per feature or fix.
- **`format-check` in the PR checklist** — `prettier --check .` exists in both `Servers` and `Clients`; run `npm run format` and recommit if either reports issues.
- **PR permission** — pushing a branch unasked is fine; opening a PR is not.
- **MUI preference** — `@mui/material`, `@mui/lab`, `@mui/x-charts` and `@mui/x-date-pickers` are real dependencies, so the rule is "reach for the house component first", not "no MUI".
- **Component patterns** — `StandardModal`, `CustomizableButton` + `Popover`, and `SearchBox` are the established patterns; check for one before building a bespoke equivalent.

The existing build-gate rule already covered its ground and was not duplicated.

## Verification

Each claim was checked against `develop` at commit time, not assumed:

- `format-check` resolves to `prettier --check .` in both `Servers/package.json` and `Clients/package.json`.
- All four `@mui/*` packages are present in `Clients/package.json`.
- The three components are in active use across `Clients/src`.

Usage counts are written approximate (`~137`, `~220`, `~57`) on purpose. They had already drifted from figures measured a day earlier, and an exact number in a doc reads as authoritative long after it stops being true.