### PR TITLE
Feat: Optimistic updates and targeted cache

### DIFF
--- a/Clients/src/application/hooks/__tests__/integration/optimisticMutations.integration.test.ts
+++ b/Clients/src/application/hooks/__tests__/integration/optimisticMutations.integration.test.ts
@@ -1,0 +1,137 @@
+/**
+ * Integration-style "instant feedback" demo: with a slow server, a task
+ * update and a file-tag add are visible in the query cache (i.e. what the
+ * table/banner renders) before the server responds, and the cache settles to
+ * the authoritative server entity once the requests resolve.
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { renderHook, act, waitFor } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import React from "react";
+import { useUpdateTask } from "../../useTaskMutations";
+import { useAddFileTags } from "../../useFileTagMutations";
+import { taskQueryKeys } from "../../useTasks";
+import { fileQueryKeys } from "../../useFiles";
+import { TaskStatus, TaskPriority } from "../../../../domain/enums/task.enum";
+import type { ITask } from "../../../../domain/interfaces/i.task";
+import { FileModel } from "../../../../domain/models/Common/file/file.model";
+
+vi.mock("../../../repository/task.repository", () => ({
+  updateTask: vi.fn(),
+}));
+
+vi.mock("../../../repository/file.repository", () => ({
+  updateFileMetadata: vi.fn(),
+}));
+
+vi.mock("../../../tools/alertUtils", () => ({
+  showAlert: vi.fn(),
+}));
+
+import { updateTask } from "../../../repository/task.repository";
+import { updateFileMetadata } from "../../../repository/file.repository";
+
+const mockUpdateTask = vi.mocked(updateTask);
+const mockUpdateFileMetadata = vi.mocked(updateFileMetadata);
+
+function deferred<T>() {
+  let resolve: (value: T) => void = () => {};
+  let reject: (error: unknown) => void = () => {};
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+}
+
+describe("optimistic mutations — instant feedback flow", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("shows a task update and a tag add immediately, then settles to the server entities", async () => {
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+    });
+    const wrapper = ({ children }: { children: React.ReactNode }) =>
+      React.createElement(QueryClientProvider, { client: queryClient }, children);
+
+    const taskKey = taskQueryKeys.list({});
+    const fileKey = fileQueryKeys.list({});
+    queryClient.setQueryData<ITask[]>(taskKey, [
+      {
+        id: 1,
+        title: "Review model",
+        creator_id: 1,
+        status: TaskStatus.OPEN,
+        priority: TaskPriority.LOW,
+      },
+    ]);
+    queryClient.setQueryData<FileModel[]>(fileKey, [
+      FileModel.createNewFile({
+        id: "7",
+        fileName: "evidence.pdf",
+        uploadDate: new Date("2026-01-01"),
+        uploader: "1",
+        tags: [],
+      }),
+    ]);
+
+    // Slow server: neither request resolves until we say so.
+    const taskRequest = deferred<unknown>();
+    const tagRequest = deferred<unknown>();
+    mockUpdateTask.mockImplementation(() => taskRequest.promise as Promise<any>);
+    mockUpdateFileMetadata.mockImplementation(() => tagRequest.promise as Promise<any>);
+
+    const invalidateSpy = vi.spyOn(queryClient, "invalidateQueries");
+
+    const { result } = renderHook(
+      () => ({ updateTask: useUpdateTask(), addFileTags: useAddFileTags() }),
+      { wrapper },
+    );
+
+    act(() => {
+      result.current.updateTask.mutate({ id: 1, body: { status: TaskStatus.IN_PROGRESS } });
+      result.current.addFileTags.mutate({ id: "7", currentTags: [], tags: ["evidence"] });
+    });
+
+    // Instant feedback: both caches update while the server is still pending.
+    await waitFor(() => {
+      expect(queryClient.getQueryData<ITask[]>(taskKey)?.[0].status).toBe(TaskStatus.IN_PROGRESS);
+      expect(queryClient.getQueryData<FileModel[]>(fileKey)?.[0].tags).toEqual(["evidence"]);
+    });
+    expect(result.current.updateTask.isPending).toBe(true);
+    expect(result.current.addFileTags.isPending).toBe(true);
+
+    // Server responds with the authoritative entities.
+    act(() => {
+      taskRequest.resolve({
+        message: "Updated",
+        data: {
+          id: 1,
+          title: "Review model",
+          creator_id: 1,
+          status: TaskStatus.IN_PROGRESS,
+          priority: TaskPriority.HIGH, // server-side recomputation wins
+        },
+      });
+      tagRequest.resolve({ id: "7", tags: ["evidence", "reviewed"] });
+    });
+
+    await waitFor(() => {
+      expect(result.current.updateTask.isSuccess).toBe(true);
+      expect(result.current.addFileTags.isSuccess).toBe(true);
+    });
+
+    // Cache settles to exactly what the server returned.
+    expect(queryClient.getQueryData<ITask[]>(taskKey)?.[0].priority).toBe(TaskPriority.HIGH);
+    expect(queryClient.getQueryData<FileModel[]>(fileKey)?.[0].tags).toEqual([
+      "evidence",
+      "reviewed",
+    ]);
+
+    // No list refetches: only the derived dashboard/deadline queries refresh.
+    const keys = invalidateSpy.mock.calls.map(
+      (call) => (call[0] as { queryKey: unknown[] }).queryKey,
+    );
+    expect(keys.every((key) => key[0] !== "tasks" && key[0] !== "files")).toBe(true);
+  });
+});

--- a/Clients/src/application/hooks/__tests__/useFileTagMutations.test.ts
+++ b/Clients/src/application/hooks/__tests__/useFileTagMutations.test.ts
@@ -1,0 +1,222 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { renderHook, act, waitFor } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import React from "react";
+import { useAddFileTags, useRemoveFileTag } from "../useFileTagMutations";
+import { fileQueryKeys } from "../useFiles";
+import { FileModel } from "../../../domain/models/Common/file/file.model";
+
+vi.mock("../../repository/file.repository", () => ({
+  updateFileMetadata: vi.fn(),
+}));
+
+vi.mock("../../tools/alertUtils", () => ({
+  showAlert: vi.fn(),
+}));
+
+import { updateFileMetadata } from "../../repository/file.repository";
+import { showAlert } from "../../tools/alertUtils";
+
+const mockUpdateFileMetadata = vi.mocked(updateFileMetadata);
+const mockShowAlert = vi.mocked(showAlert);
+
+function createWrapper() {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  });
+  return {
+    queryClient,
+    wrapper: ({ children }: { children: React.ReactNode }) =>
+      React.createElement(QueryClientProvider, { client: queryClient }, children),
+  };
+}
+
+function makeFile(id: string, tags: string[] = []): FileModel {
+  return FileModel.createNewFile({
+    id,
+    fileName: `file-${id}.pdf`,
+    uploadDate: new Date("2026-01-01"),
+    uploader: "1",
+    tags,
+  });
+}
+
+function deferred<T>() {
+  let resolve: (value: T) => void = () => {};
+  let reject: (error: unknown) => void = () => {};
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+}
+
+describe("useAddFileTags", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("patches tags optimistically before the server responds, then applies the server tags", async () => {
+    // Repository resolves with the FileMetadata entity.
+    const d = deferred<unknown>();
+    mockUpdateFileMetadata.mockImplementation(() => d.promise as Promise<any>);
+
+    const queryKey = fileQueryKeys.list({});
+    const { queryClient, wrapper } = createWrapper();
+    queryClient.setQueryData<FileModel[]>(queryKey, [makeFile("1", ["draft"]), makeFile("2")]);
+
+    const invalidateSpy = vi.spyOn(queryClient, "invalidateQueries");
+
+    const { result } = renderHook(() => useAddFileTags(), { wrapper });
+
+    act(() => {
+      result.current.mutate({ id: "1", currentTags: ["draft"], tags: ["legal", "ai"] });
+    });
+
+    // Optimistic merged tags are visible before the repository promise resolves.
+    await waitFor(() => {
+      const data = queryClient.getQueryData<FileModel[]>(queryKey);
+      expect(data?.[0].tags).toEqual(["draft", "legal", "ai"]);
+      expect(data?.[1].tags).toEqual([]);
+    });
+    expect(mockUpdateFileMetadata).toHaveBeenCalledWith({
+      id: "1",
+      updates: { tags: ["draft", "legal", "ai"] },
+    });
+
+    act(() => {
+      d.resolve({ id: "1", tags: ["draft", "legal", "ai", "server-added"] });
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    // Authoritative server tags replace the optimistic ones.
+    expect(queryClient.getQueryData<FileModel[]>(queryKey)?.[0].tags).toEqual([
+      "draft",
+      "legal",
+      "ai",
+      "server-added",
+    ]);
+
+    // No refetch of any kind on success — the cache holds the server entity.
+    expect(invalidateSpy).not.toHaveBeenCalled();
+  });
+
+  it("deduplicates tags that already exist", async () => {
+    const d = deferred<unknown>();
+    mockUpdateFileMetadata.mockImplementation(() => d.promise as Promise<any>);
+
+    const queryKey = fileQueryKeys.list({});
+    const { queryClient, wrapper } = createWrapper();
+    queryClient.setQueryData<FileModel[]>(queryKey, [makeFile("1", ["draft"])]);
+
+    const { result } = renderHook(() => useAddFileTags(), { wrapper });
+
+    act(() => {
+      result.current.mutate({ id: "1", currentTags: ["draft"], tags: ["draft", "new"] });
+    });
+
+    await waitFor(() =>
+      expect(queryClient.getQueryData<FileModel[]>(queryKey)?.[0].tags).toEqual(["draft", "new"]),
+    );
+    expect(mockUpdateFileMetadata).toHaveBeenCalledWith({
+      id: "1",
+      updates: { tags: ["draft", "new"] },
+    });
+
+    act(() => {
+      d.resolve({ id: "1", tags: ["draft", "new"] });
+    });
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+  });
+
+  it("rolls back tags on failure and toasts for 4xx errors", async () => {
+    const d = deferred<never>();
+    mockUpdateFileMetadata.mockImplementation(() => d.promise as Promise<any>);
+
+    const queryKey = fileQueryKeys.list({});
+    const { queryClient, wrapper } = createWrapper();
+    queryClient.setQueryData<FileModel[]>(queryKey, [makeFile("1", ["draft"])]);
+
+    const { result } = renderHook(() => useAddFileTags(), { wrapper });
+
+    act(() => {
+      result.current.mutate({ id: "1", currentTags: ["draft"], tags: ["legal"] });
+    });
+
+    await waitFor(() =>
+      expect(queryClient.getQueryData<FileModel[]>(queryKey)?.[0].tags).toEqual(["draft", "legal"]),
+    );
+
+    act(() => {
+      d.reject({ response: { status: 400 }, message: "Bad request" });
+    });
+
+    await waitFor(() => expect(result.current.isError).toBe(true));
+    expect(queryClient.getQueryData<FileModel[]>(queryKey)?.[0].tags).toEqual(["draft"]);
+    expect(mockShowAlert).toHaveBeenCalledWith(expect.objectContaining({ variant: "error" }));
+  });
+});
+
+describe("useRemoveFileTag", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("removes the tag optimistically and keeps the server tags on success", async () => {
+    const d = deferred<unknown>();
+    mockUpdateFileMetadata.mockImplementation(() => d.promise as Promise<any>);
+
+    const queryKey = fileQueryKeys.list({});
+    const { queryClient, wrapper } = createWrapper();
+    queryClient.setQueryData<FileModel[]>(queryKey, [makeFile("1", ["draft", "legal"])]);
+
+    const invalidateSpy = vi.spyOn(queryClient, "invalidateQueries");
+
+    const { result } = renderHook(() => useRemoveFileTag(), { wrapper });
+
+    act(() => {
+      result.current.mutate({ id: "1", currentTags: ["draft", "legal"], tag: "legal" });
+    });
+
+    await waitFor(() =>
+      expect(queryClient.getQueryData<FileModel[]>(queryKey)?.[0].tags).toEqual(["draft"]),
+    );
+    expect(mockUpdateFileMetadata).toHaveBeenCalledWith({
+      id: "1",
+      updates: { tags: ["draft"] },
+    });
+
+    act(() => {
+      d.resolve({ id: "1", tags: [] });
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(queryClient.getQueryData<FileModel[]>(queryKey)?.[0].tags).toEqual([]);
+    expect(invalidateSpy).not.toHaveBeenCalled();
+  });
+
+  it("restores tags when removal fails", async () => {
+    const d = deferred<never>();
+    mockUpdateFileMetadata.mockImplementation(() => d.promise as Promise<any>);
+
+    const queryKey = fileQueryKeys.list({});
+    const { queryClient, wrapper } = createWrapper();
+    queryClient.setQueryData<FileModel[]>(queryKey, [makeFile("1", ["draft", "legal"])]);
+
+    const { result } = renderHook(() => useRemoveFileTag(), { wrapper });
+
+    act(() => {
+      result.current.mutate({ id: "1", currentTags: ["draft", "legal"], tag: "legal" });
+    });
+
+    await waitFor(() =>
+      expect(queryClient.getQueryData<FileModel[]>(queryKey)?.[0].tags).toEqual(["draft"]),
+    );
+
+    act(() => {
+      d.reject({ response: { status: 500 }, message: "Server error" });
+    });
+
+    await waitFor(() => expect(result.current.isError).toBe(true));
+    expect(queryClient.getQueryData<FileModel[]>(queryKey)?.[0].tags).toEqual(["draft", "legal"]);
+    // 5xx is toasted by the axios interceptor, not the hook.
+    expect(mockShowAlert).not.toHaveBeenCalled();
+  });
+});

--- a/Clients/src/application/hooks/__tests__/usePolicyMutations.test.ts
+++ b/Clients/src/application/hooks/__tests__/usePolicyMutations.test.ts
@@ -2,17 +2,25 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 import { renderHook, act, waitFor } from "@testing-library/react";
 import React from "react";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import { useCreatePolicy, useUpdatePolicy } from "../usePolicyMutations";
+import { useCreatePolicy, useUpdatePolicy, useDeletePolicy } from "../usePolicyMutations";
 import { policyQueryKeys } from "../usePolicies";
+import { tagQueryKeys } from "../useTags";
 import { PolicyManagerModel } from "../../../domain/models/Common/policy/policyManager.model";
 import { PolicyInput } from "../../../domain/interfaces/i.policy";
 
 const mockCreatePolicy = vi.fn();
 const mockUpdatePolicy = vi.fn();
+const mockDeletePolicy = vi.fn();
+const mockShowAlert = vi.fn();
 
 vi.mock("../../repository/policy.repository", () => ({
   createPolicy: (...args: unknown[]) => mockCreatePolicy(...args),
   updatePolicy: (...args: unknown[]) => mockUpdatePolicy(...args),
+  deletePolicy: (...args: unknown[]) => mockDeletePolicy(...args),
+}));
+
+vi.mock("../../tools/alertUtils", () => ({
+  showAlert: (...args: unknown[]) => mockShowAlert(...args),
 }));
 
 function createPolicy(id: number, overrides: Partial<PolicyManagerModel> = {}): PolicyManagerModel {
@@ -162,5 +170,91 @@ describe("useUpdatePolicy", () => {
 
     expect(mockUpdatePolicy).toHaveBeenCalledWith(1, input);
     expect(returned).toEqual(updated);
+  });
+});
+
+describe("useDeletePolicy", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("removes the policy optimistically and invalidates only policy-tags on success", async () => {
+    let resolveMutation: () => void = () => {};
+    mockDeletePolicy.mockImplementation(
+      () =>
+        new Promise<void>((resolve) => {
+          resolveMutation = resolve;
+        }),
+    );
+
+    const queryKey = policyQueryKeys.list();
+    const { queryClient, wrapper } = createWrapper();
+
+    queryClient.setQueryData(queryKey, [createPolicy(1), createPolicy(2)]);
+
+    const invalidateSpy = vi.spyOn(queryClient, "invalidateQueries");
+
+    const { result } = renderHook(() => useDeletePolicy(), { wrapper });
+
+    act(() => {
+      result.current.mutate(1);
+    });
+
+    // Optimistic removal is visible before the repository promise resolves.
+    await waitFor(() => {
+      const data = queryClient.getQueryData<PolicyManagerModel[]>(queryKey);
+      expect(data?.map((p) => p.id)).toEqual([2]);
+    });
+    expect(mockDeletePolicy).toHaveBeenCalledWith(1);
+
+    act(() => {
+      resolveMutation();
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    // Deleting a policy can orphan a tag, so only the tags query refreshes.
+    const keys = invalidateSpy.mock.calls.map(
+      (call) => (call[0] as { queryKey: unknown[] }).queryKey,
+    );
+    expect(keys).toContainEqual([...tagQueryKeys.all]);
+    expect(keys.every((key) => key[0] !== "policies")).toBe(true);
+
+    // The exact removal stands — no list refetch needed.
+    expect(queryClient.getQueryData<PolicyManagerModel[]>(queryKey)?.map((p) => p.id)).toEqual([2]);
+  });
+
+  it("rolls back the removal and toasts when deletion fails with a 4xx", async () => {
+    let rejectMutation: (error: unknown) => void = () => {};
+    mockDeletePolicy.mockImplementation(
+      () =>
+        new Promise<never>((_resolve, reject) => {
+          rejectMutation = reject;
+        }),
+    );
+
+    const queryKey = policyQueryKeys.list();
+    const { queryClient, wrapper } = createWrapper();
+
+    const original = [createPolicy(1), createPolicy(2)];
+    queryClient.setQueryData(queryKey, original);
+
+    const { result } = renderHook(() => useDeletePolicy(), { wrapper });
+
+    act(() => {
+      result.current.mutate(1);
+    });
+
+    await waitFor(() =>
+      expect(queryClient.getQueryData<PolicyManagerModel[]>(queryKey)).toHaveLength(1),
+    );
+
+    act(() => {
+      rejectMutation({ response: { status: 403 }, message: "Forbidden" });
+    });
+
+    await waitFor(() => expect(result.current.isError).toBe(true));
+    expect(queryClient.getQueryData<PolicyManagerModel[]>(queryKey)).toEqual(original);
+    expect(mockShowAlert).toHaveBeenCalledWith(expect.objectContaining({ variant: "error" }));
   });
 });

--- a/Clients/src/application/hooks/__tests__/useRiskMutations.test.ts
+++ b/Clients/src/application/hooks/__tests__/useRiskMutations.test.ts
@@ -1,0 +1,292 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { renderHook, act, waitFor } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import React from "react";
+import {
+  useCreateProjectRisk,
+  useUpdateProjectRisk,
+  useDeleteProjectRisk,
+} from "../useRiskMutations";
+import { projectRiskQueryKeys, type ProjectRisk } from "../useProjectRisks";
+
+vi.mock("../../repository/projectRisk.repository", () => ({
+  createProjectRisk: vi.fn(),
+  updateProjectRisk: vi.fn(),
+  deleteProjectRisk: vi.fn(),
+}));
+
+vi.mock("../../tools/alertUtils", () => ({
+  showAlert: vi.fn(),
+}));
+
+import {
+  createProjectRisk,
+  updateProjectRisk,
+  deleteProjectRisk,
+} from "../../repository/projectRisk.repository";
+import { showAlert } from "../../tools/alertUtils";
+
+const mockCreateProjectRisk = vi.mocked(createProjectRisk);
+const mockUpdateProjectRisk = vi.mocked(updateProjectRisk);
+const mockDeleteProjectRisk = vi.mocked(deleteProjectRisk);
+const mockShowAlert = vi.mocked(showAlert);
+
+function createWrapper() {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  });
+  return {
+    queryClient,
+    wrapper: ({ children }: { children: React.ReactNode }) =>
+      React.createElement(QueryClientProvider, { client: queryClient }, children),
+  };
+}
+
+function makeRisk(id: number, overrides: Partial<ProjectRisk> = {}): ProjectRisk {
+  return {
+    id,
+    project_id: 5,
+    risk_name: `Risk ${id}`,
+    risk_level_autocalculated: "Low",
+    ...overrides,
+  } as ProjectRisk;
+}
+
+function deferred<T>() {
+  let resolve: (value: T) => void = () => {};
+  let reject: (error: unknown) => void = () => {};
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+}
+
+function invalidatedKeys(spy: { mock: { calls: unknown[][] } }): unknown[][] {
+  return spy.mock.calls.map((call) => (call[0] as { queryKey: unknown[] }).queryKey);
+}
+
+// Mirrors the real useProjectRisks cache key, including the refreshKey suffix.
+function riskListKey(projectId: number, refreshKey: unknown) {
+  return [...projectRiskQueryKeys.list(projectId, "active"), refreshKey] as const;
+}
+
+describe("useCreateProjectRisk", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("inserts an optimistic temp risk into refreshKey-suffixed variants, then swaps in the server entity", async () => {
+    const serverRisk = makeRisk(9, {
+      risk_name: "Server Risk",
+      risk_level_autocalculated: "High",
+    });
+    const d = deferred<unknown>();
+    mockCreateProjectRisk.mockImplementation(() => d.promise as Promise<any>);
+
+    const key = riskListKey(5, 0);
+    const { queryClient, wrapper } = createWrapper();
+    queryClient.setQueryData<ProjectRisk[]>(key, [makeRisk(1)]);
+
+    const invalidateSpy = vi.spyOn(queryClient, "invalidateQueries");
+
+    const { result } = renderHook(() => useCreateProjectRisk(), { wrapper });
+
+    act(() => {
+      result.current.mutate({ body: { risk_name: "Optimistic Risk", project_id: 5 } });
+    });
+
+    await waitFor(() => {
+      const data = queryClient.getQueryData<ProjectRisk[]>(key);
+      expect(data).toHaveLength(2);
+      expect(data?.[0].risk_name).toBe("Optimistic Risk");
+      expect(data?.[0].id).toBeLessThan(0);
+    });
+
+    // Repository returns the full axios response: entity at data.data.
+    act(() => {
+      d.resolve({ status: 201, data: { data: serverRisk } });
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    const data = queryClient.getQueryData<ProjectRisk[]>(key);
+    expect(data?.[0]).toEqual(serverRisk);
+
+    const keys = invalidatedKeys(invalidateSpy);
+    expect(keys).toContainEqual(["dashboard"]);
+    expect(keys.every((key) => key[0] !== "projectRisks")).toBe(true);
+  });
+
+  it("rolls back on failure and shows an error toast for 4xx", async () => {
+    const d = deferred<never>();
+    mockCreateProjectRisk.mockImplementation(() => d.promise as Promise<any>);
+
+    const key = riskListKey(5, 0);
+    const { queryClient, wrapper } = createWrapper();
+    const original = [makeRisk(1)];
+    queryClient.setQueryData<ProjectRisk[]>(key, original);
+
+    const { result } = renderHook(() => useCreateProjectRisk(), { wrapper });
+
+    act(() => {
+      result.current.mutate({ body: { risk_name: "Doomed" } });
+    });
+
+    await waitFor(() => expect(queryClient.getQueryData<ProjectRisk[]>(key)).toHaveLength(2));
+
+    act(() => {
+      d.reject({ response: { status: 422 }, message: "Unprocessable" });
+    });
+
+    await waitFor(() => expect(result.current.isError).toBe(true));
+    expect(queryClient.getQueryData<ProjectRisk[]>(key)).toEqual(original);
+    expect(mockShowAlert).toHaveBeenCalledWith(expect.objectContaining({ variant: "error" }));
+  });
+});
+
+describe("useUpdateProjectRisk", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("patches the risk optimistically across variants and applies server-computed fields on success", async () => {
+    const serverRisk = makeRisk(1, {
+      risk_name: "Renamed",
+      risk_level_autocalculated: "Critical",
+      final_risk_level: "High",
+    });
+    const d = deferred<unknown>();
+    mockUpdateProjectRisk.mockImplementation(() => d.promise as Promise<any>);
+
+    const keyA = riskListKey(5, 0);
+    const keyB = riskListKey(5, 1); // different refreshKey, same project
+    const { queryClient, wrapper } = createWrapper();
+    queryClient.setQueryData<ProjectRisk[]>(keyA, [makeRisk(1), makeRisk(2)]);
+    queryClient.setQueryData<ProjectRisk[]>(keyB, [makeRisk(1)]);
+
+    const invalidateSpy = vi.spyOn(queryClient, "invalidateQueries");
+
+    const { result } = renderHook(() => useUpdateProjectRisk(), { wrapper });
+
+    act(() => {
+      result.current.mutate({ id: 1, projectId: 5, body: { risk_name: "Optimistic Name" } });
+    });
+
+    await waitFor(() => {
+      expect(queryClient.getQueryData<ProjectRisk[]>(keyA)?.[0].risk_name).toBe("Optimistic Name");
+      expect(queryClient.getQueryData<ProjectRisk[]>(keyB)?.[0].risk_name).toBe("Optimistic Name");
+    });
+    expect(mockUpdateProjectRisk).toHaveBeenCalledWith({
+      id: 1,
+      body: { risk_name: "Optimistic Name" },
+    });
+
+    act(() => {
+      d.resolve({ status: 200, data: { data: serverRisk } });
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    // risk_level_autocalculated-driven display fields come from the server entity.
+    const updated = queryClient.getQueryData<ProjectRisk[]>(keyA)?.[0];
+    expect(updated?.risk_name).toBe("Renamed");
+    expect(updated?.risk_level_autocalculated).toBe("Critical");
+    expect(updated?.final_risk_level).toBe("High");
+
+    const keys = invalidatedKeys(invalidateSpy);
+    expect(keys).toContainEqual(["dashboard"]);
+    expect(keys.every((key) => key[0] !== "projectRisks")).toBe(true);
+  });
+
+  it("rolls back every variant on failure", async () => {
+    const d = deferred<never>();
+    mockUpdateProjectRisk.mockImplementation(() => d.promise as Promise<any>);
+
+    const keyA = riskListKey(5, 0);
+    const keyB = riskListKey(7, 0); // different project list
+    const { queryClient, wrapper } = createWrapper();
+    queryClient.setQueryData<ProjectRisk[]>(keyA, [makeRisk(1)]);
+    queryClient.setQueryData<ProjectRisk[]>(keyB, [makeRisk(1, { project_id: 7 })]);
+
+    const { result } = renderHook(() => useUpdateProjectRisk(), { wrapper });
+
+    act(() => {
+      result.current.mutate({ id: 1, body: { risk_name: "Changed" } });
+    });
+
+    await waitFor(() =>
+      expect(queryClient.getQueryData<ProjectRisk[]>(keyA)?.[0].risk_name).toBe("Changed"),
+    );
+
+    act(() => {
+      d.reject({ response: { status: 500 }, message: "Server error" });
+    });
+
+    await waitFor(() => expect(result.current.isError).toBe(true));
+    expect(queryClient.getQueryData<ProjectRisk[]>(keyA)).toEqual([makeRisk(1)]);
+    expect(queryClient.getQueryData<ProjectRisk[]>(keyB)).toEqual([makeRisk(1, { project_id: 7 })]);
+    // 5xx is toasted by the axios interceptor, not the hook.
+    expect(mockShowAlert).not.toHaveBeenCalled();
+  });
+});
+
+describe("useDeleteProjectRisk", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("removes the risk optimistically and only invalidates the dashboard", async () => {
+    const d = deferred<unknown>();
+    mockDeleteProjectRisk.mockImplementation(() => d.promise as Promise<any>);
+
+    const key = riskListKey(5, 0);
+    const { queryClient, wrapper } = createWrapper();
+    queryClient.setQueryData<ProjectRisk[]>(key, [makeRisk(1), makeRisk(2)]);
+
+    const invalidateSpy = vi.spyOn(queryClient, "invalidateQueries");
+
+    const { result } = renderHook(() => useDeleteProjectRisk(), { wrapper });
+
+    act(() => {
+      result.current.mutate({ id: 1 });
+    });
+
+    await waitFor(() =>
+      expect(queryClient.getQueryData<ProjectRisk[]>(key)).toEqual([makeRisk(2)]),
+    );
+    expect(mockDeleteProjectRisk).toHaveBeenCalledWith({ id: 1 });
+
+    act(() => {
+      d.resolve({ status: 200, data: { message: "Deleted" } });
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    const keys = invalidatedKeys(invalidateSpy);
+    expect(keys).toContainEqual(["dashboard"]);
+    expect(keys.every((key) => key[0] !== "projectRisks")).toBe(true);
+    expect(queryClient.getQueryData<ProjectRisk[]>(key)).toEqual([makeRisk(2)]);
+  });
+
+  it("restores the risk when deletion fails", async () => {
+    const d = deferred<never>();
+    mockDeleteProjectRisk.mockImplementation(() => d.promise as Promise<any>);
+
+    const key = riskListKey(5, 0);
+    const { queryClient, wrapper } = createWrapper();
+    const original = [makeRisk(1), makeRisk(2)];
+    queryClient.setQueryData<ProjectRisk[]>(key, original);
+
+    const { result } = renderHook(() => useDeleteProjectRisk(), { wrapper });
+
+    act(() => {
+      result.current.mutate({ id: 1 });
+    });
+
+    await waitFor(() =>
+      expect(queryClient.getQueryData<ProjectRisk[]>(key)).toEqual([makeRisk(2)]),
+    );
+
+    act(() => {
+      d.reject({ response: { status: 404 }, message: "Not found" });
+    });
+
+    await waitFor(() => expect(result.current.isError).toBe(true));
+    expect(queryClient.getQueryData<ProjectRisk[]>(key)).toEqual(original);
+  });
+});

--- a/Clients/src/application/hooks/__tests__/useTaskMutations.test.ts
+++ b/Clients/src/application/hooks/__tests__/useTaskMutations.test.ts
@@ -1,0 +1,302 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { renderHook, act, waitFor } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import React from "react";
+import { useCreateTask, useUpdateTask, useArchiveTask } from "../useTaskMutations";
+import { taskQueryKeys } from "../useTasks";
+import { TaskStatus, TaskPriority } from "../../../domain/enums/task.enum";
+import type { ITask } from "../../../domain/interfaces/i.task";
+
+vi.mock("../../repository/task.repository", () => ({
+  createTask: vi.fn(),
+  updateTask: vi.fn(),
+  deleteTask: vi.fn(),
+}));
+
+vi.mock("../../tools/alertUtils", () => ({
+  showAlert: vi.fn(),
+}));
+
+import { createTask, updateTask, deleteTask } from "../../repository/task.repository";
+import { showAlert } from "../../tools/alertUtils";
+
+const mockCreateTask = vi.mocked(createTask);
+const mockUpdateTask = vi.mocked(updateTask);
+const mockDeleteTask = vi.mocked(deleteTask);
+const mockShowAlert = vi.mocked(showAlert);
+
+function createWrapper() {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  });
+  return {
+    queryClient,
+    wrapper: ({ children }: { children: React.ReactNode }) =>
+      React.createElement(QueryClientProvider, { client: queryClient }, children),
+  };
+}
+
+function makeTask(id: number, overrides: Partial<ITask> = {}): ITask {
+  return {
+    id,
+    title: `Task ${id}`,
+    creator_id: 1,
+    status: TaskStatus.OPEN,
+    priority: TaskPriority.MEDIUM,
+    ...overrides,
+  };
+}
+
+function deferred<T>() {
+  let resolve: (value: T) => void = () => {};
+  let reject: (error: unknown) => void = () => {};
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+}
+
+// Returns the invalidateQueries call keys (as arrays) for assertions.
+function invalidatedKeys(spy: { mock: { calls: unknown[][] } }): unknown[][] {
+  return spy.mock.calls.map((call) => (call[0] as { queryKey: unknown[] }).queryKey);
+}
+
+describe("useCreateTask", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("inserts an optimistic temp task before the server responds, then swaps in the server entity", async () => {
+    const serverTask = makeTask(42, { title: "Server Task" });
+    const d = deferred<unknown>();
+    mockCreateTask.mockImplementation(() => d.promise as Promise<any>);
+
+    const queryKey = taskQueryKeys.list({});
+    const { queryClient, wrapper } = createWrapper();
+    queryClient.setQueryData<ITask[]>(queryKey, [makeTask(1)]);
+
+    const invalidateSpy = vi.spyOn(queryClient, "invalidateQueries");
+
+    const { result } = renderHook(() => useCreateTask(), { wrapper });
+
+    act(() => {
+      result.current.mutate({ body: { title: "Optimistic Task" } });
+    });
+
+    // Optimistic temp item is visible before the repository promise resolves.
+    await waitFor(() => {
+      const data = queryClient.getQueryData<ITask[]>(queryKey);
+      expect(data).toHaveLength(2);
+      expect(data?.[0].title).toBe("Optimistic Task");
+      expect(data?.[0].id).toBeLessThan(0);
+    });
+    expect(mockCreateTask).toHaveBeenCalledWith({ body: { title: "Optimistic Task" } });
+
+    // Repository returns the response body: { message, data: <entity> }.
+    act(() => {
+      d.resolve({ message: "Created", data: serverTask });
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    // Temp item is replaced by the authoritative server entity.
+    const data = queryClient.getQueryData<ITask[]>(queryKey);
+    expect(data?.[0]).toEqual(serverTask);
+
+    // Only derived queries are invalidated — never the tasks list.
+    const keys = invalidatedKeys(invalidateSpy);
+    expect(keys).toContainEqual(["deadlineWarnings"]);
+    expect(keys).toContainEqual(["dashboard"]);
+    expect(keys.every((key) => key[0] !== "tasks")).toBe(true);
+  });
+
+  it("rolls back and toasts on a 4xx error", async () => {
+    const d = deferred<never>();
+    mockCreateTask.mockImplementation(() => d.promise as Promise<any>);
+
+    const queryKey = taskQueryKeys.list({});
+    const { queryClient, wrapper } = createWrapper();
+    const original = [makeTask(1)];
+    queryClient.setQueryData<ITask[]>(queryKey, original);
+
+    const { result } = renderHook(() => useCreateTask(), { wrapper });
+
+    act(() => {
+      result.current.mutate({ body: { title: "Doomed" } });
+    });
+
+    await waitFor(() => expect(queryClient.getQueryData<ITask[]>(queryKey)).toHaveLength(2));
+
+    act(() => {
+      d.reject({ response: { status: 400 }, message: "Bad request" });
+    });
+
+    await waitFor(() => expect(result.current.isError).toBe(true));
+    expect(queryClient.getQueryData<ITask[]>(queryKey)).toEqual(original);
+    expect(mockShowAlert).toHaveBeenCalledWith(expect.objectContaining({ variant: "error" }));
+  });
+
+  it("does not toast on 5xx errors (already covered by the axios interceptor)", async () => {
+    mockCreateTask.mockRejectedValue({ response: { status: 500 }, message: "Server error" });
+
+    const queryKey = taskQueryKeys.list({});
+    const { queryClient, wrapper } = createWrapper();
+    queryClient.setQueryData<ITask[]>(queryKey, [makeTask(1)]);
+
+    const { result } = renderHook(() => useCreateTask(), { wrapper });
+
+    await act(async () => {
+      await expect(result.current.mutateAsync({ body: { title: "Doomed" } })).rejects.toBeTruthy();
+    });
+
+    expect(queryClient.getQueryData<ITask[]>(queryKey)).toEqual([makeTask(1)]);
+    expect(mockShowAlert).not.toHaveBeenCalled();
+  });
+});
+
+describe("useUpdateTask", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("merges fields optimistically in every cached list variant, then applies the server entity", async () => {
+    const serverTask = makeTask(1, { title: "Server Title", status: TaskStatus.IN_PROGRESS });
+    const d = deferred<unknown>();
+    mockUpdateTask.mockImplementation(() => d.promise as Promise<any>);
+
+    const keyDefault = taskQueryKeys.list({});
+    const keyArchived = taskQueryKeys.list({ includeArchived: true });
+    const { queryClient, wrapper } = createWrapper();
+    queryClient.setQueryData<ITask[]>(keyDefault, [
+      makeTask(1, { entity_links: [{ entity_id: 7, entity_type: "vendor" }] } as any),
+      makeTask(2),
+    ]);
+    queryClient.setQueryData<ITask[]>(keyArchived, [makeTask(1), makeTask(2)]);
+
+    const invalidateSpy = vi.spyOn(queryClient, "invalidateQueries");
+
+    const { result } = renderHook(() => useUpdateTask(), { wrapper });
+
+    act(() => {
+      result.current.mutate({ id: 1, body: { title: "Optimistic Title" } });
+    });
+
+    // Both cached list variants patched before the server responds.
+    await waitFor(() => {
+      expect(queryClient.getQueryData<ITask[]>(keyDefault)?.[0].title).toBe("Optimistic Title");
+      expect(queryClient.getQueryData<ITask[]>(keyArchived)?.[0].title).toBe("Optimistic Title");
+    });
+    expect(mockUpdateTask).toHaveBeenCalledWith({ id: 1, body: { title: "Optimistic Title" } });
+
+    act(() => {
+      d.resolve({ message: "Updated", data: serverTask });
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    // Server entity wins; client-only fields from the optimistic item survive.
+    const updated = queryClient.getQueryData<ITask[]>(keyDefault)?.[0] as any;
+    expect(updated.title).toBe("Server Title");
+    expect(updated.status).toBe(TaskStatus.IN_PROGRESS);
+    expect(updated.entity_links).toEqual([{ entity_id: 7, entity_type: "vendor" }]);
+
+    const keys = invalidatedKeys(invalidateSpy);
+    expect(keys).toContainEqual(["deadlineWarnings"]);
+    expect(keys).toContainEqual(["dashboard"]);
+    expect(keys.every((key) => key[0] !== "tasks")).toBe(true);
+  });
+
+  it("rolls back every variant on failure", async () => {
+    const d = deferred<never>();
+    mockUpdateTask.mockImplementation(() => d.promise as Promise<any>);
+
+    const keyDefault = taskQueryKeys.list({});
+    const keyArchived = taskQueryKeys.list({ includeArchived: true });
+    const { queryClient, wrapper } = createWrapper();
+    queryClient.setQueryData<ITask[]>(keyDefault, [makeTask(1)]);
+    queryClient.setQueryData<ITask[]>(keyArchived, [makeTask(1)]);
+
+    const { result } = renderHook(() => useUpdateTask(), { wrapper });
+
+    act(() => {
+      result.current.mutate({ id: 1, body: { title: "Changed" } });
+    });
+
+    await waitFor(() =>
+      expect(queryClient.getQueryData<ITask[]>(keyDefault)?.[0].title).toBe("Changed"),
+    );
+
+    act(() => {
+      d.reject({ response: { status: 409 }, message: "Conflict" });
+    });
+
+    await waitFor(() => expect(result.current.isError).toBe(true));
+    expect(queryClient.getQueryData<ITask[]>(keyDefault)).toEqual([makeTask(1)]);
+    expect(queryClient.getQueryData<ITask[]>(keyArchived)).toEqual([makeTask(1)]);
+  });
+});
+
+describe("useArchiveTask", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("removes the task from non-archived variants and marks it deleted in archived ones", async () => {
+    const d = deferred<unknown>();
+    mockDeleteTask.mockImplementation(() => d.promise as Promise<any>);
+
+    const keyDefault = taskQueryKeys.list({});
+    const keyArchived = taskQueryKeys.list({ includeArchived: true });
+    const { queryClient, wrapper } = createWrapper();
+    queryClient.setQueryData<ITask[]>(keyDefault, [makeTask(1), makeTask(2)]);
+    queryClient.setQueryData<ITask[]>(keyArchived, [makeTask(1), makeTask(2)]);
+
+    const invalidateSpy = vi.spyOn(queryClient, "invalidateQueries");
+
+    const { result } = renderHook(() => useArchiveTask(), { wrapper });
+
+    act(() => {
+      result.current.mutate({ id: 1 });
+    });
+
+    await waitFor(() => {
+      expect(queryClient.getQueryData<ITask[]>(keyDefault)).toEqual([makeTask(2)]);
+      expect(queryClient.getQueryData<ITask[]>(keyArchived)?.[0].status).toBe(TaskStatus.DELETED);
+    });
+    expect(mockDeleteTask).toHaveBeenCalledWith({ id: 1 });
+
+    act(() => {
+      d.resolve({ message: "Archived" });
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    const keys = invalidatedKeys(invalidateSpy);
+    expect(keys).toContainEqual(["deadlineWarnings"]);
+    expect(keys).toContainEqual(["dashboard"]);
+    expect(keys.every((key) => key[0] !== "tasks")).toBe(true);
+  });
+
+  it("restores all variants when archiving fails", async () => {
+    const d = deferred<never>();
+    mockDeleteTask.mockImplementation(() => d.promise as Promise<any>);
+
+    const keyDefault = taskQueryKeys.list({});
+    const { queryClient, wrapper } = createWrapper();
+    const original = [makeTask(1), makeTask(2)];
+    queryClient.setQueryData<ITask[]>(keyDefault, original);
+
+    const { result } = renderHook(() => useArchiveTask(), { wrapper });
+
+    act(() => {
+      result.current.mutate({ id: 1 });
+    });
+
+    await waitFor(() =>
+      expect(queryClient.getQueryData<ITask[]>(keyDefault)).toEqual([makeTask(2)]),
+    );
+
+    act(() => {
+      d.reject({ response: { status: 403 }, message: "Forbidden" });
+    });
+
+    await waitFor(() => expect(result.current.isError).toBe(true));
+    expect(queryClient.getQueryData<ITask[]>(keyDefault)).toEqual(original);
+    expect(mockShowAlert).toHaveBeenCalled();
+  });
+});

--- a/Clients/src/application/hooks/useFileTagMutations.ts
+++ b/Clients/src/application/hooks/useFileTagMutations.ts
@@ -1,0 +1,120 @@
+/**
+ * @fileoverview Single-file tag mutations with optimistic updates.
+ *
+ * Both hooks go through the updateFileMetadata PATCH endpoint with the merged
+ * tags array. The tags are patched optimistically on the file in every cached
+ * fileQueryKeys list variant, rolled back on error, and replaced with the
+ * server-returned tags on success (no list refetch).
+ *
+ * Note: folder views (useFolderFiles) keep files in local component state, not
+ * in the query cache, so there is nothing further to patch here.
+ *
+ * @module application/hooks/useFileTagMutations
+ */
+import { useMutation, useQueryClient, type QueryClient } from "@tanstack/react-query";
+import { updateFileMetadata, type FileMetadata } from "../repository/file.repository";
+import { fileQueryKeys } from "./useFiles";
+import { showMutationErrorToast } from "./utils/mutationErrorToast";
+import { FileModel } from "../../domain/models/Common/file/file.model";
+
+type ListSnapshot = [readonly unknown[], FileModel[]][];
+
+/**
+ * Snapshots every cached ["files"] list variant and applies `updater` to each.
+ */
+function patchFileLists(
+  queryClient: QueryClient,
+  updater: (list: FileModel[]) => FileModel[],
+): ListSnapshot {
+  const matches = queryClient.getQueriesData<FileModel[]>({ queryKey: fileQueryKeys.all });
+  const snapshots: ListSnapshot = [];
+  for (const [queryKey, data] of matches) {
+    if (!Array.isArray(data)) continue;
+    snapshots.push([queryKey, data]);
+    queryClient.setQueryData<FileModel[]>(queryKey, updater(data));
+  }
+  return snapshots;
+}
+
+function restoreFileLists(queryClient: QueryClient, snapshots: ListSnapshot | undefined): void {
+  if (!snapshots) return;
+  for (const [queryKey, data] of snapshots) {
+    queryClient.setQueryData(queryKey, data);
+  }
+}
+
+function withTags(file: FileModel, id: string, tags: string[]): FileModel {
+  return String(file.id) === String(id) ? FileModel.createNewFile({ ...file, tags }) : file;
+}
+
+export interface AddFileTagsVariables {
+  id: string;
+  /** Tags currently on the file — the PATCH endpoint replaces the whole array. */
+  currentTags: string[];
+  tags: string[];
+}
+
+export interface RemoveFileTagVariables {
+  id: string;
+  /** Tags currently on the file — the PATCH endpoint replaces the whole array. */
+  currentTags: string[];
+  tag: string;
+}
+
+export function useAddFileTags() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: ({ id, currentTags, tags }: AddFileTagsVariables) => {
+      const merged = Array.from(new Set([...currentTags, ...tags]));
+      return updateFileMetadata({ id, updates: { tags: merged } });
+    },
+    onMutate: async ({ id, currentTags, tags }) => {
+      await queryClient.cancelQueries({ queryKey: fileQueryKeys.all });
+      const merged = Array.from(new Set([...currentTags, ...tags]));
+      const snapshots = patchFileLists(queryClient, (list) =>
+        list.map((file) => withTags(file, id, merged)),
+      );
+      return { snapshots, id };
+    },
+    onSuccess: (serverFile: FileMetadata, _variables, context) => {
+      if (serverFile?.tags) {
+        patchFileLists(queryClient, (list) =>
+          list.map((file) => withTags(file, context?.id ?? "", serverFile.tags ?? [])),
+        );
+      }
+    },
+    onError: (error, _variables, context) => {
+      restoreFileLists(queryClient, context?.snapshots);
+      showMutationErrorToast(error, "Failed to update file tags. Please try again.");
+    },
+  });
+}
+
+export function useRemoveFileTag() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: ({ id, currentTags, tag }: RemoveFileTagVariables) =>
+      updateFileMetadata({ id, updates: { tags: currentTags.filter((t) => t !== tag) } }),
+    onMutate: async ({ id, currentTags, tag }) => {
+      await queryClient.cancelQueries({ queryKey: fileQueryKeys.all });
+      const remaining = currentTags.filter((t) => t !== tag);
+      const snapshots = patchFileLists(queryClient, (list) =>
+        list.map((file) => withTags(file, id, remaining)),
+      );
+      return { snapshots, id };
+    },
+    onSuccess: (serverFile: FileMetadata, _variables, context) => {
+      if (serverFile?.tags) {
+        patchFileLists(queryClient, (list) =>
+          list.map((file) => withTags(file, context?.id ?? "", serverFile.tags ?? [])),
+        );
+      }
+    },
+    onError: (error, _variables, context) => {
+      restoreFileLists(queryClient, context?.snapshots);
+      showMutationErrorToast(error, "Failed to update file tags. Please try again.");
+    },
+  });
+}

--- a/Clients/src/application/hooks/usePolicyMutations.ts
+++ b/Clients/src/application/hooks/usePolicyMutations.ts
@@ -1,9 +1,11 @@
 import { useMutation, useQueryClient } from "@tanstack/react-query";
-import { createPolicy, updatePolicy } from "../repository/policy.repository";
+import { createPolicy, updatePolicy, deletePolicy } from "../repository/policy.repository";
 import { PolicyInput } from "../../domain/interfaces/i.policy";
 import { PolicyManagerModel } from "../../domain/models/Common/policy/policyManager.model";
 import { policyQueryKeys } from "./usePolicies";
+import { tagQueryKeys } from "./useTags";
 import { useOptimisticListMutation } from "./utils/optimisticMutation";
+import { showMutationErrorToast } from "./utils/mutationErrorToast";
 
 export function useCreatePolicy() {
   const queryClient = useQueryClient();
@@ -30,5 +32,45 @@ export function useUpdatePolicy() {
       (policy) =>
         ({ ...policy, ...input }) as PolicyManagerModel,
     invalidateKeys: ({ id }) => [[...policyQueryKeys.list()], [...policyQueryKeys.detail(id)]],
+  });
+}
+
+/**
+ * Deletes a policy, optimistically removing it from every cached policy list.
+ * The removal is exact, so the list itself is not refetched on success — only
+ * the policy-tags query is invalidated since deleting a policy can orphan a tag.
+ */
+export function useDeletePolicy() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (id: number) => deletePolicy(id),
+    onMutate: async (id) => {
+      await queryClient.cancelQueries({ queryKey: policyQueryKeys.all });
+      const matches = queryClient.getQueriesData<PolicyManagerModel[]>({
+        queryKey: policyQueryKeys.all,
+      });
+      const snapshots: [readonly unknown[], PolicyManagerModel[]][] = [];
+      for (const [queryKey, data] of matches) {
+        if (!Array.isArray(data)) continue;
+        snapshots.push([queryKey, data]);
+        queryClient.setQueryData<PolicyManagerModel[]>(
+          queryKey,
+          data.filter((policy) => policy.id !== id),
+        );
+      }
+      return { snapshots };
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: tagQueryKeys.all });
+    },
+    onError: (error, _id, context) => {
+      if (context?.snapshots) {
+        for (const [queryKey, data] of context.snapshots) {
+          queryClient.setQueryData(queryKey, data);
+        }
+      }
+      showMutationErrorToast(error, "Failed to delete policy. Please try again.");
+    },
   });
 }

--- a/Clients/src/application/hooks/useRiskMutations.ts
+++ b/Clients/src/application/hooks/useRiskMutations.ts
@@ -1,0 +1,164 @@
+/**
+ * @fileoverview Consolidated project-risk mutations with optimistic updates.
+ *
+ * Project-risk list queries are cached under
+ * [...projectRiskQueryKeys.list(projectId, "active"), refreshKey], so all
+ * optimistic updates use prefix matching on ["projectRisks"] to hit every
+ * cached variant (including refreshKey suffixes). On success the server-returned
+ * entity replaces the optimistic item (no list refetch); only the derived
+ * ["dashboard"] query is invalidated.
+ *
+ * @module application/hooks/useRiskMutations
+ */
+import { useMutation, useQueryClient, type QueryClient } from "@tanstack/react-query";
+import {
+  createProjectRisk,
+  updateProjectRisk,
+  deleteProjectRisk,
+} from "../repository/projectRisk.repository";
+import { projectRiskQueryKeys, type ProjectRisk } from "./useProjectRisks";
+import { showMutationErrorToast } from "./utils/mutationErrorToast";
+
+// The project-risk repository returns the full axios response; the
+// authoritative entity lives at response.data.data (see UpdateProjectRiskResponse).
+function extractRiskEntity(response: any): ProjectRisk | undefined {
+  const entity = response?.data?.data ?? response?.data;
+  return entity && typeof entity === "object" && "id" in entity
+    ? (entity as ProjectRisk)
+    : undefined;
+}
+
+type ListSnapshot = [readonly unknown[], ProjectRisk[]][];
+
+/**
+ * Snapshots every cached ["projectRisks"] list variant and applies `updater`.
+ * Covers the refreshKey-suffixed variants via prefix matching.
+ */
+function patchRiskLists(
+  queryClient: QueryClient,
+  updater: (list: ProjectRisk[]) => ProjectRisk[],
+): ListSnapshot {
+  const matches = queryClient.getQueriesData<ProjectRisk[]>({ queryKey: projectRiskQueryKeys.all });
+  const snapshots: ListSnapshot = [];
+  for (const [queryKey, data] of matches) {
+    if (!Array.isArray(data)) continue;
+    snapshots.push([queryKey, data]);
+    queryClient.setQueryData<ProjectRisk[]>(queryKey, updater(data));
+  }
+  return snapshots;
+}
+
+function restoreRiskLists(queryClient: QueryClient, snapshots: ListSnapshot | undefined): void {
+  if (!snapshots) return;
+  for (const [queryKey, data] of snapshots) {
+    queryClient.setQueryData(queryKey, data);
+  }
+}
+
+const DASHBOARD_KEY: readonly unknown[] = ["dashboard"];
+
+export interface CreateProjectRiskVariables {
+  body: Record<string, unknown>;
+}
+
+export interface UpdateProjectRiskVariables {
+  id: number;
+  projectId?: number;
+  body: Record<string, unknown>;
+}
+
+export interface UpdateProjectRiskResponse {
+  status: number;
+  data: {
+    data?: { id?: number };
+    message?: string;
+    errors?: Array<{ message?: string }>;
+  };
+}
+
+export interface DeleteProjectRiskVariables {
+  id: number;
+}
+
+export function useCreateProjectRisk() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: ({ body }: CreateProjectRiskVariables) =>
+      createProjectRisk({ body }) as Promise<UpdateProjectRiskResponse>,
+    onMutate: async ({ body }) => {
+      await queryClient.cancelQueries({ queryKey: projectRiskQueryKeys.all });
+      // Placeholder id until the server assigns the real one.
+      const tempId = -Date.now();
+      const optimisticRisk = { ...body, id: tempId } as unknown as ProjectRisk;
+      const snapshots = patchRiskLists(queryClient, (list) => [optimisticRisk, ...list]);
+      return { snapshots, tempId };
+    },
+    onSuccess: (response, _variables, context) => {
+      const entity = extractRiskEntity(response);
+      if (entity) {
+        patchRiskLists(queryClient, (list) =>
+          list.map((risk) => (risk.id === context?.tempId ? { ...risk, ...entity } : risk)),
+        );
+      }
+      queryClient.invalidateQueries({ queryKey: DASHBOARD_KEY });
+    },
+    onError: (error, _variables, context) => {
+      restoreRiskLists(queryClient, context?.snapshots);
+      showMutationErrorToast(error, "Failed to create the risk. Please try again.");
+    },
+  });
+}
+
+export function useUpdateProjectRisk() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: ({ id, body }: UpdateProjectRiskVariables) =>
+      updateProjectRisk({ id, body }) as Promise<UpdateProjectRiskResponse>,
+    onMutate: async ({ id, body }) => {
+      await queryClient.cancelQueries({ queryKey: projectRiskQueryKeys.all });
+      const snapshots = patchRiskLists(queryClient, (list) =>
+        list.map((risk) => (risk.id === id ? ({ ...risk, ...body } as ProjectRisk) : risk)),
+      );
+      return { snapshots, id };
+    },
+    onSuccess: (response, _variables, context) => {
+      const entity = extractRiskEntity(response);
+      if (entity) {
+        // The server entity carries the authoritative risk_level_autocalculated
+        // and other computed display fields.
+        patchRiskLists(queryClient, (list) =>
+          list.map((risk) => (risk.id === context?.id ? { ...risk, ...entity } : risk)),
+        );
+      }
+      queryClient.invalidateQueries({ queryKey: DASHBOARD_KEY });
+    },
+    onError: (error, _variables, context) => {
+      restoreRiskLists(queryClient, context?.snapshots);
+      showMutationErrorToast(error, "Failed to update the risk. Please try again.");
+    },
+  });
+}
+
+export function useDeleteProjectRisk() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: ({ id }: DeleteProjectRiskVariables) => deleteProjectRisk({ id }),
+    onMutate: async ({ id }) => {
+      await queryClient.cancelQueries({ queryKey: projectRiskQueryKeys.all });
+      const snapshots = patchRiskLists(queryClient, (list) =>
+        list.filter((risk) => risk.id !== id),
+      );
+      return { snapshots };
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: DASHBOARD_KEY });
+    },
+    onError: (error, _variables, context) => {
+      restoreRiskLists(queryClient, context?.snapshots);
+      showMutationErrorToast(error, "Failed to delete the risk. Please try again.");
+    },
+  });
+}

--- a/Clients/src/application/hooks/useTaskMutations.ts
+++ b/Clients/src/application/hooks/useTaskMutations.ts
@@ -1,0 +1,166 @@
+/**
+ * @fileoverview Consolidated task mutations with optimistic updates.
+ *
+ * Each mutation patches every cached `taskQueryKeys` list variant via prefix
+ * matching, replaces the optimistic item with the authoritative server entity
+ * on success (no list refetch), rolls back on error, and invalidates only the
+ * server-computed derived queries (["deadlineWarnings"], ["dashboard"]).
+ *
+ * @module application/hooks/useTaskMutations
+ */
+import { useMutation, useQueryClient, type QueryClient } from "@tanstack/react-query";
+import { createTask, updateTask, deleteTask } from "../repository/task.repository";
+import { taskQueryKeys } from "./useTasks";
+import { showMutationErrorToast } from "./utils/mutationErrorToast";
+import type { ITask } from "../../domain/interfaces/i.task";
+import { TaskStatus } from "../../domain/enums/task.enum";
+
+// Re-export the per-field optimistic hooks so task mutations are reachable
+// from a single module.
+export { useUpdateTaskStatus } from "./useUpdateTaskStatus";
+export { useUpdateTaskPriority } from "./useUpdateTaskPriority";
+
+// The task repository returns the response body ({ message, data: <entity> }),
+// so the authoritative entity lives on `.data`.
+function extractTaskEntity(response: any): ITask | undefined {
+  const entity = response?.data;
+  return entity && typeof entity === "object" ? (entity as ITask) : undefined;
+}
+
+type ListSnapshot = [readonly unknown[], ITask[]][];
+
+/**
+ * Snapshots every cached ["tasks"] list variant and applies `updater` to each.
+ * `updater` receives the list and the filters object embedded in the query key
+ * (taskQueryKeys.list(filters)) so behavior can vary per variant.
+ */
+function patchTaskLists(
+  queryClient: QueryClient,
+  updater: (list: ITask[], filters: { includeArchived?: boolean }) => ITask[],
+): ListSnapshot {
+  const matches = queryClient.getQueriesData<ITask[]>({ queryKey: taskQueryKeys.all });
+  const snapshots: ListSnapshot = [];
+  for (const [queryKey, data] of matches) {
+    if (!Array.isArray(data)) continue;
+    snapshots.push([queryKey, data]);
+    const filters = (queryKey[2] ?? {}) as { includeArchived?: boolean };
+    queryClient.setQueryData<ITask[]>(queryKey, updater(data, filters));
+  }
+  return snapshots;
+}
+
+function restoreTaskLists(queryClient: QueryClient, snapshots: ListSnapshot | undefined): void {
+  if (!snapshots) return;
+  for (const [queryKey, data] of snapshots) {
+    queryClient.setQueryData(queryKey, data);
+  }
+}
+
+const DERIVED_TASK_KEYS: readonly (readonly unknown[])[] = [["deadlineWarnings"], ["dashboard"]];
+
+export interface CreateTaskVariables {
+  body: Partial<ITask>;
+}
+
+export interface UpdateTaskVariables {
+  id: number;
+  body: Partial<ITask>;
+}
+
+export interface ArchiveTaskVariables {
+  id: number;
+}
+
+export function useCreateTask() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: ({ body }: CreateTaskVariables) => createTask({ body }),
+    onMutate: async ({ body }) => {
+      await queryClient.cancelQueries({ queryKey: taskQueryKeys.all });
+      // Placeholder id until the server assigns the real one.
+      const tempId = -Date.now();
+      const optimisticTask = {
+        status: TaskStatus.OPEN,
+        ...body,
+        id: tempId,
+      } as ITask;
+      const snapshots = patchTaskLists(queryClient, (list) => [optimisticTask, ...list]);
+      return { snapshots, tempId };
+    },
+    onSuccess: (response, _variables, context) => {
+      const entity = extractTaskEntity(response);
+      if (entity) {
+        patchTaskLists(queryClient, (list) =>
+          // Keep client-only fields (e.g. entity_links) from the optimistic item.
+          list.map((task) => (task.id === context?.tempId ? { ...task, ...entity } : task)),
+        );
+      }
+      DERIVED_TASK_KEYS.forEach((queryKey) => queryClient.invalidateQueries({ queryKey }));
+    },
+    onError: (error, _variables, context) => {
+      restoreTaskLists(queryClient, context?.snapshots);
+      showMutationErrorToast(error, "Failed to create the task. Please try again.");
+    },
+  });
+}
+
+export function useUpdateTask() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: ({ id, body }: UpdateTaskVariables) => updateTask({ id, body }),
+    onMutate: async ({ id, body }) => {
+      await queryClient.cancelQueries({ queryKey: taskQueryKeys.all });
+      const snapshots = patchTaskLists(queryClient, (list) =>
+        list.map((task) => (task.id === id ? ({ ...task, ...body } as ITask) : task)),
+      );
+      return { snapshots, id };
+    },
+    onSuccess: (response, _variables, context) => {
+      const entity = extractTaskEntity(response);
+      if (entity) {
+        patchTaskLists(queryClient, (list) =>
+          // Merge over the optimistic item so client-only fields survive.
+          list.map((task) => (task.id === context?.id ? { ...task, ...entity } : task)),
+        );
+      }
+      DERIVED_TASK_KEYS.forEach((queryKey) => queryClient.invalidateQueries({ queryKey }));
+    },
+    onError: (error, _variables, context) => {
+      restoreTaskLists(queryClient, context?.snapshots);
+      showMutationErrorToast(error, "Failed to update the task. Please try again.");
+    },
+  });
+}
+
+export function useArchiveTask() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: ({ id }: ArchiveTaskVariables) => deleteTask({ id }),
+    onMutate: async ({ id }) => {
+      await queryClient.cancelQueries({ queryKey: taskQueryKeys.all });
+      const snapshots = patchTaskLists(queryClient, (list, filters) =>
+        // Archived tasks only belong in variants that include them.
+        filters.includeArchived
+          ? list.map((task) => (task.id === id ? { ...task, status: TaskStatus.DELETED } : task))
+          : list.filter((task) => task.id !== id),
+      );
+      return { snapshots, id };
+    },
+    onSuccess: (response, _variables, context) => {
+      const entity = extractTaskEntity(response);
+      if (entity) {
+        patchTaskLists(queryClient, (list) =>
+          list.map((task) => (task.id === context?.id ? { ...task, ...entity } : task)),
+        );
+      }
+      DERIVED_TASK_KEYS.forEach((queryKey) => queryClient.invalidateQueries({ queryKey }));
+    },
+    onError: (error, _variables, context) => {
+      restoreTaskLists(queryClient, context?.snapshots);
+      showMutationErrorToast(error, "Failed to archive the task. Please try again.");
+    },
+  });
+}

--- a/Clients/src/application/hooks/useUpdateProjectRisk.ts
+++ b/Clients/src/application/hooks/useUpdateProjectRisk.ts
@@ -1,35 +1,4 @@
-import { updateProjectRisk } from "../repository/projectRisk.repository";
-import { projectRiskQueryKeys, type ProjectRisk } from "./useProjectRisks";
-import { useOptimisticListMutation } from "./utils/optimisticMutation";
-
-export interface UpdateProjectRiskVariables {
-  id: number;
-  projectId?: number;
-  body: Record<string, unknown>;
-}
-
-export interface UpdateProjectRiskResponse {
-  status: number;
-  data: {
-    data?: { id?: number };
-    message?: string;
-    errors?: Array<{ message?: string }>;
-  };
-}
-
-export function useUpdateProjectRisk() {
-  return useOptimisticListMutation<
-    ProjectRisk,
-    UpdateProjectRiskResponse,
-    Error,
-    UpdateProjectRiskVariables
-  >({
-    mutationFn: ({ id, body }) =>
-      updateProjectRisk({ id, body }) as Promise<UpdateProjectRiskResponse>,
-    queryKey: ({ projectId }) => projectRiskQueryKeys.list(projectId ?? 0, "active"),
-    updateItem:
-      ({ id, body }) =>
-      (risk) =>
-        risk.id === id ? { ...risk, ...body } : risk,
-  });
-}
+// Consolidated into ./useRiskMutations — re-exported here so existing
+// imports (e.g. AddNewRiskForm/hooks/useRiskForm) keep working.
+export { useUpdateProjectRisk } from "./useRiskMutations";
+export type { UpdateProjectRiskVariables, UpdateProjectRiskResponse } from "./useRiskMutations";

--- a/Clients/src/application/hooks/utils/mutationErrorToast.ts
+++ b/Clients/src/application/hooks/utils/mutationErrorToast.ts
@@ -1,0 +1,29 @@
+import { showAlert } from "../../tools/alertUtils";
+
+/**
+ * Shows a global error toast for a failed mutation.
+ *
+ * The axios response interceptor (customAxios.showGlobalErrorAlert) already
+ * toasts 5xx and network failures, so those are skipped here to avoid double
+ * toasts — this helper only surfaces errors the interceptor does not cover
+ * (e.g. 4xx responses).
+ *
+ * @param {unknown} error - The mutation error (axios error or APIError)
+ * @param {string} fallbackMessage - Message shown when the error has no usable message
+ */
+export function showMutationErrorToast(error: unknown, fallbackMessage: string): void {
+  const axiosError = error as { response?: { status?: number }; message?: string };
+  const apiError = error as { status?: number };
+  const status = axiosError?.response?.status ?? apiError?.status;
+
+  const isServerError = status != null && status >= 500;
+  // Matches the interceptor's network-error check: no response at all.
+  const isNetworkError = status == null && axiosError?.response == null;
+  if (isServerError || isNetworkError) return;
+
+  showAlert({
+    variant: "error",
+    title: "Error",
+    body: fallbackMessage,
+  });
+}

--- a/Clients/src/presentation/pages/PolicyDashboard/PolicyManager.tsx
+++ b/Clients/src/presentation/pages/PolicyDashboard/PolicyManager.tsx
@@ -1,6 +1,5 @@
 import React, { useEffect, useState, useMemo, useCallback } from "react";
 import { useLocation, useNavigate, useSearchParams } from "react-router";
-import { useQueryClient } from "@tanstack/react-query";
 import { Box, Stack, Fade, Tooltip, IconButton } from "@mui/material";
 import {
   CirclePlus as AddCircleOutlineIcon,
@@ -12,7 +11,7 @@ import {
 } from "lucide-react";
 import PolicyTable from "../../components/Policies/PolicyTable";
 import { CustomizableButton } from "../../components/button/customizable-button";
-import { deletePolicy } from "../../../application/repository/policy.repository";
+import { useDeletePolicy } from "../../../application/hooks/usePolicyMutations";
 import { EmptyState } from "../../components/EmptyState";
 import EmptyStateTip from "../../components/EmptyState/EmptyStateTip";
 import StandardTableHead from "../../components/Table/StandardTableHead";
@@ -25,7 +24,7 @@ import Alert from "../../components/Alert";
 import { AlertProps } from "../../types/alert.types";
 import { PolicyManagerModel } from "../../../domain/models/Common/policy/policyManager.model";
 import { PolicyManagerProps } from "../../types/interfaces/i.policy";
-import { usePolicies, policyQueryKeys } from "../../../application/hooks/usePolicies";
+import { usePolicies } from "../../../application/hooks/usePolicies";
 import PolicyStatusCard from "./PolicyStatusCard";
 import { ExportMenu } from "../../components/Table/ExportMenu";
 import useUsers from "../../../application/hooks/useUsers";
@@ -77,9 +76,9 @@ const POLICY_TABLE_COLUMNS: ColumnConfig<PolicyColumnKey>[] = [
 const PolicyManager: React.FC<PolicyManagerProps> = ({ tags: _tags }) => {
   const location = useLocation();
   const navigate = useNavigate();
-  const queryClient = useQueryClient();
   const [searchParams, setSearchParams] = useSearchParams();
   const { data: policies = [], isLoading } = usePolicies();
+  const deletePolicyMutation = useDeletePolicy();
   const [flashRowId, setFlashRowId] = useState<number | null>(null);
   const { userRoleName } = useAuth();
   const canRunBulkActions = !!userRoleName && ["Admin", "Editor"].includes(userRoleName);
@@ -194,8 +193,7 @@ const PolicyManager: React.FC<PolicyManagerProps> = ({ tags: _tags }) => {
 
   const handleDelete = async (id: number) => {
     try {
-      await deletePolicy(id);
-      queryClient.invalidateQueries({ queryKey: policyQueryKeys.lists() });
+      await deletePolicyMutation.mutateAsync(id);
 
       // Show success alert using VerifyWise standard pattern
       handleAlert({
@@ -205,15 +203,8 @@ const PolicyManager: React.FC<PolicyManagerProps> = ({ tags: _tags }) => {
         alertTimeout: 4000, // 4 seconds to give users time to read
       });
     } catch (err) {
+      // Global error toast handled by the mutation hook / axios interceptor.
       console.error(err);
-
-      // Show error alert for failed deletion
-      handleAlert({
-        variant: "error",
-        body: "Failed to delete policy. Please try again.",
-        setAlert,
-        alertTimeout: 4000,
-      });
     }
   };
 

--- a/Clients/src/presentation/pages/Tasks/index.tsx
+++ b/Clients/src/presentation/pages/Tasks/index.tsx
@@ -14,9 +14,6 @@ import { VerifyWiseContext } from "../../../application/contexts/VerifyWise.cont
 import { storageService } from "../../../infrastructure/storage";
 import { ITask, TaskSummary } from "../../../domain/interfaces/i.task";
 import {
-  createTask,
-  updateTask,
-  deleteTask,
   getTaskById,
   restoreTask,
   hardDeleteTask,
@@ -32,6 +29,11 @@ import useUsers from "../../../application/hooks/useUsers";
 import { useTasks, taskQueryKeys } from "../../../application/hooks/useTasks";
 import { useUpdateTaskStatus } from "../../../application/hooks/useUpdateTaskStatus";
 import { useUpdateTaskPriority } from "../../../application/hooks/useUpdateTaskPriority";
+import {
+  useCreateTask,
+  useUpdateTask,
+  useArchiveTask,
+} from "../../../application/hooks/useTaskMutations";
 
 import Toggle from "../../components/Inputs/Toggle";
 import { TaskPriority, TaskStatus } from "../../../domain/enums/task.enum";
@@ -96,6 +98,9 @@ const Tasks: React.FC = () => {
   const tasks = useMemo(() => rawTasks.map((task) => new TaskModel(task)), [rawTasks]);
   const updateTaskStatusMutation = useUpdateTaskStatus();
   const updateTaskPriorityMutation = useUpdateTaskPriority();
+  const createTaskMutation = useCreateTask();
+  const updateTaskMutation = useUpdateTask();
+  const archiveTaskMutation = useArchiveTask();
   const error = queryError ? "Failed to load tasks. Please try again later." : null;
   const [isCreateTaskModalOpen, setIsCreateTaskModalOpen] = useState(false);
   const [editingTask, setEditingTask] = useState<ITask | null>(null);
@@ -351,7 +356,7 @@ const Tasks: React.FC = () => {
       // but also sync them separately after creation
       const { entity_links, ...taskData } = formData;
 
-      const response = await createTask({
+      const response = await createTaskMutation.mutateAsync({
         body: {
           ...taskData,
           // Include entity_links for notification email (backend uses these immediately)
@@ -378,11 +383,6 @@ const Tasks: React.FC = () => {
           }
         }
 
-        // Add the new task to the cache
-        queryClient.setQueryData(
-          taskQueryKeys.list({ includeArchived }),
-          (old: ITask[] | undefined) => (old ? [response.data, ...old] : [response.data]),
-        );
         setAlert({
           variant: "success",
           title: "Task created successfully",
@@ -395,13 +395,9 @@ const Tasks: React.FC = () => {
       }
       return undefined;
     } catch (error) {
+      // The mutation hook surfaces a global error toast (and the axios
+      // interceptor covers 5xx/network), so no local alert here.
       console.error("Error creating task:", error);
-      setAlert({
-        variant: "error",
-        title: "Error creating task",
-        body: "Failed to create the task. Please try again.",
-      });
-      setTimeout(() => setAlert(null), 4000);
       return undefined;
     }
   };
@@ -416,11 +412,7 @@ const Tasks: React.FC = () => {
     if (!task) return;
 
     try {
-      await deleteTask({ id: taskId });
-      queryClient.setQueryData(
-        taskQueryKeys.list({ includeArchived }),
-        (old: ITask[] | undefined) => old?.filter((t) => t.id !== taskId) ?? [],
-      );
+      await archiveTaskMutation.mutateAsync({ id: taskId });
       setAlert({
         variant: "success",
         title: "Task archived successfully",
@@ -428,13 +420,8 @@ const Tasks: React.FC = () => {
       });
       setTimeout(() => setAlert(null), 4000);
     } catch (error) {
+      // Global error toast handled by the mutation hook / axios interceptor.
       console.error("Error archiving task:", error);
-      setAlert({
-        variant: "error",
-        title: "Error archiving task",
-        body: "Failed to archive the task. Please try again.",
-      });
-      setTimeout(() => setAlert(null), 4000);
     }
   };
 
@@ -446,7 +433,7 @@ const Tasks: React.FC = () => {
       // but also sync them separately after the update
       const { entity_links: newEntityLinks, ...taskData } = formData;
 
-      const response = await updateTask({
+      const response = await updateTaskMutation.mutateAsync({
         id: editingTask.id!,
         body: {
           ...taskData,
@@ -500,17 +487,8 @@ const Tasks: React.FC = () => {
           }
         }
 
-        // Update task in cache with new entity links
-        const updatedTaskWithLinks = {
-          ...response.data,
-          entity_links: newEntityLinks || [],
-        };
-
-        queryClient.setQueryData(
-          taskQueryKeys.list({ includeArchived }),
-          (old: ITask[] | undefined) =>
-            old?.map((task) => (task.id === editingTask.id ? updatedTaskWithLinks : task)) ?? [],
-        );
+        // The mutation hook already patched the cache (optimistic merge keeps
+        // entity_links; the server entity is merged in on success).
 
         // Flash the updated row
         setFlashRowId(editingTask.id!);
@@ -527,13 +505,8 @@ const Tasks: React.FC = () => {
         setTimeout(() => setAlert(null), 4000);
       }
     } catch (error) {
+      // Global error toast handled by the mutation hook / axios interceptor.
       console.error("Error updating task:", error);
-      setAlert({
-        variant: "error",
-        title: "Error updating task",
-        body: "Failed to update the task. Please try again.",
-      });
-      setTimeout(() => setAlert(null), 4000);
     }
   };
 

--- a/Servers/controllers/__tests__/fileManager.ctrl.test.ts
+++ b/Servers/controllers/__tests__/fileManager.ctrl.test.ts
@@ -735,6 +735,38 @@ describe("fileManager.ctrl", () => {
       expect(res.status).toHaveBeenCalledWith(200);
     });
 
+    it("should return the full updated file record including tags in the response body", async () => {
+      const updatedFile = makeDbFile({
+        tags: ["tag1", "tag2"],
+        version: "2.0",
+        review_status: "approved",
+        description: "updated description",
+        last_modified_by: 1,
+        updated_at: "2026-08-14T00:00:00.000Z",
+      });
+      mockGetFileById.mockResolvedValue(makeDbFile() as any);
+      mockGetFileMeta.mockResolvedValue(makeDbFile() as any);
+      mockUpdateMeta.mockResolvedValue(updatedFile as any);
+      const req = createReq({
+        params: { id: "1" },
+        body: { tags: ["tag1", "tag2"], version: "2.0" },
+      });
+      const res = createRes();
+      await updateMetadata(req, res);
+      expect(res.status).toHaveBeenCalledWith(200);
+      expect(res.json).toHaveBeenCalledWith({
+        message: "OK",
+        data: expect.objectContaining({
+          id: 1,
+          filename: "test.pdf",
+          tags: ["tag1", "tag2"],
+          version: "2.0",
+          review_status: "approved",
+          updated_at: "2026-08-14T00:00:00.000Z",
+        }),
+      });
+    });
+
     it("should return 500 on error", async () => {
       mockGetFileById.mockRejectedValue(new Error("DB error"));
       const req = createReq({ params: { id: "1" } });

--- a/Servers/controllers/__tests__/policy.ctrl.test.ts
+++ b/Servers/controllers/__tests__/policy.ctrl.test.ts
@@ -396,6 +396,33 @@ describe("policy.ctrl", () => {
       await PolicyController.requestReview(req, res);
       expect(res.status).toHaveBeenCalledWith(200);
     });
+    it("should return the full updated policy entity in the response body", async () => {
+      const fullPolicy = {
+        id: 1,
+        title: "P1",
+        author_id: 1,
+        status: "Under Review",
+        tags: ["security"],
+        assigned_reviewer_ids: [2],
+        last_updated_by: 1,
+        last_updated_at: "2026-08-14T00:00:00.000Z",
+      };
+      mockGetById.mockResolvedValue([fullPolicy] as any);
+      const req = createReq({ params: { id: "1" }, body: { reviewer_ids: [2] } });
+      const res = createRes();
+      await PolicyController.requestReview(req, res);
+      expect(res.status).toHaveBeenCalledWith(200);
+      expect(res.json).toHaveBeenCalledWith({
+        message: "OK",
+        data: expect.objectContaining({
+          id: 1,
+          title: "P1",
+          status: "Under Review",
+          assigned_reviewer_ids: [2],
+          last_updated_at: "2026-08-14T00:00:00.000Z",
+        }),
+      });
+    });
     it("should return 500 on error", async () => {
       mockGetById.mockRejectedValue(new Error("DB error"));
       const req = createReq({ params: { id: "1" }, body: { reviewer_ids: [2] } });
@@ -425,6 +452,32 @@ describe("policy.ctrl", () => {
       const res = createRes();
       await PolicyController.approveReview(req, res);
       expect(res.status).toHaveBeenCalledWith(200);
+    });
+    it("should return the full approved policy entity in the response body", async () => {
+      const fullPolicy = {
+        id: 1,
+        title: "P1",
+        author_id: 1,
+        status: "Approved",
+        tags: ["security"],
+        assigned_reviewer_ids: [2],
+        last_updated_by: 1,
+        last_updated_at: "2026-08-14T00:00:00.000Z",
+      };
+      mockGetById.mockResolvedValue([fullPolicy] as any);
+      const req = createReq({ params: { id: "1" }, body: { comment: "ok" } });
+      const res = createRes();
+      await PolicyController.approveReview(req, res);
+      expect(res.status).toHaveBeenCalledWith(200);
+      expect(res.json).toHaveBeenCalledWith({
+        message: "OK",
+        data: expect.objectContaining({
+          id: 1,
+          title: "P1",
+          status: "Approved",
+          assigned_reviewer_ids: [2],
+        }),
+      });
     });
     it("should return 500 on error", async () => {
       mockGetById.mockRejectedValue(new Error("DB error"));
@@ -461,6 +514,32 @@ describe("policy.ctrl", () => {
       const res = createRes();
       await PolicyController.rejectReview(req, res);
       expect(res.status).toHaveBeenCalledWith(200);
+    });
+    it("should return the full rejected policy entity in the response body", async () => {
+      const fullPolicy = {
+        id: 1,
+        title: "P1",
+        author_id: 1,
+        status: "Changes Requested",
+        tags: ["security"],
+        assigned_reviewer_ids: [2],
+        last_updated_by: 1,
+        last_updated_at: "2026-08-14T00:00:00.000Z",
+      };
+      mockGetById.mockResolvedValue([fullPolicy] as any);
+      const req = createReq({ params: { id: "1" }, body: { comment: "fix" } });
+      const res = createRes();
+      await PolicyController.rejectReview(req, res);
+      expect(res.status).toHaveBeenCalledWith(200);
+      expect(res.json).toHaveBeenCalledWith({
+        message: "OK",
+        data: expect.objectContaining({
+          id: 1,
+          title: "P1",
+          status: "Changes Requested",
+          assigned_reviewer_ids: [2],
+        }),
+      });
     });
     it("should return 500 on error", async () => {
       mockGetById.mockRejectedValue(new Error("DB error"));

--- a/Servers/controllers/__tests__/risks.ctrl.test.ts
+++ b/Servers/controllers/__tests__/risks.ctrl.test.ts
@@ -272,6 +272,35 @@ describe("risks.ctrl", () => {
       expect(res.status).toHaveBeenCalledWith(201);
       expect(res.json).toHaveBeenCalledWith(expect.objectContaining({ data: risk }));
     });
+    it("should return the full created risk entity including server-computed fields", async () => {
+      const risk = {
+        ...buildRisk(),
+        risk_owner: 3,
+        risk_category: ["operational"],
+        likelihood: "Rare",
+        severity: "Minor",
+        risk_level_autocalculated: "Low risk",
+        current_risk_level: "Low risk",
+        mitigation_status: "Not Started",
+        ale_estimate: null,
+        created_at: "2026-08-14T00:00:00.000Z",
+        updated_at: "2026-08-14T00:00:00.000Z",
+      };
+      mockCreateService.mockResolvedValue(risk as any);
+      const req = createReq({ body: { risk_name: "R1", projects: [], frameworks: [] } });
+      const res = createRes();
+      await createRisk(req, res);
+      expect(res.status).toHaveBeenCalledWith(201);
+      expect(res.json).toHaveBeenCalledWith({
+        message: "Created",
+        data: expect.objectContaining({
+          id: 1,
+          risk_name: "R1",
+          risk_level_autocalculated: "Low risk",
+          created_at: "2026-08-14T00:00:00.000Z",
+        }),
+      });
+    });
     it("should return 400 when creation returns null", async () => {
       mockCreateService.mockResolvedValue(null as any);
       const req = createReq({ body: { risk_name: "R1" } });
@@ -306,6 +335,40 @@ describe("risks.ctrl", () => {
       await updateRiskById(req, res);
       expect(res.status).toHaveBeenCalledWith(200);
       expect(res.json).toHaveBeenCalledWith(expect.objectContaining({ data: updated }));
+    });
+    it("should return the full updated risk entity including server-computed fields", async () => {
+      const existing = { ...buildRisk(), risk_owner: null, event_frequency_min: null };
+      const updated = {
+        ...buildRisk({ risk_name: "R2" }),
+        risk_owner: 3,
+        risk_category: ["financial"],
+        likelihood: "Possible",
+        severity: "Major",
+        risk_level_autocalculated: "High risk",
+        current_risk_level: "High risk",
+        mitigation_status: "In Progress",
+        ale_estimate: 12500,
+        roi_percentage: 42,
+        created_at: "2026-08-01T00:00:00.000Z",
+        updated_at: "2026-08-14T00:00:00.000Z",
+      };
+      mockGetById.mockResolvedValue(existing as any);
+      mockUpdate.mockResolvedValue(updated as any);
+      const req = createReq({ params: { id: "1" }, body: { risk_name: "R2" } });
+      const res = createRes();
+      await updateRiskById(req, res);
+      expect(res.status).toHaveBeenCalledWith(200);
+      expect(res.json).toHaveBeenCalledWith({
+        message: "OK",
+        data: expect.objectContaining({
+          id: 1,
+          risk_name: "R2",
+          risk_level_autocalculated: "High risk",
+          ale_estimate: 12500,
+          roi_percentage: 42,
+          updated_at: "2026-08-14T00:00:00.000Z",
+        }),
+      });
     });
     it("should return 500 on error", async () => {
       mockGetById.mockRejectedValue(new Error("DB error"));

--- a/Servers/controllers/__tests__/task.ctrl.test.ts
+++ b/Servers/controllers/__tests__/task.ctrl.test.ts
@@ -153,6 +153,43 @@ describe("task.ctrl", () => {
       await createTask(req, res);
       expect(res.status).toHaveBeenCalledWith(201);
     });
+    it("should return the full created task entity in the response body", async () => {
+      const fullTask = {
+        id: 1,
+        title: "T1",
+        description: "desc",
+        creator_id: 1,
+        organization_id: 1,
+        due_date: "2026-09-01T00:00:00.000Z",
+        priority: "High",
+        status: "Open",
+        categories: ["a"],
+        created_at: "2026-08-14T00:00:00.000Z",
+        updated_at: "2026-08-14T00:00:00.000Z",
+      };
+      const task = {
+        ...mockTask(fullTask),
+        dataValues: { ...fullTask, assignees: [2, 3] },
+      };
+      mockCreate.mockResolvedValue(task as any);
+      const req = createReq({ body: { title: "T1", assignees: [2, 3] } });
+      const res = createRes();
+      await createTask(req, res);
+      expect(res.status).toHaveBeenCalledWith(201);
+      expect(res.json).toHaveBeenCalledWith({
+        message: "Created",
+        data: expect.objectContaining({
+          id: 1,
+          title: "T1",
+          description: "desc",
+          creator_id: 1,
+          priority: "High",
+          status: "Open",
+          created_at: "2026-08-14T00:00:00.000Z",
+          assignees: [2, 3],
+        }),
+      });
+    });
     it("should return 500 on error", async () => {
       mockCreate.mockRejectedValue(new Error("DB error"));
       const req = createReq({ body: { title: "T1" } });
@@ -239,6 +276,46 @@ describe("task.ctrl", () => {
       await updateTask(req, res);
       expect(res.status).toHaveBeenCalledWith(200);
     });
+    it("should return the full updated task entity in the response body", async () => {
+      const existing = mockTask(buildTask());
+      const fullUpdated = {
+        id: 1,
+        title: "T2",
+        description: "desc",
+        creator_id: 1,
+        organization_id: 1,
+        due_date: "2026-09-01T00:00:00.000Z",
+        priority: "High",
+        status: "In Progress",
+        categories: ["a"],
+        created_at: "2026-08-14T00:00:00.000Z",
+        updated_at: "2026-08-14T01:00:00.000Z",
+      };
+      const updated = {
+        ...mockTask(fullUpdated),
+        dataValues: { ...fullUpdated, assignees: [2] },
+      };
+      mockGetById.mockResolvedValue(existing as any);
+      mockUpdate.mockResolvedValue(updated as any);
+      const req = createReq({
+        params: { id: "1" },
+        body: { title: "T2", status: "In Progress", assignees: [2] },
+      });
+      const res = createRes();
+      await updateTask(req, res);
+      expect(res.status).toHaveBeenCalledWith(200);
+      expect(res.json).toHaveBeenCalledWith({
+        message: "OK",
+        data: expect.objectContaining({
+          id: 1,
+          title: "T2",
+          status: "In Progress",
+          priority: "High",
+          updated_at: "2026-08-14T01:00:00.000Z",
+          assignees: [2],
+        }),
+      });
+    });
     it("should return 500 on error", async () => {
       mockGetById.mockRejectedValue(new Error("DB error"));
       const req = createReq({ params: { id: "1" }, body: { title: "T2" } });
@@ -291,6 +368,34 @@ describe("task.ctrl", () => {
       const res = createRes();
       await restoreTask(req, res);
       expect(res.status).toHaveBeenCalledWith(200);
+    });
+    it("should return the full restored task entity in the response body", async () => {
+      const restored = {
+        ...buildTask(),
+        description: "desc",
+        creator_id: 1,
+        organization_id: 1,
+        priority: "Medium",
+        status: "Open",
+        categories: [],
+        created_at: "2026-08-14T00:00:00.000Z",
+        updated_at: "2026-08-14T01:00:00.000Z",
+        assignees: [2],
+      };
+      mockRestore.mockResolvedValue(restored as any);
+      const req = createReq({ params: { id: "1" } });
+      const res = createRes();
+      await restoreTask(req, res);
+      expect(res.status).toHaveBeenCalledWith(200);
+      expect(res.json).toHaveBeenCalledWith({
+        message: "OK",
+        data: expect.objectContaining({
+          id: 1,
+          title: "T1",
+          status: "Open",
+          assignees: [2],
+        }),
+      });
     });
     it("should return 404 when task is not found", async () => {
       mockRestore.mockResolvedValue(null as any);


### PR DESCRIPTION
## Describe your changes

Adds optimistic mutation hooks for tasks, project risks, file tags, and policies, with instant cache updates, snapshot rollback on failure, and the standardized error toast. Successful mutations swap in the server-returned entity and invalidate only derived queries (deadline warnings, dashboard counters, policy tags), eliminating full-list refetches. Backend endpoints were verified to return full updated entities, with new unit and integration tests covering optimistic updates, rollback, invalidation targets, and instant feedback.

Fixes No. 5 of #4150 

## Please ensure all items are checked off before requesting a review:

- [x] I deployed the code locally.
- [x] I have performed a self-review of my code.
- [x] I have included the issue # in the PR.
- [x] I have labelled the PR correctly.
- [x] The issue I am working on is assigned to me.
- [x] I have avoided using hardcoded values to ensure scalability and maintain consistency across the application.
- [x] I have ensured that font sizes, color choices, and other UI elements are referenced from the theme.
- [x] My pull request is focused and addresses a single, specific feature.
- [x] If there are UI changes, I have attached a screenshot or video to this PR.
- [ ] If I added or modified an API endpoint, the change is reflected in the generated OpenAPI spec (`npm run generate:swagger`).
- [ ] If the endpoint requires authentication, it uses `authenticateJWT` and the generated spec declares `bearerAuth` security.
- [ ] I ran `npm run check:api-drift` and committed the regenerated `swagger.yaml` and `endpoints.ts`.
- [ ] If this PR adds or modifies an organization-scoped table, the [tenant isolation registry](Servers/tests/integration/tenant-isolation/tenantIsolation.registry.ts) and [test matrix](Servers/tests/integration/tenant-isolation) are updated. See the [tenant isolation runbook](docs/technical/security/tenant-isolation.md) for details.
