### PR TITLE
fix(approvals): stretch workflow step divider when validation error appear

### DIFF
--- a/Clients/src/presentation/components/Modals/NewApprovalWorkflow/index.tsx
+++ b/Clients/src/presentation/components/Modals/NewApprovalWorkflow/index.tsx
@@ -233,10 +233,8 @@ const CreateNewApprovalWorkflow: FC<ICreateApprovalWorkflowProps> = ({
                   />
                 </Box>
               </Stack>
-              <Stack direction="row" alignItems="flex-start">
-                <Box>
-                  <Divider orientation="vertical" flexItem sx={verticalStepDividerStyle} />
-                </Box>
+              <Stack direction="row" alignItems="stretch">
+                <Divider orientation="vertical" flexItem sx={verticalStepDividerStyle} />
                 <Stack sx={stepFieldsContainer} spacing={6}>
                   <Field
                     id={`step_name_${stepIndex}`}

--- a/Clients/src/presentation/components/Modals/NewApprovalWorkflow/style.ts
+++ b/Clients/src/presentation/components/Modals/NewApprovalWorkflow/style.ts
@@ -50,8 +50,8 @@ export const removeStepLinkContainer = {
 
 export const verticalStepDividerStyle = {
   borderRightWidth: "1px",
-  height: "216px",
-  borderColor: "#E0E0E0",
+  alignSelf: "stretch",
+  borderColor: borderPalette.dark,
   mt: 4,
   ml: 6,
   mr: 12,


### PR DESCRIPTION

## Describe your changes

Remove the fixed divider height so the line tracks the step fields, and use the palette border token instead of a hardcoded color.

## Write your issue number after "Fixes "

Fixes #3821 

## Please ensure all items are checked off before requesting a review:

- [x] I deployed the code locally.
- [x] I have performed a self-review of my code.
- [x] I have included the issue # in the PR.
- [x] I have labelled the PR correctly.
- [x] The issue I am working on is assigned to me.
- [x] I have avoided using hardcoded values to ensure scalability and maintain consistency across the application.
- [x] I have ensured that font sizes, color choices, and other UI elements are referenced from the theme.
- [x] My pull request is focused and addresses a single, specific feature.
- [x] If there are UI changes, I have attached a screenshot or video to this PR.
- [ ] If I added or modified an API endpoint, the change is reflected in the generated OpenAPI spec (`npm run generate:swagger`).
- [ ] If the endpoint requires authentication, it uses `authenticateJWT` and the generated spec declares `bearerAuth` security.
- [ ] I ran `npm run check:api-drift` and committed the regenerated `swagger.yaml` and `endpoints.ts`.
- [ ] If this PR adds or modifies an organization-scoped table, the [tenant isolation registry](Servers/tests/integration/tenant-isolation/tenantIsolation.registry.ts) and [test matrix](Servers/tests/integration/tenant-isolation) are updated. See the [tenant isolation runbook](docs/technical/security/tenant-isolation.md) for details.

<img width="2513" height="1241" alt="Screenshot 2026-08-14 at 4 34 40 PM" src="https://github.com/user-attachments/assets/7bb5eeb9-3609-4c4f-9561-1f457c72ec7c" />
