### PR TITLE
chore(aigateway): bump litellm 1.89.3 -> 1.97.0

### DIFF
--- a/AIGateway/requirements.txt
+++ b/AIGateway/requirements.txt
@@ -14,7 +14,7 @@ asyncpg>=0.31.0
 
 # LiteLLM SDK (MIT licensed)
 # Pinned to a specific version — updated per VerifyWise release
-litellm==1.89.3
+litellm==1.97.0
 
 # Database migrations (Alembic)
 sqlalchemy[asyncio]>=2.0.0


### PR DESCRIPTION
## Summary

Bumps the litellm SDK used by the AI Gateway from `1.89.3` to `1.97.0` (one line, `AIGateway/requirements.txt`). The pin was ~2 months / 33 stable releases behind. This is the per-release SDK refresh noted in the requirements comment.

## Why

- **Security hardening on a path we use:** 1.95.0 prevents provider-key exposure through URL-valued model destinations and `fallbacks`. The gateway passes a per-call `api_key` inside `fallbacks` in `services/llm_service.py`, so this touches our exact code path.
- **Fresh model + pricing catalog:** the gateway reads `litellm.model_cost` for its model list and spend tracking. On the old pin that catalog was 60 days stale (missing models, outdated prices).

## Risk assessment

- **No breaking changes hit our SDK surface.** Reviewed all 33 release notes in range against the APIs the gateway calls (`acompletion`, `aembedding`, `completion_cost`, `cost_per_token`, `token_counter`, `get_model_info`, `model_cost`). Every breaking/deprecation signal in the range was proxy-server / Helm / Docker / DB-migration only — none of which we use (we import the SDK, we do not run the litellm proxy).
- **No CVE regression.** The current pin `1.89.3` already sits above the highest-patched litellm advisory (`1.84.0`); no published advisory is fixed inside the `1.89.3 → 1.97.0` window, and none is introduced.
- **No dependency conflicts** with the gateway's other pins (`pydantic>=2.13`, `httpx>=0.28`, `fastapi>=0.120`, `openai`, `anthropic`).
- Isolated, reversible one-line change.
