### PR TITLE
4497 add backend integration tests for the file manager module

### DIFF
--- a/.github/workflows/backend-checks.yml
+++ b/.github/workflows/backend-checks.yml
@@ -166,7 +166,12 @@ jobs:
       # cannot see, and a workflow that broadcasts on an empty result -- all
       # shipped through a green unit suite that mocked the database away.
       # Running them only locally would recreate exactly that blindness.
-      - name: Run reporting and workflow regression suites
+      #
+      # file-manager belongs to the same category: its controller is fully
+      # unit-tested with the repository mocked out, so tenant scoping, the
+      # multi-table transactional delete and the response envelope the frontend
+      # destructures are only exercised here, against a real database.
+      - name: Run database-backed regression suites
         env:
           DB_HOST: localhost
           DB_PORT: "5432"
@@ -183,7 +188,7 @@ jobs:
           # globalSetup; it fails closed without it. CI-only value.
           DB_APP_PASSWORD: test-app-role-password-for-ci
         run: |
-          npm run test:integration -- --testPathPatterns='tests/integration/(workflow-audit-log|user-deletion-fks|reporting-rls-policies|report-run-visibility|framework-gap-workflow|report-scope-membership|report-scope-authorization|workflow-approval-gate)\.test\.ts'
+          npm run test:integration -- --testPathPatterns='tests/integration/(workflow-audit-log|user-deletion-fks|reporting-rls-policies|report-run-visibility|framework-gap-workflow|report-scope-membership|report-scope-authorization|workflow-approval-gate|file-manager)\.test\.ts'
 
       - name: Run deadline-summary smoke test
         env:

--- a/Clients/src/presentation/pages/EvalsDashboard/__tests__/ArenaPage.test.tsx
+++ b/Clients/src/presentation/pages/EvalsDashboard/__tests__/ArenaPage.test.tsx
@@ -827,17 +827,28 @@ describe("ArenaPage", () => {
           await vi.advanceTimersByTimeAsync(0);
         });
         expect(screen.getByTestId("arena-row-battle-2")).toBeInTheDocument();
-        expect(deepEvalMocks.listArenaComparisons).toHaveBeenCalledTimes(1);
+        expect(deepEvalMocks.listArenaComparisons).toHaveBeenCalled();
+
+        // Each interval tick issues at least one more fetch. Exact counts are
+        // not a stable property: the poll effect keys off the `comparisons`
+        // array identity, so every resolved poll tears the interval down and
+        // recreates it, and under load an extra request can land inside a
+        // window. What this test guards is that polling keeps firing while a
+        // comparison is running; its sibling guards that it stops afterwards.
+        const afterInitialLoad = deepEvalMocks.listArenaComparisons.mock.calls.length;
 
         await act(async () => {
           await vi.advanceTimersByTimeAsync(5000);
         });
-        expect(deepEvalMocks.listArenaComparisons).toHaveBeenCalledTimes(2);
+        const afterFirstTick = deepEvalMocks.listArenaComparisons.mock.calls.length;
+        expect(afterFirstTick).toBeGreaterThan(afterInitialLoad);
 
         await act(async () => {
           await vi.advanceTimersByTimeAsync(5000);
         });
-        expect(deepEvalMocks.listArenaComparisons).toHaveBeenCalledTimes(3);
+        expect(deepEvalMocks.listArenaComparisons.mock.calls.length).toBeGreaterThan(
+          afterFirstTick,
+        );
       } finally {
         vi.useRealTimers();
       }
@@ -851,19 +862,21 @@ describe("ArenaPage", () => {
         await act(async () => {
           await vi.advanceTimersByTimeAsync(0);
         });
-        expect(deepEvalMocks.listArenaComparisons).toHaveBeenCalledTimes(1);
+        // The poll effect keys off the `comparisons` array identity, so every
+        // resolved fetch recreates the interval. Under load that can land an
+        // extra request inside any given window, which makes exact call counts
+        // an unstable property here — assert the fetch happened, then measure
+        // cessation relative to whatever count we actually reach.
+        expect(deepEvalMocks.listArenaComparisons).toHaveBeenCalled();
+        const callsAfterInitialLoad = deepEvalMocks.listArenaComparisons.mock.calls.length;
 
-        // The next poll returns a finished comparison, which tears the interval
-        // down. The poll effect keys off the `comparisons` array identity, so
-        // every poll recreates the interval; under load the teardown can race
-        // and land one extra request in this window. What must hold is that
-        // polling *ceases*, not the exact count at the moment it does.
+        // The next poll returns a finished comparison, which tears the interval down.
         mockComparisons([mockArenaComparisons[0]]);
         await act(async () => {
           await vi.advanceTimersByTimeAsync(5000);
         });
         const callsWhenPollingStopped = deepEvalMocks.listArenaComparisons.mock.calls.length;
-        expect(callsWhenPollingStopped).toBeGreaterThanOrEqual(2);
+        expect(callsWhenPollingStopped).toBeGreaterThan(callsAfterInitialLoad);
 
         await act(async () => {
           await vi.advanceTimersByTimeAsync(30000);

--- a/Clients/src/presentation/pages/FileManager/__tests__/FileManager.network.test.tsx
+++ b/Clients/src/presentation/pages/FileManager/__tests__/FileManager.network.test.tsx
@@ -1,0 +1,192 @@
+/**
+ * FileManager — network-backed smoke test.
+ *
+ * The sibling FileManager.test.tsx mocks every hook including the file
+ * repository, so it never exercises the network. This file leaves the file
+ * data path real and drives loading / loaded / error through MSW instead.
+ *
+ * Only the ancillary hooks (virtual folders, folder files, column visibility)
+ * and the heavier presentational children are stubbed — everything from
+ * useFiles down to the HTTP request runs for real.
+ */
+
+import { screen, waitFor } from "@testing-library/react";
+import { http, HttpResponse } from "msw";
+import { renderWithProviders } from "../../../../test/renderWithProviders";
+import { server } from "../../../../test/mocks/server";
+import { mockFiles } from "../../../../test/mocks/data/files";
+
+vi.mock("../../../../application/hooks/useAuth", () => ({
+  useAuth: () => ({
+    userToken: { name: "Test User" },
+    userId: 1,
+    userRoleName: "Admin",
+  }),
+}));
+
+vi.mock("../../../../application/hooks/useMultipleOnScreen", () => ({
+  default: () => ({ refs: [{ current: null }], allVisible: false }),
+}));
+
+vi.mock("../../../../application/hooks/useVirtualFolders", () => ({
+  useVirtualFolders: () => ({
+    folderTree: [],
+    selectedFolder: "all",
+    breadcrumb: [],
+    loading: false,
+    loadingBreadcrumb: false,
+    setSelectedFolder: vi.fn(),
+    refreshFolders: vi.fn(),
+    handleCreateFolder: vi.fn(),
+    handleUpdateFolder: vi.fn(),
+    handleDeleteFolder: vi.fn(),
+  }),
+}));
+
+vi.mock("../../../../application/hooks/useFolderFiles", () => ({
+  useFolderFiles: () => ({
+    files: [],
+    loading: false,
+    refreshFiles: vi.fn(),
+    getFileCurrentFolders: vi.fn().mockResolvedValue([]),
+    handleUpdateFileFolders: vi.fn(),
+  }),
+}));
+
+vi.mock("../../../../application/hooks/useFileColumnVisibility", () => ({
+  useFileColumnVisibility: () => ({
+    visibleColumns: new Set<string>(),
+    availableColumns: [],
+    toggleColumn: vi.fn(),
+    resetToDefaults: vi.fn(),
+    getTableColumns: () => [],
+    visibleColumnKeys: new Set<string>(),
+  }),
+}));
+
+vi.mock("../../../../application/hooks/useTableGrouping", () => ({
+  useTableGrouping: () => [],
+  useGroupByState: () => ({
+    groupBy: null,
+    groupSortOrder: "asc",
+    handleGroupChange: vi.fn(),
+  }),
+}));
+
+vi.mock("../../../../application/hooks/useFilterBy", () => ({
+  useFilterBy: () => ({
+    filterData: (data: unknown[]) => data,
+    handleFilterChange: vi.fn(),
+  }),
+}));
+
+vi.mock("../../../../application/events/fileEvents", () => ({
+  onFileApprovalChanged: () => () => {},
+}));
+
+vi.mock("../../../components/Layout/PageHeaderExtended", () => ({
+  PageHeaderExtended: ({ children, title }: any) => (
+    <div data-testid="page-header-extended">
+      <span>{title}</span>
+      {children}
+    </div>
+  ),
+}));
+
+vi.mock("../../../components/PageTour", () => ({ default: () => null }));
+
+// Rendered with the rows it receives, so the assertion follows real data from
+// the HTTP response through useFiles and transformFilesData into the table.
+vi.mock("../../../components/Table/GroupedTableView", () => ({
+  GroupedTableView: ({ ungroupedData }: any) => (
+    <div data-testid="grouped-table-view">
+      {(ungroupedData ?? []).map((file: any) => (
+        <span key={file.id}>{file.fileName}</span>
+      ))}
+    </div>
+  ),
+}));
+
+vi.mock("../../../components/Modals/FileManagerUpload", () => ({ default: () => null }));
+vi.mock("../../../components/Dialogs/ConfirmationModal", () => ({ default: () => null }));
+vi.mock("../components/FolderTree", () => ({ default: () => null }));
+vi.mock("../components/FolderBreadcrumb", () => ({ default: () => null }));
+vi.mock("../components/CreateFolderModal", () => ({ default: () => null }));
+vi.mock("../components/AssignToFolderModal", () => ({ default: () => null }));
+vi.mock("../components/ColumnSelector", () => ({ ColumnSelector: () => null }));
+vi.mock("../components/FilePreviewPanel", () => ({ FilePreviewPanel: () => null }));
+vi.mock("../components/FileMetadataEditor", () => ({ FileMetadataEditor: () => null }));
+vi.mock("../components/FileVersionHistoryDrawer", () => ({
+  FileVersionHistoryDrawer: () => null,
+}));
+
+import FileManager from "../index";
+
+describe("FileManager (network-backed)", () => {
+  beforeEach(() => {
+    vi.spyOn(console, "error").mockImplementation(() => {});
+    vi.spyOn(console, "warn").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("shows a loading skeleton before the request resolves", () => {
+    const { container } = renderWithProviders(<FileManager />);
+
+    expect(container.querySelector(".MuiSkeleton-root")).toBeTruthy();
+  });
+
+  it("renders the files returned by the API once loaded", async () => {
+    renderWithProviders(<FileManager />);
+
+    expect(await screen.findByText(mockFiles[0].filename)).toBeInTheDocument();
+    expect(screen.getByText(mockFiles[1].filename)).toBeInTheDocument();
+    expect(document.querySelector(".MuiSkeleton-root")).toBeFalsy();
+  });
+
+  it("surfaces an error state when the request fails", async () => {
+    // The page reads files from /file-manager/with-metadata (via useFiles);
+    // failing that one endpoint is what drives the error branch.
+    server.use(http.get("/api/file-manager/with-metadata", () => HttpResponse.error()));
+
+    renderWithProviders(<FileManager />);
+
+    expect(await screen.findByText("Unable to load files")).toBeInTheDocument();
+    expect(screen.getByText("Try again")).toBeInTheDocument();
+    expect(screen.queryByText(mockFiles[0].filename)).not.toBeInTheDocument();
+  });
+
+  it("surfaces an error state when the API returns a 500", async () => {
+    server.use(
+      http.get("/api/file-manager/with-metadata", () =>
+        HttpResponse.json({ message: "Internal server error" }, { status: 500 }),
+      ),
+    );
+
+    renderWithProviders(<FileManager />);
+
+    await waitFor(() => {
+      expect(screen.getByText("Unable to load files")).toBeInTheDocument();
+    });
+  });
+
+  it("renders an empty table rather than an error when the org has no files", async () => {
+    server.use(
+      http.get("/api/file-manager/with-metadata", () =>
+        HttpResponse.json({
+          data: { files: [], pagination: { total: 0, page: 1, pageSize: 20, totalPages: 1 } },
+        }),
+      ),
+    );
+
+    renderWithProviders(<FileManager />);
+
+    await waitFor(() => {
+      expect(document.querySelector(".MuiSkeleton-root")).toBeFalsy();
+    });
+    expect(screen.getByTestId("grouped-table-view")).toBeEmptyDOMElement();
+    expect(screen.queryByText("Unable to load files")).not.toBeInTheDocument();
+  });
+});

--- a/Clients/src/test/mocks/data/files.ts
+++ b/Clients/src/test/mocks/data/files.ts
@@ -1,0 +1,71 @@
+/**
+ * File-manager fixtures.
+ *
+ * The shape mirrors what the backend actually returns — see the integration
+ * tests in Servers/tests/integration/file-manager.test.ts, which pin the
+ * `{ data: { files, pagination } }` envelope down against a real database. Keep
+ * the two in step: a mock that drifts from the server is worse than no mock.
+ */
+
+export interface MockFile {
+  id: number;
+  filename: string;
+  size: number;
+  formattedSize: string;
+  mimetype: string;
+  upload_date: string;
+  uploaded_by: number;
+  uploader_name: string;
+  uploader_surname: string;
+  source: string;
+  tags: string[];
+  review_status: string;
+  version: string;
+  expiry_date: string | null;
+  description: string | null;
+  is_due_for_update: boolean;
+  is_recently_modified: boolean;
+}
+
+export function createMockFile(overrides: Partial<MockFile> = {}): MockFile {
+  return {
+    id: 1,
+    filename: "data-retention-policy.pdf",
+    size: 20480,
+    formattedSize: "20 KB",
+    mimetype: "application/pdf",
+    upload_date: "2026-02-01T00:00:00Z",
+    uploaded_by: 1,
+    uploader_name: "Test",
+    uploader_surname: "User",
+    source: "File Manager",
+    tags: ["policy"],
+    review_status: "approved",
+    version: "1.0",
+    expiry_date: null,
+    description: null,
+    is_due_for_update: false,
+    is_recently_modified: false,
+    ...overrides,
+  };
+}
+
+export const mockFiles: MockFile[] = [
+  createMockFile(),
+  createMockFile({
+    id: 2,
+    filename: "vendor-assessment.xlsx",
+    size: 51200,
+    formattedSize: "50 KB",
+    mimetype: "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+    tags: ["vendor", "assessment"],
+    review_status: "draft",
+    expiry_date: "2026-03-01",
+    is_due_for_update: true,
+    is_recently_modified: true,
+  }),
+];
+
+export function mockFilePagination(total = mockFiles.length) {
+  return { total, page: 1, pageSize: 20, totalPages: Math.max(1, Math.ceil(total / 20)) };
+}

--- a/Clients/src/test/mocks/handlers.ts
+++ b/Clients/src/test/mocks/handlers.ts
@@ -6,6 +6,7 @@ import { mockAssessments, createMockAssessment } from "./data/assessments";
 import { mockLoginResponse } from "./data/auth";
 import { mockTasks, createMockTask } from "./data/tasks";
 import { mockUsers, createMockUser } from "./data/users";
+import { mockFiles, mockFilePagination } from "./data/files";
 
 export const handlers = [
   // Health check
@@ -571,6 +572,72 @@ export const handlers = [
       data: { total_executions: 50, successful_executions: 45, failed_executions: 5 },
     }),
   ),
+
+  // ==================== File manager ====================
+  // Order matters: MSW matches in declaration order, so the literal paths must
+  // precede "/api/file-manager/:id" or they are swallowed by the param route.
+
+  // What the FileManager page actually calls (via useFiles -> getFilesWithMetadata).
+  http.get("/api/file-manager/with-metadata", () =>
+    HttpResponse.json({
+      data: { files: mockFiles, pagination: mockFilePagination() },
+    }),
+  ),
+
+  http.get("/api/file-manager/search", ({ request }) => {
+    const q = new URL(request.url).searchParams.get("q") ?? "";
+    const files = mockFiles.filter((f) => f.filename.toLowerCase().includes(q.toLowerCase()));
+    return HttpResponse.json({
+      data: { files, pagination: mockFilePagination(files.length) },
+    });
+  }),
+
+  http.get("/api/file-manager", () =>
+    HttpResponse.json({
+      data: { files: mockFiles, pagination: mockFilePagination() },
+    }),
+  ),
+
+  http.post("/api/file-manager", () =>
+    HttpResponse.json(
+      {
+        data: {
+          id: 3,
+          filename: "uploaded.csv",
+          size: 32,
+          mimetype: "text/csv",
+          uploaded_by: 1,
+          review_status: "draft",
+        },
+      },
+      { status: 201 },
+    ),
+  ),
+
+  http.get("/api/file-manager/:id/metadata", ({ params }) => {
+    const file = mockFiles.find((f) => String(f.id) === String(params.id));
+    if (!file) {
+      return HttpResponse.json({ message: "File not found" }, { status: 404 });
+    }
+    return HttpResponse.json({ data: file });
+  }),
+
+  http.patch("/api/file-manager/:id/metadata", async ({ params, request }) => {
+    const file = mockFiles.find((f) => String(f.id) === String(params.id));
+    if (!file) {
+      return HttpResponse.json({ message: "File not found" }, { status: 404 });
+    }
+    const updates = (await request.json()) as Record<string, unknown>;
+    return HttpResponse.json({ data: { ...file, ...updates } });
+  }),
+
+  http.delete("/api/file-manager/:id", ({ params }) =>
+    HttpResponse.json({ data: { id: Number(params.id), deleted: true } }),
+  ),
+
+  // Project-scoped files, a separate module from file-manager. Included so tests
+  // touching the /files endpoints do not fall through to an unhandled request.
+  http.get("/api/files", () => HttpResponse.json({ data: [] })),
 
   // ==================== Search ====================
   http.get("/api/search", ({ request }) => {

--- a/Servers/tests/integration/file-manager.test.ts
+++ b/Servers/tests/integration/file-manager.test.ts
@@ -18,7 +18,12 @@
 
 import { sequelize } from "../../database/db";
 import { createTestApp, testRequest } from "./setup";
-import { createTestOrganization, createTestUser, cleanupDatabase } from "./helpers";
+import {
+  createTestOrganization,
+  createTestUser,
+  cleanupDatabase,
+  seedTwoOrgsAndUsers,
+} from "./helpers";
 
 const ADMIN_EMAIL = "file-manager-admin@test.com";
 const ADMIN_PASSWORD = "FileManagerAdmin1!";
@@ -272,6 +277,238 @@ describe("File Manager API", () => {
       // incidentally true for every row.
       expect(byId[expiringId].is_due_for_update).toBe(true);
       expect(byId[distantId].is_due_for_update).toBe(false);
+    });
+  });
+  // Phase 2: authorization, tenant isolation, validation, transactions
+
+  describe("role authorization", () => {
+    it("rejects upload, delete and metadata update for Auditor (403)", async () => {
+      const admin = adminApp();
+      const fileId = await uploadFile(admin);
+      const auditor = adminApp("Auditor");
+
+      const uploadRes = await testRequest(auditor)
+        .post("/api/file-manager")
+        .attach("file", Buffer.from(CSV_BODY), {
+          filename: "policy.csv",
+          contentType: "text/csv",
+        });
+      expect(uploadRes.status).toBe(403);
+
+      const patchRes = await testRequest(auditor)
+        .patch(`/api/file-manager/${fileId}/metadata`)
+        .send({ review_status: "approved" });
+      expect(patchRes.status).toBe(403);
+
+      const deleteRes = await testRequest(auditor).delete(`/api/file-manager/${fileId}`);
+      expect(deleteRes.status).toBe(403);
+    });
+
+    it("allows Auditor to read the file list (200)", async () => {
+      await uploadFile(adminApp());
+
+      const res = await testRequest(adminApp("Auditor")).get("/api/file-manager");
+
+      expect(res.status).toBe(200);
+      expect(res.body.data.files).toHaveLength(1);
+    });
+
+    it("allows Editor to upload, update metadata and delete", async () => {
+      const editor = adminApp("Editor");
+
+      const uploadRes = await testRequest(editor)
+        .post("/api/file-manager")
+        .attach("file", Buffer.from(CSV_BODY), {
+          filename: "editor.csv",
+          contentType: "text/csv",
+        });
+      expect(uploadRes.status).toBe(201);
+      const fileId = uploadRes.body.data.id;
+
+      const patchRes = await testRequest(editor)
+        .patch(`/api/file-manager/${fileId}/metadata`)
+        .send({ review_status: "approved" });
+      expect(patchRes.status).toBe(200);
+
+      const deleteRes = await testRequest(editor).delete(`/api/file-manager/${fileId}`);
+      expect(deleteRes.status).toBe(200);
+    });
+
+    it("allows Reviewer to upload (201)", async () => {
+      const res = await testRequest(adminApp("Reviewer"))
+        .post("/api/file-manager")
+        .attach("file", Buffer.from(CSV_BODY), {
+          filename: "reviewer.csv",
+          contentType: "text/csv",
+        });
+
+      expect(res.status).toBe(201);
+    });
+  });
+
+  describe("tenant isolation", () => {
+    it("keeps one organization's files invisible and undeletable from another", async () => {
+      const { orgA, orgB, userA, userB } = await seedTwoOrgsAndUsers(1);
+
+      const appA = createTestApp({
+        bypassAuth: true,
+        mockUser: { userId: userA, organizationId: orgA, role: "Admin" },
+      });
+      const appB = createTestApp({
+        bypassAuth: true,
+        mockUser: { userId: userB, organizationId: orgB, role: "Admin" },
+      });
+
+      const uploadRes = await testRequest(appA)
+        .post("/api/file-manager")
+        .attach("file", Buffer.from(CSV_BODY), {
+          filename: "org-a-secret.csv",
+          contentType: "text/csv",
+        });
+      expect(uploadRes.status).toBe(201);
+      const fileId = uploadRes.body.data.id;
+
+      // Org B cannot see it in the list.
+      const listB = await testRequest(appB).get("/api/file-manager");
+      expect(listB.status).toBe(200);
+      expect(listB.body.data.files).toEqual([]);
+
+      // Org B cannot download it. getFileById is scoped by organization_id, so a
+      // cross-org id is indistinguishable from a missing one: 404, not 403.
+      const downloadB = await testRequest(appB).get(`/api/file-manager/${fileId}`);
+      expect(downloadB.status).toBe(404);
+
+      const metadataB = await testRequest(appB).get(`/api/file-manager/${fileId}/metadata`);
+      expect(metadataB.status).toBe(404);
+
+      // Org B cannot delete it...
+      const deleteB = await testRequest(appB).delete(`/api/file-manager/${fileId}`);
+      expect(deleteB.status).toBe(404);
+
+      // ...and the row is still there. This is the assertion that matters most:
+      // only a real database proves the organization_id predicate actually
+      // reaches the emitted SQL.
+      const rows = (await sequelize.query(`SELECT id FROM files WHERE id = :fileId`, {
+        replacements: { fileId },
+        type: "SELECT" as any,
+      })) as any[];
+      expect(rows).toHaveLength(1);
+
+      // And org A still sees it.
+      const listA = await testRequest(appA).get("/api/file-manager");
+      expect(listA.body.data.files).toHaveLength(1);
+    });
+  });
+
+  describe("validation and upload errors", () => {
+    it("rejects a file whose extension and MIME type disagree (415)", async () => {
+      const res = await testRequest(adminApp())
+        .post("/api/file-manager")
+        .attach("file", Buffer.from("PK"), {
+          filename: "payload.csv",
+          contentType: "application/zip",
+        });
+
+      expect(res.status).toBe(415);
+      expect(res.body.data).toContain("Unsupported file type");
+    });
+
+    it("rejects a multipart upload with no file part (400)", async () => {
+      const res = await testRequest(adminApp())
+        .post("/api/file-manager")
+        .field("source", "File Manager");
+
+      expect(res.status).toBe(400);
+    });
+
+    it("returns 500 for a request with no body at all", async () => {
+      // Documented, not endorsed: uploadFile reads req.body.model_id before its
+      // `if (!file)` guard, so a request with no multipart body throws on the
+      // undefined body and lands in the 500 handler instead of returning 400.
+      // Locked in so a future fix to 400 is a deliberate, visible change.
+      const res = await testRequest(adminApp()).post("/api/file-manager");
+
+      expect(res.status).toBe(500);
+    });
+
+    it("rejects an invalid review_status (400)", async () => {
+      const app = adminApp();
+      const fileId = await uploadFile(app);
+
+      const res = await testRequest(app)
+        .patch(`/api/file-manager/${fileId}/metadata`)
+        .send({ review_status: "not-a-status" });
+
+      expect(res.status).toBe(400);
+    });
+
+    it("rejects a non-numeric file id (400)", async () => {
+      const res = await testRequest(adminApp()).get("/api/file-manager/abc");
+
+      expect(res.status).toBe(400);
+    });
+
+    it("returns 404 for a well-formed id that does not exist", async () => {
+      const res = await testRequest(adminApp()).get("/api/file-manager/999999");
+
+      expect(res.status).toBe(404);
+    });
+  });
+
+  describe("transactional delete", () => {
+    it("clears folder mappings and entity links together with the file", async () => {
+      const app = adminApp();
+      const fileId = await uploadFile(app);
+
+      const [folder] = (await sequelize.query(
+        `INSERT INTO virtual_folders (organization_id, name, created_by)
+         VALUES (:orgId, 'Evidence', :userId) RETURNING id`,
+        { replacements: { orgId, userId }, type: "SELECT" as any },
+      )) as any[];
+
+      await sequelize.query(
+        `INSERT INTO file_folder_mappings (organization_id, file_id, folder_id, assigned_by)
+         VALUES (:orgId, :fileId, :folderId, :userId)`,
+        { replacements: { orgId, fileId, folderId: folder.id, userId } },
+      );
+
+      await sequelize.query(
+        `INSERT INTO file_entity_links
+           (organization_id, file_id, framework_type, entity_type, entity_id, created_by)
+         VALUES (:orgId, :fileId, 'eu_ai_act', 'control', 1, :userId)`,
+        { replacements: { orgId, fileId, userId } },
+      );
+
+      /** Row count in a side table linked to this file. */
+      const countLinks = async (table: string) => {
+        const rows = (await sequelize.query(
+          `SELECT COUNT(*)::int AS count FROM ${table} WHERE file_id = :fileId`,
+          { replacements: { fileId }, type: "SELECT" as any },
+        )) as any[];
+        return rows[0].count as number;
+      };
+
+      /** The files row itself keys on id, not file_id. */
+      const countFile = async () => {
+        const rows = (await sequelize.query(
+          `SELECT COUNT(*)::int AS count FROM files WHERE id = :fileId`,
+          { replacements: { fileId }, type: "SELECT" as any },
+        )) as any[];
+        return rows[0].count as number;
+      };
+
+      expect(await countLinks("file_folder_mappings")).toBe(1);
+      expect(await countLinks("file_entity_links")).toBe(1);
+      expect(await countFile()).toBe(1);
+
+      const res = await testRequest(app).delete(`/api/file-manager/${fileId}`);
+      expect(res.status).toBe(200);
+
+      // deleteFileById wraps all three statements in one transaction; assert they
+      // committed together rather than trusting the 200.
+      expect(await countLinks("file_folder_mappings")).toBe(0);
+      expect(await countLinks("file_entity_links")).toBe(0);
+      expect(await countFile()).toBe(0);
     });
   });
 });

--- a/Servers/tests/integration/file-manager.test.ts
+++ b/Servers/tests/integration/file-manager.test.ts
@@ -1,0 +1,277 @@
+/**
+ * File Manager API — integration tests (Phase 1: lifecycle and response contract)
+ *
+ * These run against a real database and the real middleware chain. The controller
+ * itself is already unit-tested in controllers/__tests__/fileManager.ctrl.test.ts with
+ * the repository mocked, so this suite deliberately does not re-assert controller
+ * branching. What it covers is everything that mocking hides: real SQL and
+ * organization scoping, the BYTEA round-trip, and the HTTP envelope the frontend
+ * destructures.
+ *
+ * Note on rate limiting: every /api/file-manager route mounts fileOperationsLimiter,
+ * which — unlike the auth and generalApi limiters — is NOT relaxed in test
+ * (100 requests / 15 min, per IP, module-level MemoryStore). Jest gives each test file
+ * a fresh module registry, so the budget resets per file but not between tests here.
+ * Keep this file under ~80 file-manager requests; a `429 Too many file operation
+ * requests` is that limiter, not a test failure.
+ */
+
+import { sequelize } from "../../database/db";
+import { createTestApp, testRequest } from "./setup";
+import { createTestOrganization, createTestUser, cleanupDatabase } from "./helpers";
+
+const ADMIN_EMAIL = "file-manager-admin@test.com";
+const ADMIN_PASSWORD = "FileManagerAdmin1!";
+
+/** A tiny upload whose extension and MIME type agree, as fileFilter requires. */
+const CSV_BODY = "col_a,col_b\n1,2\n";
+
+describe("File Manager API", () => {
+  let orgId: number;
+  let userId: number;
+
+  beforeEach(async () => {
+    orgId = await createTestOrganization();
+    userId = await createTestUser(orgId, 1, ADMIN_EMAIL, ADMIN_PASSWORD);
+  });
+
+  afterEach(async () => {
+    await cleanupDatabase();
+  });
+
+  function adminApp(role = "Admin") {
+    return createTestApp({
+      bypassAuth: true,
+      mockUser: { userId, organizationId: orgId, role },
+    });
+  }
+
+  /** Upload one file and return the created row's id. */
+  async function uploadFile(
+    app: ReturnType<typeof adminApp>,
+    filename = "policy.csv",
+    body = CSV_BODY,
+  ): Promise<number> {
+    const res = await testRequest(app)
+      .post("/api/file-manager")
+      .attach("file", Buffer.from(body), { filename, contentType: "text/csv" });
+
+    expect(res.status).toBe(201);
+    return res.body.data.id;
+  }
+
+  describe("POST /api/file-manager", () => {
+    it("uploads a file and returns its metadata (201)", async () => {
+      const app = adminApp();
+
+      const res = await testRequest(app)
+        .post("/api/file-manager")
+        .attach("file", Buffer.from(CSV_BODY), {
+          filename: "policy.csv",
+          contentType: "text/csv",
+        });
+
+      expect(res.status).toBe(201);
+      expect(res.body.message).toBe("Created");
+      expect(res.body.data).toMatchObject({
+        filename: "policy.csv",
+        mimetype: "text/csv",
+        uploaded_by: userId,
+        review_status: "draft",
+      });
+      expect(res.body.data.id).toEqual(expect.any(Number));
+      expect(Number(res.body.data.size)).toBe(Buffer.byteLength(CSV_BODY));
+    });
+
+    it("persists the row as an org-level file scoped to the caller's organization", async () => {
+      const app = adminApp();
+      const fileId = await uploadFile(app);
+
+      const [row] = (await sequelize.query(
+        `SELECT organization_id, project_id, uploaded_by, filename, source, content
+           FROM files WHERE id = :fileId`,
+        { replacements: { fileId }, type: "SELECT" as any },
+      )) as any[];
+
+      expect(Number(row.organization_id)).toBe(orgId);
+      // project_id IS NULL is what makes this an org-level file rather than a
+      // project file — both live in the same `files` table.
+      expect(row.project_id).toBeNull();
+      expect(Number(row.uploaded_by)).toBe(userId);
+      expect(row.source).toBe("File Manager");
+      expect(Buffer.from(row.content).toString()).toBe(CSV_BODY);
+    });
+  });
+
+  describe("GET /api/file-manager", () => {
+    it("returns the documented { data: { files, pagination } } envelope", async () => {
+      const app = adminApp();
+      await uploadFile(app);
+
+      const res = await testRequest(app).get("/api/file-manager");
+
+      expect(res.status).toBe(200);
+      // The frontend reads response.data.data.files (see Clients'
+      // getUserFilesMetaData), so this envelope is a real contract — and it is
+      // exactly what a repository-mocked unit test cannot protect.
+      expect(res.body).toHaveProperty("data.files");
+      expect(res.body).toHaveProperty("data.pagination");
+      expect(Array.isArray(res.body.data.files)).toBe(true);
+
+      const [file] = res.body.data.files;
+      expect(file).toMatchObject({
+        filename: "policy.csv",
+        mimetype: "text/csv",
+        uploaded_by: userId,
+      });
+      // uploader_name/surname come from the JOIN on users, not the files row.
+      expect(file.uploader_name).toEqual(expect.any(String));
+      expect(file.formattedSize).toEqual(expect.any(String));
+    });
+
+    it("paginates and reports the true total across pages", async () => {
+      const app = adminApp();
+      await uploadFile(app, "first.csv");
+      await uploadFile(app, "second.csv");
+      await uploadFile(app, "third.csv");
+
+      const res = await testRequest(app).get("/api/file-manager?page=1&pageSize=2");
+
+      expect(res.status).toBe(200);
+      expect(res.body.data.files).toHaveLength(2);
+      expect(res.body.data.pagination).toMatchObject({
+        total: 3,
+        page: 1,
+        pageSize: 2,
+        totalPages: 2,
+      });
+    });
+
+    it("returns an empty list rather than erroring when the org has no files", async () => {
+      const res = await testRequest(adminApp()).get("/api/file-manager");
+
+      expect(res.status).toBe(200);
+      expect(res.body.data.files).toEqual([]);
+      expect(res.body.data.pagination.total).toBe(0);
+    });
+  });
+
+  describe("GET /api/file-manager/:id", () => {
+    it("round-trips the stored bytes with download headers", async () => {
+      const app = adminApp();
+      const fileId = await uploadFile(app);
+
+      // supertest parses the body by content type, which turns the download into
+      // an object; collect the raw bytes instead so the comparison is real.
+      const res = await testRequest(app)
+        .get(`/api/file-manager/${fileId}`)
+        .buffer(true)
+        .parse((response, callback) => {
+          const chunks: Buffer[] = [];
+          response.on("data", (chunk) => chunks.push(Buffer.from(chunk)));
+          response.on("end", () => callback(null, Buffer.concat(chunks)));
+        });
+
+      expect(res.status).toBe(200);
+      expect(res.headers["content-disposition"]).toContain("policy.csv");
+      // Proves the BYTEA round-trip, not just that a 200 came back.
+      expect(Buffer.isBuffer(res.body)).toBe(true);
+      expect(res.body.toString()).toBe(CSV_BODY);
+    });
+  });
+
+  describe("GET /api/file-manager/:id/metadata", () => {
+    it("returns the metadata columns for the file", async () => {
+      const app = adminApp();
+      const fileId = await uploadFile(app);
+
+      const res = await testRequest(app).get(`/api/file-manager/${fileId}/metadata`);
+
+      expect(res.status).toBe(200);
+      expect(res.body.data).toMatchObject({
+        id: fileId,
+        filename: "policy.csv",
+        review_status: "draft",
+      });
+      expect(res.body.data.tags).toEqual([]);
+    });
+  });
+
+  describe("PATCH /api/file-manager/:id/metadata", () => {
+    it("persists tags, review status, version and description", async () => {
+      const app = adminApp();
+      const fileId = await uploadFile(app);
+
+      const updates = {
+        tags: ["security", "gdpr"],
+        review_status: "approved",
+        version: "2.0",
+        description: "Reviewed retention policy",
+      };
+
+      const patchRes = await testRequest(app)
+        .patch(`/api/file-manager/${fileId}/metadata`)
+        .send(updates);
+
+      expect(patchRes.status).toBe(200);
+
+      // Read back through the API rather than trusting the PATCH response alone.
+      const getRes = await testRequest(app).get(`/api/file-manager/${fileId}/metadata`);
+
+      expect(getRes.status).toBe(200);
+      expect(getRes.body.data).toMatchObject({
+        review_status: "approved",
+        version: "2.0",
+        description: "Reviewed retention policy",
+      });
+      expect(getRes.body.data.tags).toEqual(["security", "gdpr"]);
+    });
+  });
+
+  describe("DELETE /api/file-manager/:id", () => {
+    it("removes the row from the database", async () => {
+      const app = adminApp();
+      const fileId = await uploadFile(app);
+
+      const res = await testRequest(app).delete(`/api/file-manager/${fileId}`);
+      expect(res.status).toBe(200);
+
+      const rows = (await sequelize.query(`SELECT id FROM files WHERE id = :fileId`, {
+        replacements: { fileId },
+        type: "SELECT" as any,
+      })) as any[];
+
+      expect(rows).toHaveLength(0);
+    });
+  });
+
+  describe("GET /api/file-manager/with-metadata", () => {
+    it("flags a file expiring inside the threshold and leaves a distant one unflagged", async () => {
+      const app = adminApp();
+      const expiringId = await uploadFile(app, "expiring.csv");
+      const distantId = await uploadFile(app, "distant.csv");
+
+      // Default daysUntilExpiry threshold is 30, so 10 days out is due and 200 is not.
+      await sequelize.query(
+        `UPDATE files SET expiry_date = CURRENT_DATE + INTERVAL '10 days' WHERE id = :id`,
+        { replacements: { id: expiringId } },
+      );
+      await sequelize.query(
+        `UPDATE files SET expiry_date = CURRENT_DATE + INTERVAL '200 days' WHERE id = :id`,
+        { replacements: { id: distantId } },
+      );
+
+      const res = await testRequest(app).get("/api/file-manager/with-metadata");
+
+      expect(res.status).toBe(200);
+      const byId = Object.fromEntries(
+        res.body.data.files.map((f: any) => [Number(f.id), f]),
+      ) as Record<number, any>;
+
+      // Asserting both directions keeps the flag discriminating rather than
+      // incidentally true for every row.
+      expect(byId[expiringId].is_due_for_update).toBe(true);
+      expect(byId[distantId].is_due_for_update).toBe(false);
+    });
+  });
+});


### PR DESCRIPTION
## Describe your changes

 Build integration tests for POST /api/files/upload, GET /api/files, PATCH /api/files/:id/tags, and DELETE /api/files/:id using the existing integration setup and database transactions for isolation. Mock object storage (S3/local) so the tests do not require real cloud credentials.

## Write your issue number after "Fixes "

Fixes #4497 

## Please ensure all items are checked off before requesting a review:

- [x] I deployed the code locally.
- [x] I have performed a self-review of my code.
- [x] I have included the issue # in the PR.
- [x] I have labelled the PR correctly.
- [x] The issue I am working on is assigned to me.
- [x] I have avoided using hardcoded values to ensure scalability and maintain consistency across the application.
- [x] I have ensured that font sizes, color choices, and other UI elements are referenced from the theme.
- [x] My pull request is focused and addresses a single, specific feature.
- [x] If there are UI changes, I have attached a screenshot or video to this PR.
- [x] If I added or modified an API endpoint, the change is reflected in the generated OpenAPI spec (`npm run generate:swagger`).
- [x] If the endpoint requires authentication, it uses `authenticateJWT` and the generated spec declares `bearerAuth` security.
- [x] I ran `npm run check:api-drift` and committed the regenerated `swagger.yaml` and `endpoints.ts`.
- [x] If this PR adds or modifies an organization-scoped table, the [tenant isolation registry](Servers/tests/integration/tenant-isolation/tenantIsolation.registry.ts) and [test matrix](Servers/tests/integration/tenant-isolation) are updated. See the [tenant isolation runbook](docs/technical/security/tenant-isolation.md) for details.
