### PR TITLE
fix SSO config endpoints crashing with config.toJSON is not a function

### DIFF
--- a/Servers/controllers/__tests__/ssoConfig.ctrl.test.ts
+++ b/Servers/controllers/__tests__/ssoConfig.ctrl.test.ts
@@ -1,0 +1,124 @@
+import { describe, it, expect, jest, beforeEach, afterEach } from "@jest/globals";
+import { Request, Response } from "express";
+
+jest.mock("../../utils/ssoConfig.utils", () => ({
+  isSSOFeatureEnabled: jest.fn(),
+  getSSOConfigQuery: jest.fn(),
+  getFirstEnabledSSOConfigQuery: jest.fn(),
+  getSSOCapableOrganizationsQuery: jest.fn(),
+  saveSSOConfigQuery: jest.fn(),
+  setSSOEnabledQuery: jest.fn(),
+}));
+jest.mock("../../utils/logger/fileLogger", () => ({
+  __esModule: true,
+  default: { error: jest.fn() },
+  logStructured: jest.fn(),
+}));
+jest.mock("../../utils/statusCode.utils", () => ({
+  STATUS_CODE: {
+    200: (data: any) => ({ message: "OK", data }),
+    201: (data: any) => ({ message: "Created", data }),
+    400: (data: any) => ({ message: "Bad Request", data }),
+    404: (data: any) => ({ message: "Not Found", data }),
+    500: (data: any) => ({ message: "Internal Server Error", data }),
+  },
+}));
+
+import { getSSOConfig, saveSSOConfig } from "../ssoConfig.ctrl";
+import { getSSOConfigQuery, saveSSOConfigQuery } from "../../utils/ssoConfig.utils";
+
+const mockGetConfig = getSSOConfigQuery as jest.MockedFunction<typeof getSSOConfigQuery>;
+const mockSaveConfig = saveSSOConfigQuery as jest.MockedFunction<typeof saveSSOConfigQuery>;
+
+function createReq(overrides?: Partial<Request>): Request {
+  return {
+    organizationId: 1,
+    query: { provider: "AzureAD" },
+    body: {},
+    ...overrides,
+  } as any;
+}
+
+function createRes(): any {
+  const res: any = {};
+  res.status = jest.fn<any>().mockReturnValue(res);
+  res.json = jest.fn<any>().mockReturnValue(res);
+  return res;
+}
+
+// getSSOConfigQuery/saveSSOConfigQuery run raw sequelize.query() under the
+// hood, so at runtime they resolve to plain objects, not Sequelize model
+// instances with a .toJSON() method. These POJOs are what the mocks below
+// simulate (regression test for #4219).
+const rawRow = {
+  id: 1,
+  organization_id: 1,
+  provider: "AzureAD",
+  is_enabled: false,
+  config_data: {
+    client_id: "client-1",
+    client_secret: "top-secret",
+    tenant_id: "tenant-1",
+  },
+};
+
+describe("ssoConfig.ctrl", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  describe("getSSOConfig", () => {
+    it("does not crash on a plain-object row and masks the secret", async () => {
+      mockGetConfig.mockResolvedValue(rawRow as any);
+
+      const req = createReq();
+      const res = createRes();
+
+      await getSSOConfig(req, res as Response);
+
+      expect(res.status).toHaveBeenCalledWith(200);
+      expect(res.json).toHaveBeenCalledWith({
+        message: "OK",
+        data: {
+          ...rawRow,
+          config_data: { ...rawRow.config_data, client_secret: "********" },
+        },
+      });
+    });
+
+    it("returns 404 when no config exists", async () => {
+      mockGetConfig.mockResolvedValue(undefined);
+
+      const req = createReq();
+      const res = createRes();
+
+      await getSSOConfig(req, res as Response);
+
+      expect(res.status).toHaveBeenCalledWith(404);
+    });
+  });
+
+  describe("saveSSOConfig", () => {
+    it("does not crash on a plain-object row and masks the secret", async () => {
+      mockSaveConfig.mockResolvedValue(rawRow as any);
+
+      const req = createReq({ body: rawRow.config_data });
+      const res = createRes();
+
+      await saveSSOConfig(req, res as Response);
+
+      expect(res.status).toHaveBeenCalledWith(201);
+      expect(res.json).toHaveBeenCalledWith({
+        message: "Created",
+        data: {
+          ...rawRow,
+          config_data: { ...rawRow.config_data, client_secret: "********" },
+        },
+      });
+    });
+  });
+});

--- a/Servers/controllers/ssoConfig.ctrl.ts
+++ b/Servers/controllers/ssoConfig.ctrl.ts
@@ -38,7 +38,7 @@ export const getSSOConfig = async (req: Request, res: Response) => {
     }
     return res.status(200).json(
       STATUS_CODE[200]({
-        ...config.toJSON(),
+        ...config,
         config_data: maskConfig(config.config_data),
       }),
     );
@@ -65,7 +65,7 @@ export const saveSSOConfig = async (req: Request, res: Response) => {
     const saved = await saveSSOConfigQuery(organizationId, provider, body);
     return res.status(201).json(
       STATUS_CODE[201]({
-        ...saved.toJSON(),
+        ...saved,
         config_data: maskConfig(saved.config_data),
       }),
     );


### PR DESCRIPTION
## Describe your changes

`getSSOConfigQuery`/`saveSSOConfigQuery` in `Servers/utils/ssoConfig.utils.ts` run raw `sequelize.query()` calls, which return plain objects at runtime, not `SSOConfigurationModel` instances (the `as [SSOConfigurationModel[], number]` cast is misleading — it only satisfies the compiler). `Servers/controllers/ssoConfig.ctrl.ts` then called `.toJSON()` on those plain objects, which doesn't exist there, so `GET`/`PUT /api/ssoConfig` both 500'd with `config.toJSON is not a function` / `saved.toJSON is not a function`. Since the `INSERT` in the save path succeeds before the controller throws, a partial row gets persisted and every subsequent `GET` 500s too — so the SSO settings tab is unusable end to end.

Fix: spread the result directly instead of calling `.toJSON()` on it, since it's already the right shape.

Added a regression test (`Servers/controllers/__tests__/ssoConfig.ctrl.test.ts`) with a plain-object mock that reproduces the crash on the old code and passes on the fix. I also ran this against a real local Postgres (fresh `sequelize db:migrate`, calling `saveSSOConfig`/`getSSOConfig` directly) to confirm the actual save → read round trip works and the secret gets masked correctly.

## Write your issue number after "Fixes "

Fixes #4219

## Please ensure all items are checked off before requesting a review:

- [x] I deployed the code locally.
- [x] I have performed a self-review of my code.
- [x] I have included the issue # in the PR.
- [ ] I have labelled the PR correctly. (no label permissions as an external contributor)
- [ ] The issue I am working on is assigned to me. (commented on the issue to claim it, not yet assigned)
- [x] I have avoided using hardcoded values to ensure scalability and maintain consistency across the application.
- [x] N/A — no UI/theme changes, backend only.
- [x] My pull request is focused and addresses a single, specific feature.
- [x] N/A — no UI changes.
- [x] N/A — no API shape/route change, existing endpoint behavior restored.
- [x] N/A — no new endpoint.
- [x] N/A — no route changes.
- [x] N/A — no new/modified organization-scoped table.
