### PR TITLE
Fix deploy to test failing evalserver requirements

### DIFF
--- a/EvalServer/Dockerfile
+++ b/EvalServer/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.14-slim
+FROM python:3.12-slim
 
 # Pull the latest Debian security patches so Trivy release scans don't fail on
 # fixable base-image CVEs (e.g. util-linux CVE-2026-53612..53615, fixed in

--- a/EvalServer/Dockerfile.dev
+++ b/EvalServer/Dockerfile.dev
@@ -1,4 +1,4 @@
-FROM python:3.14-slim
+FROM python:3.12-slim
 
 # Set the working directory inside the container
 WORKDIR /app


### PR DESCRIPTION
## Describe your changes

- Fix deploy to test failing evalserver requirements
<img width="1470" height="804" alt="image" src="https://github.com/user-attachments/assets/0384c144-9f1c-4eed-9e86-1a80154e9a2c" />

## Write your issue number after "Fixes "

Enter the corresponding issue number after "Fixes #"

## Please ensure all items are checked off before requesting a review:

- [ ] I deployed the code locally.
- [ ] I have performed a self-review of my code.
- [ ] I have included the issue # in the PR.
- [ ] I have labelled the PR correctly.
- [ ] The issue I am working on is assigned to me.
- [ ] I have avoided using hardcoded values to ensure scalability and maintain consistency across the application.
- [ ] I have ensured that font sizes, color choices, and other UI elements are referenced from the theme.
- [ ] My pull request is focused and addresses a single, specific feature.
- [ ] If there are UI changes, I have attached a screenshot or video to this PR.
- [ ] If I added or modified an API endpoint, the change is reflected in the generated OpenAPI spec (`npm run generate:swagger`).
- [ ] If the endpoint requires authentication, it uses `authenticateJWT` and the generated spec declares `bearerAuth` security.
- [ ] I ran `npm run check:api-drift` and committed the regenerated `swagger.yaml` and `endpoints.ts`.
- [ ] If this PR adds or modifies an organization-scoped table, the [tenant isolation registry](Servers/tests/integration/tenant-isolation/tenantIsolation.registry.ts) and [test matrix](Servers/tests/integration/tenant-isolation) are updated. See the [tenant isolation runbook](docs/technical/security/tenant-isolation.md) for details.
