### PR TITLE
feat(dates): add useFormattedDate hook that reads user preference

### DIFF
--- a/Clients/src/application/hooks/__tests__/useFormattedDate.test.ts
+++ b/Clients/src/application/hooks/__tests__/useFormattedDate.test.ts
@@ -1,0 +1,68 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { renderHook } from "@testing-library/react";
+import { UserDateFormat } from "../../../domain/enums/userDateFormat.enum";
+
+const prefs = { current: { date_format: UserDateFormat.DD_MM_YYYY_DASH } };
+
+vi.mock("../useUserPreferences", () => ({
+  default: () => ({ userPreferences: prefs.current }),
+}));
+
+import useFormattedDate from "../useFormattedDate";
+
+describe("useFormattedDate", () => {
+  beforeEach(() => {
+    prefs.current = { date_format: UserDateFormat.DD_MM_YYYY_DASH };
+  });
+
+  it("formats with DD-MM-YYYY by default", () => {
+    const { result } = renderHook(() => useFormattedDate());
+    expect(result.current("2024-11-01")).toBe("01-11-2024");
+  });
+
+  it.each([
+    [UserDateFormat.DD_MM_YYYY_DASH, "01-11-2024"],
+    [UserDateFormat.MM_DD_YYYY_DASH, "11-01-2024"],
+    [UserDateFormat.DD_MM_YY_SLASH, "01/11/24"],
+    [UserDateFormat.MM_DD_YY_SLASH, "11/01/24"],
+  ])("formats 2024-11-01 as %s", (dateFormat, expected) => {
+    prefs.current = { date_format: dateFormat };
+    const { result } = renderHook(() => useFormattedDate());
+    expect(result.current("2024-11-01")).toBe(expected);
+  });
+
+  it("appends HH:mm when includeTime is true", () => {
+    const { result } = renderHook(() => useFormattedDate());
+    expect(result.current("2024-11-01T14:30:25", { includeTime: true })).toBe("01-11-2024, 14:30");
+  });
+
+  it("includes seconds when requested", () => {
+    const { result } = renderHook(() => useFormattedDate());
+    expect(result.current("2024-11-01T14:30:25", { includeTime: true, includeSeconds: true })).toBe(
+      "01-11-2024, 14:30:25",
+    );
+  });
+
+  it("does not throw for an invalid date", () => {
+    const { result } = renderHook(() => useFormattedDate());
+    expect(() => result.current("not-a-date")).not.toThrow();
+    expect(result.current("not-a-date")).toBe("not-a-date");
+  });
+
+  it("returns an em dash for empty values", () => {
+    const { result } = renderHook(() => useFormattedDate());
+    expect(result.current(null)).toBe("—");
+    expect(result.current(undefined)).toBe("—");
+    expect(result.current("")).toBe("—");
+  });
+
+  it("updates output when the preference changes", () => {
+    const { result, rerender } = renderHook(() => useFormattedDate());
+    expect(result.current("2024-11-01")).toBe("01-11-2024");
+
+    prefs.current = { date_format: UserDateFormat.MM_DD_YYYY_DASH };
+    rerender();
+
+    expect(result.current("2024-11-01")).toBe("11-01-2024");
+  });
+});

--- a/Clients/src/application/hooks/useFormattedDate.ts
+++ b/Clients/src/application/hooks/useFormattedDate.ts
@@ -1,0 +1,46 @@
+import { useCallback } from "react";
+import { UserDateFormat } from "../../domain/enums/userDateFormat.enum";
+import {
+  displayFormattedDate,
+  displayFormattedDateTime,
+} from "../../presentation/tools/isoDateToString";
+import useUserPreferences from "./useUserPreferences";
+
+export interface FormatDateOptions {
+  includeTime?: boolean;
+  includeSeconds?: boolean;
+  separator?: string;
+}
+
+/**
+ * Preference-aware date formatter. Call once in the component body, then use
+ * the returned function in maps/tables (hooks cannot be called per row).
+ *
+ * Reads `date_format` from the authenticated user's preferences query, not
+ * from JWT or localStorage, so the UI re-renders when the preference changes.
+ */
+const useFormattedDate = () => {
+  const { userPreferences } = useUserPreferences();
+  const dateFormat = userPreferences.date_format ?? UserDateFormat.DD_MM_YYYY_DASH;
+
+  return useCallback(
+    (date: string | Date | null | undefined, options: FormatDateOptions = {}): string => {
+      if (date === null || date === undefined || date === "") {
+        return "—";
+      }
+
+      if (options.includeTime) {
+        return displayFormattedDateTime(date, {
+          includeSeconds: options.includeSeconds,
+          separator: options.separator,
+          dateFormat,
+        });
+      }
+
+      return displayFormattedDate(date, dateFormat);
+    },
+    [dateFormat],
+  );
+};
+
+export default useFormattedDate;

--- a/Clients/src/presentation/tools/__tests__/isoDateToString.test.ts
+++ b/Clients/src/presentation/tools/__tests__/isoDateToString.test.ts
@@ -6,6 +6,7 @@ import {
   formatDate,
   formatDateTime,
 } from "../isoDateToString";
+import { UserDateFormat } from "../../../domain/enums/userDateFormat.enum";
 
 describe("formatDate", () => {
   beforeEach(() => {
@@ -75,6 +76,11 @@ describe("displayFormattedDate", () => {
     const result = displayFormattedDate("2024-11-01");
     expect(result).toBe("01-11-2024");
   });
+
+  it("uses an explicit dateFormat argument over localStorage", () => {
+    localStorage.setItem("verifywise_preferences", JSON.stringify({ date_format: "MM-DD-YYYY" }));
+    expect(displayFormattedDate("2024-11-01", UserDateFormat.DD_MM_YY_SLASH)).toBe("01/11/24");
+  });
 });
 
 describe("displayFormattedTime", () => {
@@ -107,6 +113,15 @@ describe("displayFormattedDateTime", () => {
     expect(displayFormattedDateTime("2024-11-01T14:30:25", { separator: " at " })).toBe(
       "01-11-2024 at 14:30",
     );
+  });
+
+  it("uses an explicit dateFormat option over localStorage", () => {
+    localStorage.setItem("verifywise_preferences", JSON.stringify({ date_format: "DD-MM-YYYY" }));
+    expect(
+      displayFormattedDateTime("2024-11-01T14:30:25", {
+        dateFormat: UserDateFormat.MM_DD_YY_SLASH,
+      }),
+    ).toBe("11/01/24, 14:30");
   });
 });
 

--- a/Clients/src/presentation/tools/isoDateToString.ts
+++ b/Clients/src/presentation/tools/isoDateToString.ts
@@ -18,6 +18,13 @@ const getPreferredDateFormat = (): string => {
     : DATE_FORMAT_MAP[UserDateFormat.DD_MM_YYYY_DASH];
 };
 
+const resolveDateFnsPattern = (dateFormat?: UserDateFormat): string => {
+  if (dateFormat && DATE_FORMAT_MAP[dateFormat]) {
+    return DATE_FORMAT_MAP[dateFormat];
+  }
+  return getPreferredDateFormat();
+};
+
 const parseDateValue = (value: string | Date): Date | null => {
   if (value instanceof Date) {
     return isValid(value) ? value : null;
@@ -37,7 +44,10 @@ const parseDateValue = (value: string | Date): Date | null => {
  * @param {string} isoDate - The ISO date string to be converted.
  * @returns {string} The formatted date string in the format (default: DD-MM-YYYY).
  */
-export const displayFormattedDate = (isoDate: string | Date): string => {
+export const displayFormattedDate = (
+  isoDate: string | Date,
+  dateFormat?: UserDateFormat,
+): string => {
   const date = parseDateValue(isoDate);
 
   if (!date) {
@@ -45,7 +55,7 @@ export const displayFormattedDate = (isoDate: string | Date): string => {
     return String(isoDate);
   }
 
-  return format(date, getPreferredDateFormat());
+  return format(date, resolveDateFnsPattern(dateFormat));
 };
 
 /**
@@ -83,7 +93,11 @@ export function displayFormattedTime(
  */
 export function displayFormattedDateTime(
   isoDate: string | Date,
-  options: { includeSeconds?: boolean; separator?: string } = {},
+  options: {
+    includeSeconds?: boolean;
+    separator?: string;
+    dateFormat?: UserDateFormat;
+  } = {},
 ): string {
   const date = parseDateValue(isoDate);
 
@@ -93,7 +107,7 @@ export function displayFormattedDateTime(
   }
 
   const separator = options.separator ?? ", ";
-  return `${format(date, getPreferredDateFormat())}${separator}${format(
+  return `${format(date, resolveDateFnsPattern(options.dateFormat))}${separator}${format(
     date,
     options.includeSeconds ? "HH:mm:ss" : "HH:mm",
   )}`;


### PR DESCRIPTION
## Describe your changes

Format dates from authenticated user preferences so the UI updates immediately when date_format changes, instead of only reading localStorage.

## Write your issue number after "Fixes "

Fixes #4620 

## Please ensure all items are checked off before requesting a review:

- [x] I deployed the code locally.
- [x] I have performed a self-review of my code.
- [x] I have included the issue # in the PR.
- [x] I have labelled the PR correctly.
- [x] The issue I am working on is assigned to me.
- [x] I have avoided using hardcoded values to ensure scalability and maintain consistency across the application.
- [x] I have ensured that font sizes, color choices, and other UI elements are referenced from the theme.
- [ ] My pull request is focused and addresses a single, specific feature.
- [ ] If there are UI changes, I have attached a screenshot or video to this PR.
- [ ] If I added or modified an API endpoint, the change is reflected in the generated OpenAPI spec (`npm run generate:swagger`).
- [ ] If the endpoint requires authentication, it uses `authenticateJWT` and the generated spec declares `bearerAuth` security.
- [ ] I ran `npm run check:api-drift` and committed the regenerated `swagger.yaml` and `endpoints.ts`.
- [ ] If this PR adds or modifies an organization-scoped table, the [tenant isolation registry](Servers/tests/integration/tenant-isolation/tenantIsolation.registry.ts) and [test matrix](Servers/tests/integration/tenant-isolation) are updated. See the [tenant isolation runbook](docs/technical/security/tenant-isolation.md) for details.
