### PR TITLE
Feat: Evidence Hub Retention

### DIFF
--- a/Clients/src/application/repository/evidenceHub.repository.ts
+++ b/Clients/src/application/repository/evidenceHub.repository.ts
@@ -38,4 +38,3 @@ export async function updateEvidenceHubSettings(
   const response = await apiServices.put("/evidenceHub/settings", update);
   return (response.data as { data: EvidenceHubOrgSettings }).data;
 }
-

--- a/Clients/src/application/repository/evidenceHub.repository.ts
+++ b/Clients/src/application/repository/evidenceHub.repository.ts
@@ -13,3 +13,29 @@ export async function createEvidenceHub(routeUrl: string, data: any): Promise<an
   const response = await apiServices.post(routeUrl, data);
   return response.data;
 }
+
+// ---- Org-wide Evidence Hub settings (retention policy) ----
+
+export interface EvidenceHubOrgSettings {
+  organization_id: number;
+  default_retention_period: string | null;
+  archive_on_expiry: boolean;
+}
+
+export interface EvidenceHubOrgSettingsUpdate {
+  default_retention_period?: string | null;
+  archive_on_expiry?: boolean;
+}
+
+export async function getEvidenceHubSettings(): Promise<EvidenceHubOrgSettings> {
+  const response = await apiServices.get("/evidenceHub/settings");
+  return (response.data as { data: EvidenceHubOrgSettings }).data;
+}
+
+export async function updateEvidenceHubSettings(
+  update: EvidenceHubOrgSettingsUpdate,
+): Promise<EvidenceHubOrgSettings> {
+  const response = await apiServices.put("/evidenceHub/settings", update);
+  return (response.data as { data: EvidenceHubOrgSettings }).data;
+}
+

--- a/Clients/src/domain/models/Common/evidenceHub/evidenceHub.model.ts
+++ b/Clients/src/domain/models/Common/evidenceHub/evidenceHub.model.ts
@@ -14,6 +14,8 @@ export class EvidenceHubModel {
   description?: string | null;
   evidence_files: FileResponse[] = [];
   expiry_date?: Date | null;
+  expired_at?: string | null;
+  archived_at?: string | null;
   mapped_model_ids?: number[] | null;
   mapped_training_ids?: number[] | null;
   tags?: string[];
@@ -30,6 +32,8 @@ export class EvidenceHubModel {
     this.description = data.description ?? null;
     this.evidence_files = data.evidence_files ?? [];
     this.expiry_date = data.expiry_date ? new Date(data.expiry_date) : null;
+    this.expired_at = data.expired_at ?? null;
+    this.archived_at = data.archived_at ?? null;
     this.mapped_model_ids = data.mapped_model_ids ?? null;
     this.mapped_training_ids = data.mapped_training_ids ?? null;
     this.tags = data.tags ?? [];

--- a/Clients/src/i18n/translations.ts
+++ b/Clients/src/i18n/translations.ts
@@ -6325,6 +6325,7 @@ export const translations: Record<string, Record<string, string>> = {
     "Experimental research only, not deployed to users":
       "Nur experimentelle Forschung, nicht für Nutzer bereitgestellt",
     "Expired": "Abgelaufen",
+    "Expiring soon": "Läuft bald ab",
     "Expires": "Läuft ab",
     "Explain AI models to ensure responsible use and maintain an AI systems repository.":
       "Erklären Sie KI-Modelle, um eine verantwortungsvolle Nutzung sicherzustellen, und pflegen Sie ein Repository für KI-Systeme.",
@@ -15522,6 +15523,7 @@ export const translations: Record<string, Record<string, string>> = {
     "Experimental research only, not deployed to users":
       "Recherche expérimentale uniquement, non déployé aux utilisateurs",
     "Expired": "Expiré",
+    "Expiring soon": "Expire bientôt",
     "Expires": "Expire",
     "Explain AI models to ensure responsible use and maintain an AI systems repository.":
       "Expliquez les modèles IA pour assurer une utilisation responsable et maintenez un référentiel des systèmes IA.",
@@ -22300,6 +22302,7 @@ export const translations: Record<string, Record<string, string>> = {
     "Experiment name": "Nombre del experimento",
     "Experiment results downloaded": "Resultados del experimento descargados",
     "Expired": "Caducado",
+    "Expiring soon": "Caduca pronto",
     "Expires": "Caduca",
     "Explainability": "Explicabilidad",
     "Exposed API keys and credentials": "Claves de API y credenciales expuestas",

--- a/Clients/src/i18n/translations.ts
+++ b/Clients/src/i18n/translations.ts
@@ -115,6 +115,8 @@ export const translations: Record<string, Record<string, string>> = {
     "Alert settings saved": "Benachrichtigungseinstellungen gespeichert",
     "Failed to save alert settings":
       "Benachrichtigungseinstellungen konnten nicht gespeichert werden",
+    "Failed to save evidence retention settings":
+      "Aufbewahrungseinstellungen für Nachweise konnten nicht gespeichert werden",
     "Notifications are delivered in-app, and by email when email alerts are enabled. A threshold set to notify and flag for revalidation also marks the model as due for a fresh validation.":
       "Benachrichtigungen werden in der App zugestellt und per E-Mail, wenn E-Mail-Benachrichtigungen aktiviert sind. Ein Schwellenwert mit Benachrichtigung und Revalidierungs-Kennzeichnung markiert das Modell zusätzlich als fällig für eine neue Validierung.",
     "A finding must be verified before it can be closed.":
@@ -541,6 +543,8 @@ export const translations: Record<string, Record<string, string>> = {
     "Evidence": "Nachweise",
     "Evidence hub": "Nachweiszentrale",
     "Evidence Hub": "Nachweiszentrale",
+    "Evidence Hub retention": "Nachweiszentrale-Aufbewahrung",
+    "Evidence retention settings saved": "Aufbewahrungseinstellungen für Nachweise gespeichert",
     "Reporting": "Berichte",
     "AI trust center": "KI-Vertrauenszentrum",
     "GOVERNANCE": "GOVERNANCE",
@@ -786,6 +790,7 @@ export const translations: Record<string, Record<string, string>> = {
     "DATE UPDATED": "AKTUALISIERUNGSDATUM",
     "Due date": "Fälligkeitsdatum",
     "Due today": "Heute fällig",
+    "No default": "Kein Standard",
     "No due date": "Kein Fälligkeitsdatum",
     "Expiry": "Ablauf",
     "EXPIRY": "ABLAUF",
@@ -1447,6 +1452,7 @@ export const translations: Record<string, Record<string, string>> = {
     "Create use case": "Anwendungsfall erstellen",
     "Default TTL (seconds)": "Standard-TTL (Sekunden)",
     "Default branch": "Standard-Branch",
+    "Default retention period": "Standard-Aufbewahrungsfrist",
     "Departments (comma-separated)": "Abteilungen (kommagetrennt)",
     "Describe the products or services this vendor delivers (e.g., cloud hosting, legal advisory, AI APIs).":
       "Beschreiben Sie die Produkte oder Dienstleistungen, die dieser Anbieter liefert (z. B. Cloud-Hosting, Rechtsberatung, KI-APIs).",
@@ -1608,6 +1614,11 @@ export const translations: Record<string, Record<string, string>> = {
     "Approve": "Genehmigen",
     "Archive": "Archivieren",
     "Archive form": "Formular archivieren",
+    "Applied to new evidence that has no explicit expiry date or retention policy of its own. A daily job flags records past their expiry date and notifies the reviewer or organization admins.":
+      "Wird auf neue Nachweise angewendet, die weder ein explizites Ablaufdatum noch eine eigene Aufbewahrungsfrist haben. Ein täglicher Job markiert Datensätze nach Ablauf und benachrichtigt den Prüfer oder die Administratoren der Organisation.",
+    "Archive expired evidence": "Abgelaufene Nachweise archivieren",
+    "Archived evidence is hidden from the Evidence Hub list but never deleted. Archival also requires the server flag EVIDENCE_RETENTION_ARCHIVE_ENABLED.":
+      "Archivierte Nachweise werden in der Nachweiszentrale-Liste ausgeblendet, aber nie gelöscht. Die Archivierung erfordert zusätzlich das Server-Flag EVIDENCE_RETENTION_ARCHIVE_ENABLED.",
     "Back to history": "Zurück zum Verlauf",
     "Back to prompts": "Zurück zu Prompts",
     "Click to upload": "Zum Hochladen klicken",
@@ -1830,6 +1841,7 @@ export const translations: Record<string, Record<string, string>> = {
     "Run first experiment": "Erstes Experiment ausführen",
     "Run your first experiment": "Ihr erstes Experiment ausführen",
     "Save changes": "Änderungen speichern",
+    "Save retention settings": "Aufbewahrungseinstellungen speichern",
     "Save Changes": "Änderungen speichern",
     "Save configuration": "Konfiguration speichern",
     "Save dataset": "Datensatz speichern",
@@ -9364,6 +9376,8 @@ export const translations: Record<string, Record<string, string>> = {
     "Save alert settings": "Enregistrer les paramètres d'alerte",
     "Alert settings saved": "Paramètres d'alerte enregistrés",
     "Failed to save alert settings": "Échec de l'enregistrement des paramètres d'alerte",
+    "Failed to save evidence retention settings":
+      "Échec de l'enregistrement des paramètres de conservation des preuves",
     "Notifications are delivered in-app, and by email when email alerts are enabled. A threshold set to notify and flag for revalidation also marks the model as due for a fresh validation.":
       "Les notifications sont envoyées dans l'application, et par e-mail lorsque les alertes par e-mail sont activées. Un seuil configuré pour notifier et signaler une revalidation marque également le modèle comme devant faire l'objet d'une nouvelle validation.",
     "A finding must be verified before it can be closed.":
@@ -9791,6 +9805,8 @@ export const translations: Record<string, Record<string, string>> = {
     "Evidence": "Preuves",
     "Evidence hub": "Centre de preuves",
     "Evidence Hub": "Centre de preuves",
+    "Evidence Hub retention": "Conservation du Centre de preuves",
+    "Evidence retention settings saved": "Paramètres de conservation des preuves enregistrés",
     "Reporting": "Rapports",
     "AI trust center": "Centre de confiance IA",
     "GOVERNANCE": "GOUVERNANCE",
@@ -10015,6 +10031,7 @@ export const translations: Record<string, Record<string, string>> = {
     "Date": "Date",
     "Due date": "Date d'échéance",
     "Due today": "Dû aujourd'hui",
+    "No default": "Aucune valeur par défaut",
     "No due date": "Aucune échéance",
     "Expiry": "Expiration",
     "Expiry date": "Date d'expiration",
@@ -10844,6 +10861,7 @@ export const translations: Record<string, Record<string, string>> = {
     "Create use case": "Créer un cas d'usage",
     "Default TTL (seconds)": "TTL par défaut (secondes)",
     "Default branch": "Branche par défaut",
+    "Default retention period": "Période de conservation par défaut",
     "Departments (comma-separated)": "Départements (séparés par des virgules)",
     "Describe the products or services this vendor delivers (e.g., cloud hosting, legal advisory, AI APIs).":
       "Décrivez les produits ou services fournis par ce fournisseur (ex. hébergement cloud, conseil juridique, API IA).",
@@ -10999,6 +11017,11 @@ export const translations: Record<string, Record<string, string>> = {
     "Add to risk register": "Ajouter au registre des risques",
     "Add your first prompt": "Ajouter votre premier prompt",
     "Archive form": "Archiver le formulaire",
+    "Applied to new evidence that has no explicit expiry date or retention policy of its own. A daily job flags records past their expiry date and notifies the reviewer or organization admins.":
+      "Appliqué aux nouvelles preuves sans date d'expiration explicite ni politique de conservation propre. Une tâche quotidienne marque les enregistrements expirés et avertit le réviseur ou les administrateurs de l'organisation.",
+    "Archive expired evidence": "Archiver les preuves expirées",
+    "Archived evidence is hidden from the Evidence Hub list but never deleted. Archival also requires the server flag EVIDENCE_RETENTION_ARCHIVE_ENABLED.":
+      "Les preuves archivées sont masquées de la liste du Centre de preuves mais ne sont jamais supprimées. L'archivage nécessite également le flag serveur EVIDENCE_RETENTION_ARCHIVE_ENABLED.",
     "Back to history": "Retour à l'historique",
     "Back to prompts": "Retour aux prompts",
     "Click to upload": "Cliquer pour téléverser",
@@ -11208,6 +11231,7 @@ export const translations: Record<string, Record<string, string>> = {
     "Run first experiment": "Lancer la première expérience",
     "Run your first experiment": "Lancez votre première expérience",
     "Save changes": "Enregistrer les modifications",
+    "Save retention settings": "Enregistrer les paramètres de conservation",
     "Save Changes": "Enregistrer les modifications",
     "Save configuration": "Enregistrer la configuration",
     "Save dataset": "Enregistrer le jeu de données",
@@ -18565,6 +18589,8 @@ export const translations: Record<string, Record<string, string>> = {
     "Save alert settings": "Guardar configuración de alertas",
     "Alert settings saved": "Configuración de alertas guardada",
     "Failed to save alert settings": "No se pudo guardar la configuración de alertas",
+    "Failed to save evidence retention settings":
+      "No se pudo guardar la configuración de retención de evidencias",
     "Notifications are delivered in-app, and by email when email alerts are enabled. A threshold set to notify and flag for revalidation also marks the model as due for a fresh validation.":
       "Las notificaciones se entregan en la aplicación y por correo electrónico cuando las alertas por correo están habilitadas. Un umbral configurado para notificar y marcar para revalidación también marca el modelo como pendiente de una nueva validación.",
     "A finding must be verified before it can be closed.":
@@ -18781,6 +18807,8 @@ export const translations: Record<string, Record<string, string>> = {
     "Evidence": "Evidencia",
     "Evidence hub": "Centro de evidencias",
     "Evidence Hub": "Centro de evidencias",
+    "Evidence Hub retention": "Retención del Centro de evidencias",
+    "Evidence retention settings saved": "Configuración de retención de evidencias guardada",
     "Reporting": "Informes",
     "AI trust center": "Centro de confianza de IA",
     "GOVERNANCE": "GOBERNANZA",
@@ -19009,6 +19037,7 @@ export const translations: Record<string, Record<string, string>> = {
     "DATE UPDATED": "FECHA DE ACTUALIZACIÓN",
     "Due date": "Fecha de vencimiento",
     "Due today": "Vence hoy",
+    "No default": "Sin valor predeterminado",
     "No due date": "Sin fecha de vencimiento",
     "Expiry": "Caducidad",
     "EXPIRY": "CADUCIDAD",
@@ -19499,6 +19528,7 @@ export const translations: Record<string, Record<string, string>> = {
     "Create use case": "Crear caso de uso",
     "Default TTL (seconds)": "TTL predeterminado (segundos)",
     "Default branch": "Rama predeterminada",
+    "Default retention period": "Período de retención predeterminado",
     "Departments (comma-separated)": "Departamentos (separados por comas)",
     "Display text (optional)": "Texto a mostrar (opcional)",
     "Enter folder description (optional)": "Introduzca la descripción de la carpeta (opcional)",
@@ -19598,6 +19628,11 @@ export const translations: Record<string, Record<string, string>> = {
     "Approve": "Aprobar",
     "Archive": "Archivar",
     "Archive form": "Archivar formulario",
+    "Applied to new evidence that has no explicit expiry date or retention policy of its own. A daily job flags records past their expiry date and notifies the reviewer or organization admins.":
+      "Se aplica a las nuevas evidencias sin fecha de caducidad explícita ni política de retención propia. Una tarea diaria marca los registros caducados y notifica al revisor o a los administradores de la organización.",
+    "Archive expired evidence": "Archivar evidencias caducadas",
+    "Archived evidence is hidden from the Evidence Hub list but never deleted. Archival also requires the server flag EVIDENCE_RETENTION_ARCHIVE_ENABLED.":
+      "Las evidencias archivadas se ocultan de la lista del Centro de evidencias pero nunca se eliminan. El archivado también requiere el flag de servidor EVIDENCE_RETENTION_ARCHIVE_ENABLED.",
     "Back to history": "Volver al historial",
     "Back to prompts": "Volver a los prompts",
     "Click to upload": "Haga clic para cargar",
@@ -19814,6 +19849,7 @@ export const translations: Record<string, Record<string, string>> = {
     "Run first experiment": "Ejecutar primer experimento",
     "Run your first experiment": "Ejecuta tu primer experimento",
     "Save changes": "Guardar cambios",
+    "Save retention settings": "Guardar configuración de retención",
     "Save Changes": "Guardar cambios",
     "Save configuration": "Guardar configuración",
     "Save dataset": "Guardar conjunto de datos",

--- a/Clients/src/presentation/pages/ModelInventory/evidenceHubTable.tsx
+++ b/Clients/src/presentation/pages/ModelInventory/evidenceHubTable.tsx
@@ -19,6 +19,7 @@ import {
 import TablePaginationActions from "../../components/TablePagination";
 import CustomizableSkeleton from "../../components/Skeletons";
 import CustomIconButton from "../../components/IconButton";
+import StatusChip from "../../components/Chip";
 import {
   ChevronsUpDown,
   ChevronUp,
@@ -52,6 +53,25 @@ import { EvidenceHubTableProps } from "../../../domain/interfaces/i.modelInvento
 dayjs.extend(utc);
 
 const EVIDENCE_HUB_SORTING_KEY = "verifywise_evidence_hub_sorting";
+
+/** Records expiring within this window are flagged "expiring soon". */
+const EXPIRING_SOON_DAYS = 30;
+
+type ExpiryStatus = "expired" | "expiring_soon" | null;
+
+// Derived client-side from expiry_date; null/invalid dates mean "no expiry".
+const getExpiryStatus = (
+  expiryDate: Date | string | null | undefined,
+): ExpiryStatus => {
+  if (!expiryDate) return null;
+  const expiry = new Date(expiryDate);
+  if (isNaN(expiry.getTime())) return null;
+  const now = new Date();
+  if (expiry.getTime() < now.getTime()) return "expired";
+  const soonThreshold = new Date(now);
+  soonThreshold.setDate(soonThreshold.getDate() + EXPIRING_SOON_DAYS);
+  return expiry.getTime() <= soonThreshold.getTime() ? "expiring_soon" : null;
+};
 
 type SortDirection = "asc" | "desc" | null;
 type SortConfig = {
@@ -567,7 +587,19 @@ const EvidenceHubTable: React.FC<EvidenceHubTableProps> = ({
               )}
               {isColVisible("expiry_date") && (
                 <TableCell sx={singleTheme.tableStyles.primary.body.cell}>
-                  {evidence.expiry_date ? displayFormattedDate(evidence.expiry_date) : "-"}
+                  {evidence.expiry_date ? (
+                    <Stack direction="row" spacing={1} alignItems="center">
+                      <span>{displayFormattedDate(evidence.expiry_date)}</span>
+                      {getExpiryStatus(evidence.expiry_date) === "expired" && (
+                        <StatusChip label="Expired" variant="error" />
+                      )}
+                      {getExpiryStatus(evidence.expiry_date) === "expiring_soon" && (
+                        <StatusChip label="Expiring soon" variant="warning" />
+                      )}
+                    </Stack>
+                  ) : (
+                    "-"
+                  )}
                 </TableCell>
               )}
               <TableCell sx={singleTheme.tableStyles.primary.body.cell}>

--- a/Clients/src/presentation/pages/ModelInventory/evidenceHubTable.tsx
+++ b/Clients/src/presentation/pages/ModelInventory/evidenceHubTable.tsx
@@ -60,9 +60,7 @@ const EXPIRING_SOON_DAYS = 30;
 type ExpiryStatus = "expired" | "expiring_soon" | null;
 
 // Derived client-side from expiry_date; null/invalid dates mean "no expiry".
-const getExpiryStatus = (
-  expiryDate: Date | string | null | undefined,
-): ExpiryStatus => {
+const getExpiryStatus = (expiryDate: Date | string | null | undefined): ExpiryStatus => {
   if (!expiryDate) return null;
   const expiry = new Date(expiryDate);
   if (isNaN(expiry.getTime())) return null;

--- a/Clients/src/presentation/pages/SettingsPage/Organization/EvidenceRetentionSection.tsx
+++ b/Clients/src/presentation/pages/SettingsPage/Organization/EvidenceRetentionSection.tsx
@@ -1,0 +1,122 @@
+import { useEffect, useState } from "react";
+import { Box, Stack, Typography } from "@mui/material";
+import SelectComponent from "../../../components/Inputs/Select";
+import Toggle from "../../../components/Inputs/Toggle";
+import { CustomizableButton } from "../../../components/button/customizable-button";
+import {
+  getEvidenceHubSettings,
+  updateEvidenceHubSettings,
+} from "../../../../application/repository/evidenceHub.repository";
+
+// Mirrors RETENTION_OPTIONS in components/Modals/EvidenceHub/index.tsx and
+// EVIDENCE_RETENTION_PERIODS on the server (utils/evidenceRetention.utils.ts).
+const RETENTION_OPTIONS = [
+  { _id: "30_days", name: "30 days" },
+  { _id: "90_days", name: "90 days" },
+  { _id: "6_months", name: "6 months" },
+  { _id: "1_year", name: "1 year" },
+  { _id: "3_years", name: "3 years" },
+  { _id: "5_years", name: "5 years" },
+  { _id: "7_years", name: "7 years" },
+  { _id: "indefinite", name: "Indefinite" },
+];
+
+interface EvidenceRetentionSectionProps {
+  isDisabled?: boolean;
+  onError: (message: string) => void;
+  onSuccess: (message: string) => void;
+}
+
+const EvidenceRetentionSection = ({
+  isDisabled,
+  onError,
+  onSuccess,
+}: EvidenceRetentionSectionProps) => {
+  const [retentionPeriod, setRetentionPeriod] = useState<string>("");
+  const [archiveOnExpiry, setArchiveOnExpiry] = useState(false);
+  const [saving, setSaving] = useState(false);
+
+  // Seed from the org settings; a missing row resolves to server defaults
+  // (no default retention, archival off).
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      try {
+        const settings = await getEvidenceHubSettings();
+        if (cancelled) return;
+        setRetentionPeriod(settings.default_retention_period ?? "");
+        setArchiveOnExpiry(settings.archive_on_expiry);
+      } catch {
+        // Leave the section at defaults if settings cannot be loaded.
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  const handleSave = async () => {
+    setSaving(true);
+    try {
+      await updateEvidenceHubSettings({
+        default_retention_period: retentionPeriod || null,
+        archive_on_expiry: archiveOnExpiry,
+      });
+      onSuccess("Evidence retention settings saved");
+    } catch (error: any) {
+      onError(error?.message || "Failed to save evidence retention settings");
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  return (
+    <Box sx={{ mt: 6 }}>
+      <Typography sx={{ fontSize: 15, fontWeight: 600, mb: 1 }}>
+        Evidence Hub retention
+      </Typography>
+      <Typography sx={{ fontSize: 13, color: "text.secondary", mb: 3, maxWidth: 560 }}>
+        Applied to new evidence that has no explicit expiry date or retention policy of its
+        own. A daily job flags records past their expiry date and notifies the reviewer or
+        organization admins.
+      </Typography>
+
+      <Box sx={{ maxWidth: "360px", mb: 3 }}>
+        <SelectComponent
+          id="evidence-default-retention"
+          label="Default retention period"
+          items={RETENTION_OPTIONS}
+          value={retentionPeriod}
+          onChange={(event: any) => setRetentionPeriod(event.target.value)}
+          placeholder="No default"
+          disabled={isDisabled}
+          sx={{ width: "100%" }}
+        />
+      </Box>
+
+      <Stack direction="row" alignItems="center" spacing={2} sx={{ mb: 1 }}>
+        <Toggle
+          ariaLabel="Archive expired evidence"
+          checked={archiveOnExpiry}
+          onChange={(_, checked) => setArchiveOnExpiry(checked)}
+          disabled={isDisabled}
+        />
+        <Typography sx={{ fontSize: 13 }}>Archive expired evidence</Typography>
+      </Stack>
+      <Typography sx={{ fontSize: 12, color: "text.secondary", mb: 3, maxWidth: 560 }}>
+        Archived evidence is hidden from the Evidence Hub list but never deleted. Archival
+        also requires the server flag EVIDENCE_RETENTION_ARCHIVE_ENABLED.
+      </Typography>
+
+      <CustomizableButton
+        variant="contained"
+        text="Save retention settings"
+        onClick={handleSave}
+        isDisabled={isDisabled || saving}
+        testId="evidence-hub-save-retention-btn"
+      />
+    </Box>
+  );
+};
+
+export default EvidenceRetentionSection;

--- a/Clients/src/presentation/pages/SettingsPage/Organization/EvidenceRetentionSection.tsx
+++ b/Clients/src/presentation/pages/SettingsPage/Organization/EvidenceRetentionSection.tsx
@@ -72,13 +72,11 @@ const EvidenceRetentionSection = ({
 
   return (
     <Box sx={{ mt: 6 }}>
-      <Typography sx={{ fontSize: 15, fontWeight: 600, mb: 1 }}>
-        Evidence Hub retention
-      </Typography>
+      <Typography sx={{ fontSize: 15, fontWeight: 600, mb: 1 }}>Evidence Hub retention</Typography>
       <Typography sx={{ fontSize: 13, color: "text.secondary", mb: 3, maxWidth: 560 }}>
-        Applied to new evidence that has no explicit expiry date or retention policy of its
-        own. A daily job flags records past their expiry date and notifies the reviewer or
-        organization admins.
+        Applied to new evidence that has no explicit expiry date or retention policy of its own. A
+        daily job flags records past their expiry date and notifies the reviewer or organization
+        admins.
       </Typography>
 
       <Box sx={{ maxWidth: "360px", mb: 3 }}>
@@ -104,8 +102,8 @@ const EvidenceRetentionSection = ({
         <Typography sx={{ fontSize: 13 }}>Archive expired evidence</Typography>
       </Stack>
       <Typography sx={{ fontSize: 12, color: "text.secondary", mb: 3, maxWidth: 560 }}>
-        Archived evidence is hidden from the Evidence Hub list but never deleted. Archival
-        also requires the server flag EVIDENCE_RETENTION_ARCHIVE_ENABLED.
+        Archived evidence is hidden from the Evidence Hub list but never deleted. Archival also
+        requires the server flag EVIDENCE_RETENTION_ARCHIVE_ENABLED.
       </Typography>
 
       <CustomizableButton

--- a/Clients/src/presentation/pages/SettingsPage/Organization/index.tsx
+++ b/Clients/src/presentation/pages/SettingsPage/Organization/index.tsx
@@ -27,6 +27,7 @@ import { getAuthToken } from "../../../../application/redux/auth/getAuthToken";
 import { useAuth } from "../../../../application/hooks/useAuth";
 import { useLogoFetch } from "../../../../application/hooks/useLogoFetch";
 import { OrganizationModel } from "../../../../domain/models/Common/organization/organization.model";
+import EvidenceRetentionSection from "./EvidenceRetentionSection";
 
 interface AlertState {
   variant: "success" | "info" | "warning" | "error";
@@ -539,6 +540,13 @@ const Organization = () => {
           </Stack>
         </Box>
       </Stack>
+
+      {/* Evidence Hub retention settings */}
+      <EvidenceRetentionSection
+        isDisabled={isEditingDisabled}
+        onError={(message) => showAlert("error", "Error", message)}
+        onSuccess={(message) => showAlert("success", "Success", message)}
+      />
 
       {/* Remove Logo Confirmation Modal */}
       {isRemoveLogoModalOpen && (

--- a/Servers/.env.example
+++ b/Servers/.env.example
@@ -107,3 +107,8 @@ SSO_ENABLED=false
 LANGFUSE_HOST=https://cloud.langfuse.com
 LANGFUSE_PUBLIC_KEY=
 LANGFUSE_SECRET_KEY=
+
+# Evidence Hub retention — soft-archive expired evidence in the daily sweep.
+# Default off. Archival NEVER deletes records; it also requires the org's
+# archive_on_expiry setting (PUT /api/evidenceHub/settings).
+# EVIDENCE_RETENTION_ARCHIVE_ENABLED=false

--- a/Servers/constants/emailTemplates.ts
+++ b/Servers/constants/emailTemplates.ts
@@ -59,6 +59,9 @@ export const EMAIL_TEMPLATES = {
   MRM_BREACH_ALERT: "mrm-breach-alert.mjml",
   MRM_REVALIDATION_DUE: "mrm-revalidation-due.mjml",
 
+  // Evidence Hub templates
+  EVIDENCE_EXPIRED: "evidence-expired.mjml",
+
   // AI Gateway templates
   AI_GATEWAY_BUDGET_WARNING: "ai-gateway-budget-warning.mjml",
   AI_GATEWAY_BUDGET_EXHAUSTED: "ai-gateway-budget-exhausted.mjml",

--- a/Servers/controllers/evidenceHub.ctrl.ts
+++ b/Servers/controllers/evidenceHub.ctrl.ts
@@ -216,10 +216,7 @@ export async function updateEvidenceById(req: Request, res: Response) {
     // policy (falling back to the org default); "indefinite"/null clears
     // expiry (null = "no expiry"). Untouched requests keep the stored value.
     const updateBody: Record<string, any> = { ...req.body };
-    if (
-      updateBody.expiry_date === undefined &&
-      updateBody.retention_policy !== undefined
-    ) {
+    if (updateBody.expiry_date === undefined && updateBody.retention_policy !== undefined) {
       updateBody.expiry_date = await resolveEvidenceExpiryDate(
         req.organizationId!,
         null,

--- a/Servers/controllers/evidenceHub.ctrl.ts
+++ b/Servers/controllers/evidenceHub.ctrl.ts
@@ -17,6 +17,7 @@ import {
   recordEvidenceRemovedFromModel,
   recordEvidenceFieldChangeForModel,
 } from "../utils/modelInventoryChangeHistory.utils";
+import { resolveEvidenceExpiryDate } from "../utils/evidenceRetention.utils";
 
 export async function getAllEvidences(req: Request, res: Response) {
   logStructured(
@@ -209,8 +210,24 @@ export async function updateEvidenceById(req: Request, res: Response) {
     // Track field changes for models that remain mapped
     const continuingModels = newMappedModels.filter((id: number) => oldMappedModels.includes(id));
 
+    // An explicit expiry_date always wins. When the request changes
+    // retention_policy without an expiry_date, recompute expiry from the
+    // policy (falling back to the org default); "indefinite"/null clears
+    // expiry (null = "no expiry"). Untouched requests keep the stored value.
+    const updateBody: Record<string, any> = { ...req.body };
+    if (
+      updateBody.expiry_date === undefined &&
+      updateBody.retention_policy !== undefined
+    ) {
+      updateBody.expiry_date = await resolveEvidenceExpiryDate(
+        req.organizationId!,
+        null,
+        updateBody.retention_policy,
+      );
+    }
+
     Object.assign(existingEvidence, {
-      ...req.body,
+      ...updateBody,
       ...(req.body?.description !== undefined && {
         description: sanitizeUserHtml(req.body.description),
       }),

--- a/Servers/controllers/evidenceHub.ctrl.ts
+++ b/Servers/controllers/evidenceHub.ctrl.ts
@@ -29,7 +29,8 @@ export async function getAllEvidences(req: Request, res: Response) {
   logger.debug("🔍 Fetching all evidences");
 
   try {
-    const evidences = await getAllEvidencesQuery(req.organizationId!);
+    const includeArchived = req.query.includeArchived === "true";
+    const evidences = await getAllEvidencesQuery(req.organizationId!, includeArchived);
 
     if (evidences && evidences.length > 0) {
       logStructured(

--- a/Servers/controllers/evidenceHubSettings.ctrl.ts
+++ b/Servers/controllers/evidenceHubSettings.ctrl.ts
@@ -1,0 +1,82 @@
+import { Request, Response } from "express";
+import { STATUS_CODE } from "../utils/statusCode.utils";
+import logger, { logStructured } from "../utils/logger/fileLogger";
+import { translateError } from "../utils/i18n.utils";
+import { CustomException } from "../domain.layer/exceptions/custom.exception";
+import {
+  getEvidenceHubOrgSettings,
+  upsertEvidenceHubOrgSettings,
+} from "../utils/evidenceHubSettings.utils";
+import { EVIDENCE_RETENTION_PERIODS } from "../utils/evidenceRetention.utils";
+
+const FILE = "evidenceHubSettings.ctrl.ts";
+
+function fail(req: Request, res: Response, fn: string, msg: string, error: unknown) {
+  logStructured("error", msg, fn, FILE);
+  logger.error(`❌ Error in ${fn}:`, error);
+  const status = error instanceof CustomException ? error.statusCode : 500;
+  if (status >= 500) {
+    return res.status(500).json(STATUS_CODE[500](translateError(req, error)));
+  }
+  const body = (STATUS_CODE as any)[status]
+    ? (STATUS_CODE as any)[status](translateError(req, error))
+    : STATUS_CODE[400](translateError(req, error));
+  return res.status(status).json(body);
+}
+
+export async function getEvidenceHubSettingsHandler(req: Request, res: Response) {
+  const fn = "getEvidenceHubSettingsHandler";
+  logStructured("processing", "fetching Evidence Hub settings", fn, FILE);
+  try {
+    const settings = await getEvidenceHubOrgSettings(req.organizationId!);
+    logStructured("successful", "Evidence Hub settings retrieved", fn, FILE);
+    return res.status(200).json(STATUS_CODE[200](settings));
+  } catch (error) {
+    return fail(req, res, fn, "failed to retrieve Evidence Hub settings", error);
+  }
+}
+
+export async function updateEvidenceHubSettingsHandler(req: Request, res: Response) {
+  const fn = "updateEvidenceHubSettingsHandler";
+  logStructured("processing", "updating Evidence Hub settings", fn, FILE);
+  try {
+    const body = req.body ?? {};
+    const has = (key: string) => Object.prototype.hasOwnProperty.call(body, key);
+
+    // PARTIAL semantics: only fields present in the body are validated and
+    // updated; absent fields keep their current value.
+    if (!has("default_retention_period") && !has("archive_on_expiry")) {
+      return res.status(400).json(STATUS_CODE[400](req.t!("No settings provided")));
+    }
+
+    if (
+      has("default_retention_period") &&
+      body.default_retention_period !== null &&
+      !(EVIDENCE_RETENTION_PERIODS as readonly string[]).includes(
+        body.default_retention_period,
+      )
+    ) {
+      return res
+        .status(400)
+        .json(STATUS_CODE[400](req.t!("Invalid default retention period")));
+    }
+
+    if (has("archive_on_expiry") && typeof body.archive_on_expiry !== "boolean") {
+      return res
+        .status(400)
+        .json(STATUS_CODE[400](req.t!("Archive on expiry must be true or false")));
+    }
+
+    const settings = await upsertEvidenceHubOrgSettings(req.organizationId!, {
+      default_retention_period: has("default_retention_period")
+        ? body.default_retention_period
+        : undefined,
+      archive_on_expiry: has("archive_on_expiry") ? body.archive_on_expiry : undefined,
+    });
+
+    logStructured("successful", "Evidence Hub settings updated", fn, FILE);
+    return res.status(200).json(STATUS_CODE[200](settings));
+  } catch (error) {
+    return fail(req, res, fn, "failed to update Evidence Hub settings", error);
+  }
+}

--- a/Servers/controllers/evidenceHubSettings.ctrl.ts
+++ b/Servers/controllers/evidenceHubSettings.ctrl.ts
@@ -52,13 +52,9 @@ export async function updateEvidenceHubSettingsHandler(req: Request, res: Respon
     if (
       has("default_retention_period") &&
       body.default_retention_period !== null &&
-      !(EVIDENCE_RETENTION_PERIODS as readonly string[]).includes(
-        body.default_retention_period,
-      )
+      !(EVIDENCE_RETENTION_PERIODS as readonly string[]).includes(body.default_retention_period)
     ) {
-      return res
-        .status(400)
-        .json(STATUS_CODE[400](req.t!("Invalid default retention period")));
+      return res.status(400).json(STATUS_CODE[400](req.t!("Invalid default retention period")));
     }
 
     if (has("archive_on_expiry") && typeof body.archive_on_expiry !== "boolean") {

--- a/Servers/database/migrations/20260904002914-evidence-hub-retention.js
+++ b/Servers/database/migrations/20260904002914-evidence-hub-retention.js
@@ -1,0 +1,107 @@
+"use strict";
+
+/**
+ * Evidence Hub — retention policy.
+ *
+ * evidence_hub_org_settings: org-wide Evidence Hub configuration. One row
+ * per org, lazily created — a missing row means defaults (no org-level
+ * default retention period, archival off). Follows the mrm_org_settings
+ * pattern.
+ *
+ * default_retention_period: applied at create/update time when a record has
+ * neither an explicit expiry_date nor its own retention_policy. NULL means
+ * "no default" — records without any retention configuration keep
+ * expiry_date NULL, which is treated as "no expiry" everywhere (never
+ * flagged expired, never notified, never archived).
+ *
+ * archive_on_expiry: opt-in soft-archival of expired records (sets
+ * archived_at; never deletes). Requires the env flag
+ * EVIDENCE_RETENTION_ARCHIVE_ENABLED=true as well — both gates default off.
+ *
+ * evidence_hub.expired_at / expiry_notified_at / archived_at: state written
+ * by the daily evidence_expiry_sweep BullMQ job. expired_at flags the record
+ * as expired (NULL = not expired); expiry_notified_at dedups the one-time
+ * expiry notification; archived_at is the soft-archive marker.
+ *
+ * idx_evidence_hub_org_expiry: the sweep scans
+ * (organization_id, expiry_date < now(), expired_at IS NULL); no existing
+ * index serves that org + expiry-range scan.
+ *
+ * Tenant-scoped by organization_id.
+ */
+module.exports = {
+  async up(queryInterface) {
+    const transaction = await queryInterface.sequelize.transaction();
+    try {
+      await queryInterface.sequelize.query(
+        `
+        CREATE TABLE IF NOT EXISTS verifywise.evidence_hub_org_settings (
+          organization_id INTEGER PRIMARY KEY
+            REFERENCES verifywise.organizations(id) ON DELETE CASCADE,
+          default_retention_period VARCHAR(100) NULL
+            CHECK (
+              default_retention_period IS NULL OR default_retention_period IN (
+                '30_days', '90_days', '6_months', '1_year',
+                '3_years', '5_years', '7_years', 'indefinite'
+              )
+            ),
+          archive_on_expiry BOOLEAN NOT NULL DEFAULT false,
+          created_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(),
+          updated_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now()
+        );
+      `,
+        { transaction },
+      );
+
+      await queryInterface.sequelize.query(
+        `
+        ALTER TABLE verifywise.evidence_hub
+          ADD COLUMN IF NOT EXISTS expired_at TIMESTAMP NULL,
+          ADD COLUMN IF NOT EXISTS expiry_notified_at TIMESTAMP NULL,
+          ADD COLUMN IF NOT EXISTS archived_at TIMESTAMP NULL;
+      `,
+        { transaction },
+      );
+
+      await queryInterface.sequelize.query(
+        `
+        CREATE INDEX IF NOT EXISTS idx_evidence_hub_org_expiry
+          ON verifywise.evidence_hub(organization_id, expiry_date);
+      `,
+        { transaction },
+      );
+
+      await transaction.commit();
+    } catch (error) {
+      await transaction.rollback();
+      throw error;
+    }
+  },
+
+  async down(queryInterface) {
+    const transaction = await queryInterface.sequelize.transaction();
+    try {
+      await queryInterface.sequelize.query(
+        "DROP INDEX IF EXISTS verifywise.idx_evidence_hub_org_expiry;",
+        { transaction },
+      );
+      await queryInterface.sequelize.query(
+        `
+        ALTER TABLE verifywise.evidence_hub
+          DROP COLUMN IF EXISTS expired_at,
+          DROP COLUMN IF EXISTS expiry_notified_at,
+          DROP COLUMN IF EXISTS archived_at;
+      `,
+        { transaction },
+      );
+      await queryInterface.sequelize.query(
+        "DROP TABLE IF EXISTS verifywise.evidence_hub_org_settings CASCADE;",
+        { transaction },
+      );
+      await transaction.commit();
+    } catch (error) {
+      await transaction.rollback();
+      throw error;
+    }
+  },
+};

--- a/Servers/database/migrations/20260904013000-add-evidence-expired-notification-type.js
+++ b/Servers/database/migrations/20260904013000-add-evidence-expired-notification-type.js
@@ -1,0 +1,25 @@
+"use strict";
+
+/**
+ * Evidence Hub retention — extend the notification enums so the daily
+ * evidence_expiry_sweep job can deliver an in-app/email notification when a
+ * record passes its expiry_date.
+ *
+ * Down is a no-op: removing a Postgres enum value requires recreating the
+ * type and migrating every column that uses it — risky for a fix-forward
+ * migration (same rationale as the mrm_revalidation_due migration).
+ */
+module.exports = {
+  async up(queryInterface) {
+    await queryInterface.sequelize.query(
+      `ALTER TYPE verifywise.enum_notification_type ADD VALUE IF NOT EXISTS 'evidence_expired';`,
+    );
+    await queryInterface.sequelize.query(
+      `ALTER TYPE verifywise.enum_notification_entity_type ADD VALUE IF NOT EXISTS 'evidence';`,
+    );
+  },
+
+  async down() {
+    // No-op. See header comment.
+  },
+};

--- a/Servers/docs/schema.dbml
+++ b/Servers/docs/schema.dbml
@@ -676,12 +676,25 @@ Table topics {
 
 Table evidence_hub {
   id integer [pk, increment]
+  organization_id integer [ref: > organizations.id]
   evidence_name varchar [not null]
   evidence_type varchar [not null]
   description text
-  evidence_files json [not null, default: '[]']
-  expiry_date timestamp
-  mapped_model_ids text[]
+  expiry_date timestamp [note: 'null = no expiry; computed from retention_policy or org default when not explicit']
+  retention_policy varchar [note: '30_days | 90_days | 6_months | 1_year | 3_years | 5_years | 7_years | indefinite']
+  expired_at timestamp [note: 'set by daily evidence_expiry_sweep job; null = not expired']
+  expiry_notified_at timestamp [note: 'notification dedup; reset when expiry_date changes']
+  archived_at timestamp [note: 'soft archive only, never deleted; double-gated by EVIDENCE_RETENTION_ARCHIVE_ENABLED env + org archive_on_expiry']
+  mapped_model_ids integer[]
+  mapped_training_ids integer[]
+  created_at timestamp
+  updated_at timestamp
+}
+
+Table evidence_hub_org_settings {
+  organization_id integer [pk, ref: > organizations.id]
+  default_retention_period varchar [note: 'null = no org default; same enum as evidence_hub.retention_policy']
+  archive_on_expiry boolean [not null, default: false]
   created_at timestamp
   updated_at timestamp
 }

--- a/Servers/domain.layer/interfaces/i.evidenceHub.ts
+++ b/Servers/domain.layer/interfaces/i.evidenceHub.ts
@@ -22,6 +22,20 @@ export interface IEvidenceHub {
 
   expiry_date?: Date | string;
 
+  /**
+   * Retention period ("30_days" | "90_days" | "6_months" | "1_year" |
+   * "3_years" | "5_years" | "7_years" | "indefinite"). Used to compute
+   * expiry_date when no explicit expiry_date is given; "indefinite" and
+   * null/undefined mean "no expiry".
+   */
+  retention_policy?: string | null;
+
+  /** Set by the daily evidence_expiry_sweep job; null = not expired. */
+  expired_at?: Date | null;
+
+  /** Soft-archive marker set by the sweep when archival is opted in; never deleted. */
+  archived_at?: Date | null;
+
   /** Multiple model IDs can be mapped (empty array or null allowed) */
   mapped_model_ids?: number[] | null;
 

--- a/Servers/domain.layer/interfaces/i.notification.ts
+++ b/Servers/domain.layer/interfaces/i.notification.ts
@@ -44,6 +44,9 @@ export enum NotificationType {
   MRM_METRIC_BREACH = "mrm_metric_breach",
   MRM_REVALIDATION_DUE = "mrm_revalidation_due",
 
+  // Evidence Hub notifications
+  EVIDENCE_EXPIRED = "evidence_expired",
+
   // AI Gateway notifications
   AI_GATEWAY_BUDGET_WARNING = "ai_gateway_budget_warning",
   AI_GATEWAY_BUDGET_EXHAUSTED = "ai_gateway_budget_exhausted",
@@ -84,6 +87,7 @@ export enum NotificationEntityType {
   SHADOW_AI_TOOL = "shadow_ai_tool",
   AI_GATEWAY = "ai_gateway",
   AI_ACTION = "ai_action",
+  EVIDENCE = "evidence",
 }
 
 /**

--- a/Servers/domain.layer/models/evidenceHub/evidenceHub.model.ts
+++ b/Servers/domain.layer/models/evidenceHub/evidenceHub.model.ts
@@ -54,6 +54,30 @@ export class EvidenceHubModel extends Model<EvidenceHubModel> {
   expiry_date?: Date;
 
   @Column({
+    type: DataType.STRING(100),
+    allowNull: true,
+  })
+  retention_policy?: string | null;
+
+  @Column({
+    type: DataType.DATE,
+    allowNull: true,
+  })
+  expired_at?: Date | null;
+
+  @Column({
+    type: DataType.DATE,
+    allowNull: true,
+  })
+  expiry_notified_at?: Date | null;
+
+  @Column({
+    type: DataType.DATE,
+    allowNull: true,
+  })
+  archived_at?: Date | null;
+
+  @Column({
     type: DataType.ARRAY(DataType.INTEGER),
     allowNull: true,
   })
@@ -86,6 +110,9 @@ export class EvidenceHubModel extends Model<EvidenceHubModel> {
       description: this.description,
       evidence_files: this.evidence_files,
       expiry_date: this.expiry_date?.toISOString() || null,
+      retention_policy: this.retention_policy ?? null,
+      expired_at: this.expired_at?.toISOString() || null,
+      archived_at: this.archived_at?.toISOString() || null,
       mapped_model_ids: this.mapped_model_ids,
       mapped_training_ids: this.mapped_training_ids,
       created_at: (this.createdAt ?? this.created_at)?.toISOString(),
@@ -105,6 +132,9 @@ export class EvidenceHubModel extends Model<EvidenceHubModel> {
       description: this.description,
       evidence_files: this.evidence_files,
       expiry_date: this.expiry_date?.toISOString() || null,
+      retention_policy: this.retention_policy ?? null,
+      expired_at: this.expired_at?.toISOString() || null,
+      archived_at: this.archived_at?.toISOString() || null,
       mapped_model_ids: this.mapped_model_ids,
       mapped_training_ids: this.mapped_training_ids,
       created_at: (this.createdAt ?? this.created_at)?.toISOString(),
@@ -122,6 +152,7 @@ export class EvidenceHubModel extends Model<EvidenceHubModel> {
       description: data.description ?? existingEvidence.description,
       evidence_files: data.evidence_files ?? existingEvidence.evidence_files,
       expiry_date: data.expiry_date ?? existingEvidence.expiry_date,
+      retention_policy: data.retention_policy ?? existingEvidence.retention_policy,
       mapped_model_ids: data.mapped_model_ids ?? existingEvidence.mapped_model_ids,
       mapped_training_ids: data.mapped_training_ids ?? existingEvidence.mapped_training_ids,
       updated_at: new Date(),

--- a/Servers/jobs/producer.ts
+++ b/Servers/jobs/producer.ts
@@ -21,6 +21,7 @@ import {
   scheduleReportSchedulerTick,
   scheduleMrmRevalidationSweep,
   scheduleMrmRetentionPrune,
+  scheduleEvidenceExpirySweep,
   scheduleAiTrustIndexSync,
 } from "../services/automations/automationProducer";
 
@@ -57,6 +58,7 @@ export async function addAllJobs(): Promise<void> {
   await safeSchedule("report-scheduler-tick", scheduleReportSchedulerTick);
   await safeSchedule("mrm-revalidation-sweep", scheduleMrmRevalidationSweep); // non-obliterating — safe to run after the obliterating schedulers
   await safeSchedule("mrm-retention-prune", scheduleMrmRetentionPrune); // non-obliterating — safe to run after the obliterating schedulers
+  await safeSchedule("evidence-expiry-sweep", scheduleEvidenceExpirySweep); // non-obliterating — safe to run after the obliterating schedulers
   await safeSchedule("ai-trust-index-sync", scheduleAiTrustIndexSync);
   // Ordering constraint: obliterate-using schedulers (e.g. vendor-review,
   // report-notification) must run BEFORE all non-obliterating ones, or they wipe

--- a/Servers/routes/evidenceHub.route.ts
+++ b/Servers/routes/evidenceHub.route.ts
@@ -8,6 +8,16 @@ import {
   getEvidenceById,
   updateEvidenceById,
 } from "../controllers/evidenceHub.ctrl";
+import {
+  getEvidenceHubSettingsHandler,
+  updateEvidenceHubSettingsHandler,
+} from "../controllers/evidenceHubSettings.ctrl";
+
+// GET org-level Evidence Hub settings (must precede /:id)
+router.get("/settings", authenticateJWT, getEvidenceHubSettingsHandler);
+
+// PUT org-level Evidence Hub settings
+router.put("/settings", authenticateJWT, updateEvidenceHubSettingsHandler);
 
 // GET all evidences
 router.get("/", authenticateJWT, getAllEvidences);

--- a/Servers/services/automations/actions/__tests__/evidenceExpirySweep.test.ts
+++ b/Servers/services/automations/actions/__tests__/evidenceExpirySweep.test.ts
@@ -1,0 +1,225 @@
+import { QueryTypes } from "sequelize";
+import { sequelize } from "../../../../database/db";
+import { runEvidenceExpirySweep, runEvidenceExpirySweepAllOrgs } from "../evidenceExpirySweep";
+import { getAllOrganizationsQuery } from "../../../../utils/organization.utils";
+import { getAllUsersQuery } from "../../../../utils/user.utils";
+import { getEvidenceHubOrgSettings } from "../../../../utils/evidenceHubSettings.utils";
+import { notifyEvidenceExpired } from "../../../inAppNotification.service";
+
+jest.mock("../../../../database/db", () => ({
+  sequelize: { query: jest.fn() },
+}));
+jest.mock("../../../../utils/organization.utils", () => ({
+  getAllOrganizationsQuery: jest.fn(),
+}));
+jest.mock("../../../../utils/user.utils", () => ({
+  getAllUsersQuery: jest.fn(),
+}));
+jest.mock("../../../../utils/evidenceHubSettings.utils", () => ({
+  getEvidenceHubOrgSettings: jest.fn(),
+}));
+jest.mock("../../../inAppNotification.service", () => ({
+  notifyEvidenceExpired: jest.fn(),
+}));
+jest.mock("../../../../utils/logger/fileLogger", () => ({
+  __esModule: true,
+  default: { info: jest.fn(), error: jest.fn() },
+}));
+
+const mockQuery = sequelize.query as jest.Mock;
+const mockAllOrgs = getAllOrganizationsQuery as jest.Mock;
+const mockAllUsers = getAllUsersQuery as jest.Mock;
+const mockGetSettings = getEvidenceHubOrgSettings as jest.Mock;
+const mockNotify = notifyEvidenceExpired as jest.Mock;
+
+const FLAG_SQL = "SET expired_at";
+const SELECT_UNNOTIFIED_SQL = "expiry_notified_at IS NULL";
+const MARK_NOTIFIED_SQL = "SET expiry_notified_at";
+const ARCHIVE_SQL = "SET archived_at";
+
+/** Route the mocked sequelize.query by which statement the action issued. */
+function mockQueryRouting(handlers: {
+  flagged?: object[];
+  unnotified?: object[];
+  archived?: object[];
+}) {
+  mockQuery.mockImplementation(async (sql: string) => {
+    if (sql.includes(FLAG_SQL)) return handlers.flagged ?? [];
+    if (sql.includes(SELECT_UNNOTIFIED_SQL)) return handlers.unnotified ?? [];
+    if (sql.includes(MARK_NOTIFIED_SQL)) return [];
+    if (sql.includes(ARCHIVE_SQL)) return handlers.archived ?? [];
+    throw new Error(`Unexpected SQL in test: ${sql}`);
+  });
+}
+
+const ORIGINAL_ENV = process.env;
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  process.env = { ...ORIGINAL_ENV };
+  delete process.env.EVIDENCE_RETENTION_ARCHIVE_ENABLED;
+  mockAllOrgs.mockResolvedValue([{ id: 1 }]);
+  mockAllUsers.mockResolvedValue([
+    { id: 10, role_id: 1 },
+    { id: 11, role_id: 2 },
+  ]);
+  mockGetSettings.mockResolvedValue({
+    organization_id: 1,
+    default_retention_period: null,
+    archive_on_expiry: false,
+  });
+  mockNotify.mockResolvedValue(undefined);
+  mockQueryRouting({});
+});
+
+afterAll(() => {
+  process.env = ORIGINAL_ENV;
+});
+
+describe("runEvidenceExpirySweep", () => {
+  it("flags past-expiry records and returns them with a summary", async () => {
+    mockQuery.mockResolvedValueOnce([
+      { id: 5, evidence_name: "SOC 2 report", expiry_date: "2026-01-01", reviewer_id: 11 },
+    ]);
+
+    const { summary, records } = await runEvidenceExpirySweep(1);
+
+    expect(summary).toEqual({
+      organization_id: 1,
+      newly_expired: 1,
+      notified: 0,
+      archived: 0,
+    });
+    expect(records).toHaveLength(1);
+    const [sql, options] = mockQuery.mock.calls[0];
+    expect(sql).toContain(FLAG_SQL);
+    expect(sql).toContain("expiry_date IS NOT NULL");
+    expect(sql).toContain("expired_at IS NULL");
+    expect(options).toMatchObject({
+      replacements: { organizationId: 1 },
+      type: QueryTypes.SELECT,
+    });
+  });
+});
+
+describe("runEvidenceExpirySweepAllOrgs", () => {
+  it("isolates a failing org and still sweeps the others", async () => {
+    mockAllOrgs.mockResolvedValue([{ id: 1 }, { id: 2 }]);
+    mockQuery.mockImplementation(async (sql: string, options?: any) => {
+      if (options?.replacements?.organizationId === 2) throw new Error("boom");
+      if (sql.includes(SELECT_UNNOTIFIED_SQL)) return [];
+      return [];
+    });
+
+    await expect(runEvidenceExpirySweepAllOrgs()).resolves.toBeUndefined();
+    const flagCalls = mockQuery.mock.calls.filter(([sql]) => sql.includes(FLAG_SQL));
+    expect(flagCalls.map(([, o]) => o.replacements.organizationId)).toEqual([1, 2]);
+  });
+
+  it("skips orgs with undefined/null ids", async () => {
+    mockAllOrgs.mockResolvedValue([{ id: undefined }, { id: 7 }]);
+    await runEvidenceExpirySweepAllOrgs();
+    const flagCalls = mockQuery.mock.calls.filter(([sql]) => sql.includes(FLAG_SQL));
+    expect(flagCalls).toHaveLength(1);
+    expect(flagCalls[0][1].replacements.organizationId).toBe(7);
+  });
+
+  it("does nothing when no records are expired or unnotified", async () => {
+    await runEvidenceExpirySweepAllOrgs();
+    expect(mockNotify).not.toHaveBeenCalled();
+  });
+});
+
+describe("expiry notifications", () => {
+  it("notifies the reviewer and marks expiry_notified_at", async () => {
+    mockQueryRouting({
+      unnotified: [
+        { id: 5, evidence_name: "SOC 2 report", expiry_date: "2026-01-01", reviewer_id: 11 },
+      ],
+    });
+
+    await runEvidenceExpirySweepAllOrgs();
+
+    expect(mockNotify).toHaveBeenCalledTimes(1);
+    expect(mockNotify).toHaveBeenCalledWith(
+      1,
+      11,
+      { id: 5, name: "SOC 2 report", expiryDate: "2026-01-01" },
+      expect.any(String),
+    );
+    const markCalls = mockQuery.mock.calls.filter(([sql]) => sql.includes(MARK_NOTIFIED_SQL));
+    expect(markCalls).toHaveLength(1);
+    expect(markCalls[0][1].replacements).toEqual({ organizationId: 1, id: 5 });
+  });
+
+  it("falls back to org admins when no reviewer is set", async () => {
+    mockQueryRouting({
+      unnotified: [
+        { id: 6, evidence_name: "Pen test", expiry_date: "2026-01-02", reviewer_id: null },
+      ],
+    });
+
+    await runEvidenceExpirySweepAllOrgs();
+
+    expect(mockNotify).toHaveBeenCalledTimes(1);
+    expect(mockNotify.mock.calls[0][1]).toBe(10); // admin (role_id 1), not the non-admin
+  });
+
+  it("does not mark notified when notification fails, so the next run retries", async () => {
+    mockNotify.mockRejectedValue(new Error("smtp down"));
+    mockQueryRouting({
+      unnotified: [
+        { id: 5, evidence_name: "SOC 2 report", expiry_date: "2026-01-01", reviewer_id: 11 },
+      ],
+    });
+
+    await expect(runEvidenceExpirySweepAllOrgs()).resolves.toBeUndefined();
+
+    const markCalls = mockQuery.mock.calls.filter(([sql]) => sql.includes(MARK_NOTIFIED_SQL));
+    expect(markCalls).toHaveLength(0);
+  });
+});
+
+describe("archival gating", () => {
+  const unnotified = [];
+
+  it("never archives when the env flag is unset, even if the org opted in", async () => {
+    mockGetSettings.mockResolvedValue({
+      organization_id: 1,
+      default_retention_period: null,
+      archive_on_expiry: true,
+    });
+    mockQueryRouting({ unnotified });
+
+    await runEvidenceExpirySweepAllOrgs();
+
+    expect(mockQuery.mock.calls.some(([sql]) => sql.includes(ARCHIVE_SQL))).toBe(false);
+  });
+
+  it("never archives when the org has not opted in, even with the env flag on", async () => {
+    process.env.EVIDENCE_RETENTION_ARCHIVE_ENABLED = "true";
+    mockQueryRouting({ unnotified });
+
+    await runEvidenceExpirySweepAllOrgs();
+
+    expect(mockQuery.mock.calls.some(([sql]) => sql.includes(ARCHIVE_SQL))).toBe(false);
+  });
+
+  it("archives only when both the env flag and the org opt-in are on", async () => {
+    process.env.EVIDENCE_RETENTION_ARCHIVE_ENABLED = "true";
+    mockGetSettings.mockResolvedValue({
+      organization_id: 1,
+      default_retention_period: null,
+      archive_on_expiry: true,
+    });
+    mockQueryRouting({ unnotified, archived: [{ id: 5 }] });
+
+    await runEvidenceExpirySweepAllOrgs();
+
+    const archiveCalls = mockQuery.mock.calls.filter(([sql]) => sql.includes(ARCHIVE_SQL));
+    expect(archiveCalls).toHaveLength(1);
+    expect(archiveCalls[0][0]).toContain("expired_at IS NOT NULL");
+    expect(archiveCalls[0][0]).toContain("archived_at IS NULL");
+    expect(archiveCalls[0][0]).not.toContain("DELETE");
+  });
+});

--- a/Servers/services/automations/actions/evidenceExpirySweep.ts
+++ b/Servers/services/automations/actions/evidenceExpirySweep.ts
@@ -1,0 +1,76 @@
+import { QueryTypes } from "sequelize";
+import { sequelize } from "../../../database/db";
+import { getAllOrganizationsQuery } from "../../../utils/organization.utils";
+import logger from "../../../utils/logger/fileLogger";
+
+/**
+ * Evidence Hub — daily expiry sweep.
+ *
+ * Flags evidence_hub records whose expiry_date has passed by setting
+ * expired_at (NULL expired_at = not expired). Records with expiry_date NULL
+ * are treated as "no expiry" and are never selected. Archived records are
+ * left alone. Idempotent — only not-yet-flagged rows are touched; a record
+ * whose expiry_date is later extended is un-flagged by the update path
+ * (utils/evidenceHub.utils.ts) and becomes eligible for a fresh evaluation.
+ *
+ * Notification (dedup via expiry_notified_at) and soft-archival (double
+ * config-gated, never a delete) hook into runEvidenceExpirySweepAllOrgs.
+ */
+
+export interface ExpiredEvidenceRecord {
+  id: number;
+  evidence_name: string;
+  expiry_date: string;
+  reviewer_id: number | null;
+}
+
+export interface EvidenceExpirySweepSummary {
+  organization_id: number;
+  newly_expired: number;
+}
+
+/** Flag newly expired records for one org; returns them for notification. */
+export async function runEvidenceExpirySweep(
+  organizationId: number,
+): Promise<{ summary: EvidenceExpirySweepSummary; records: ExpiredEvidenceRecord[] }> {
+  const records = (await sequelize.query(
+    `UPDATE evidence_hub
+        SET expired_at = now()
+      WHERE organization_id = :organizationId
+        AND expiry_date IS NOT NULL
+        AND expiry_date < now()
+        AND expired_at IS NULL
+        AND archived_at IS NULL
+      RETURNING id, evidence_name, expiry_date, reviewer_id`,
+    {
+      replacements: { organizationId },
+      type: QueryTypes.SELECT,
+    },
+  )) as ExpiredEvidenceRecord[];
+
+  return {
+    summary: { organization_id: organizationId, newly_expired: records.length },
+    records,
+  };
+}
+
+/**
+ * Sweep every org — the BullMQ daily job entry point. Isolated per org so
+ * one org's failure cannot block the others (mirrors runRetentionPruneAllOrgs).
+ */
+export async function runEvidenceExpirySweepAllOrgs(): Promise<void> {
+  const organizations = await getAllOrganizationsQuery();
+  for (const org of organizations) {
+    if (org.id === undefined || org.id === null) continue;
+    try {
+      const { summary } = await runEvidenceExpirySweep(org.id);
+      if (summary.newly_expired > 0) {
+        logger.info(
+          `Evidence expiry sweep org ${org.id}: newly_expired=${summary.newly_expired}`,
+        );
+      }
+    } catch (error) {
+      logger.error(`❌ Evidence expiry sweep failed for org ${org.id}:`, error);
+    }
+  }
+}

--- a/Servers/services/automations/actions/evidenceExpirySweep.ts
+++ b/Servers/services/automations/actions/evidenceExpirySweep.ts
@@ -1,6 +1,8 @@
 import { QueryTypes } from "sequelize";
 import { sequelize } from "../../../database/db";
 import { getAllOrganizationsQuery } from "../../../utils/organization.utils";
+import { getAllUsersQuery } from "../../../utils/user.utils";
+import { notifyEvidenceExpired } from "../../inAppNotification.service";
 import logger from "../../../utils/logger/fileLogger";
 
 /**
@@ -27,6 +29,7 @@ export interface ExpiredEvidenceRecord {
 export interface EvidenceExpirySweepSummary {
   organization_id: number;
   newly_expired: number;
+  notified: number;
 }
 
 /** Flag newly expired records for one org; returns them for notification. */
@@ -49,9 +52,88 @@ export async function runEvidenceExpirySweep(
   )) as ExpiredEvidenceRecord[];
 
   return {
-    summary: { organization_id: organizationId, newly_expired: records.length },
+    summary: { organization_id: organizationId, newly_expired: records.length, notified: 0 },
     records,
   };
+}
+
+const ADMIN_ROLE_ID = 1;
+
+const formatExpiryDate = (value: unknown): string => {
+  if (!value) return "-";
+  const parsed = value instanceof Date ? value : new Date(String(value));
+  return isNaN(parsed.getTime()) ? String(value) : parsed.toISOString().slice(0, 10);
+};
+
+/**
+ * Notify for expired-but-unnotified records in one org. Recipients: the
+ * record's reviewer when set, otherwise all org admins (falling back to all
+ * org users when the org has no admin — mirrors proactiveNotify). Marks
+ * expiry_notified_at only after a record's notifications succeed, so a
+ * failure is retried on the next daily run.
+ */
+async function notifyUnnotifiedExpiredEvidence(
+  organizationId: number,
+): Promise<number> {
+  const baseUrl = process.env.FRONTEND_URL || "http://localhost:3000";
+
+  const records = (await sequelize.query(
+    `SELECT id, evidence_name, expiry_date, reviewer_id
+       FROM evidence_hub
+      WHERE organization_id = :organizationId
+        AND expired_at IS NOT NULL
+        AND expiry_notified_at IS NULL
+        AND archived_at IS NULL
+      ORDER BY id`,
+    {
+      replacements: { organizationId },
+      type: QueryTypes.SELECT,
+    },
+  )) as ExpiredEvidenceRecord[];
+
+  if (records.length === 0) return 0;
+
+  const users = await getAllUsersQuery(organizationId);
+  const userIds = users
+    .map((u) => u.id)
+    .filter((id): id is number => id !== undefined && id !== null);
+  let adminIds = users
+    .filter((u) => u.role_id === ADMIN_ROLE_ID)
+    .map((u) => u.id)
+    .filter((id): id is number => id !== undefined && id !== null);
+  if (adminIds.length === 0) adminIds = userIds;
+
+  let notified = 0;
+  for (const record of records) {
+    const recipientIds = record.reviewer_id ? [record.reviewer_id] : adminIds;
+    try {
+      for (const recipientId of recipientIds) {
+        await notifyEvidenceExpired(
+          organizationId,
+          recipientId,
+          {
+            id: record.id,
+            name: record.evidence_name,
+            expiryDate: formatExpiryDate(record.expiry_date),
+          },
+          baseUrl,
+        );
+      }
+      await sequelize.query(
+        `UPDATE evidence_hub
+            SET expiry_notified_at = now()
+          WHERE organization_id = :organizationId AND id = :id`,
+        { replacements: { organizationId, id: record.id } },
+      );
+      notified += 1;
+    } catch (error) {
+      logger.error(
+        `❌ Evidence expiry notification failed for evidence ${record.id} (org ${organizationId}):`,
+        error,
+      );
+    }
+  }
+  return notified;
 }
 
 /**
@@ -64,9 +146,10 @@ export async function runEvidenceExpirySweepAllOrgs(): Promise<void> {
     if (org.id === undefined || org.id === null) continue;
     try {
       const { summary } = await runEvidenceExpirySweep(org.id);
-      if (summary.newly_expired > 0) {
+      summary.notified = await notifyUnnotifiedExpiredEvidence(org.id);
+      if (summary.newly_expired > 0 || summary.notified > 0) {
         logger.info(
-          `Evidence expiry sweep org ${org.id}: newly_expired=${summary.newly_expired}`,
+          `Evidence expiry sweep org ${org.id}: newly_expired=${summary.newly_expired} notified=${summary.notified}`,
         );
       }
     } catch (error) {

--- a/Servers/services/automations/actions/evidenceExpirySweep.ts
+++ b/Servers/services/automations/actions/evidenceExpirySweep.ts
@@ -2,6 +2,7 @@ import { QueryTypes } from "sequelize";
 import { sequelize } from "../../../database/db";
 import { getAllOrganizationsQuery } from "../../../utils/organization.utils";
 import { getAllUsersQuery } from "../../../utils/user.utils";
+import { getEvidenceHubOrgSettings } from "../../../utils/evidenceHubSettings.utils";
 import { notifyEvidenceExpired } from "../../inAppNotification.service";
 import logger from "../../../utils/logger/fileLogger";
 
@@ -30,6 +31,7 @@ export interface EvidenceExpirySweepSummary {
   organization_id: number;
   newly_expired: number;
   notified: number;
+  archived: number;
 }
 
 /** Flag newly expired records for one org; returns them for notification. */
@@ -52,7 +54,12 @@ export async function runEvidenceExpirySweep(
   )) as ExpiredEvidenceRecord[];
 
   return {
-    summary: { organization_id: organizationId, newly_expired: records.length, notified: 0 },
+    summary: {
+      organization_id: organizationId,
+      newly_expired: records.length,
+      notified: 0,
+      archived: 0,
+    },
     records,
   };
 }
@@ -137,6 +144,34 @@ async function notifyUnnotifiedExpiredEvidence(
 }
 
 /**
+ * Soft-archive expired records for one org — sets archived_at only; records
+ * are NEVER deleted. Double-gated: requires the environment flag
+ * EVIDENCE_RETENTION_ARCHIVE_ENABLED=true AND the org's
+ * evidence_hub_org_settings.archive_on_expiry=true. Both default off.
+ */
+async function archiveExpiredEvidence(organizationId: number): Promise<number> {
+  if (process.env.EVIDENCE_RETENTION_ARCHIVE_ENABLED !== "true") return 0;
+
+  const settings = await getEvidenceHubOrgSettings(organizationId);
+  if (!settings.archive_on_expiry) return 0;
+
+  const records = (await sequelize.query(
+    `UPDATE evidence_hub
+        SET archived_at = now()
+      WHERE organization_id = :organizationId
+        AND expired_at IS NOT NULL
+        AND archived_at IS NULL
+      RETURNING id`,
+    {
+      replacements: { organizationId },
+      type: QueryTypes.SELECT,
+    },
+  )) as { id: number }[];
+
+  return records.length;
+}
+
+/**
  * Sweep every org — the BullMQ daily job entry point. Isolated per org so
  * one org's failure cannot block the others (mirrors runRetentionPruneAllOrgs).
  */
@@ -147,9 +182,10 @@ export async function runEvidenceExpirySweepAllOrgs(): Promise<void> {
     try {
       const { summary } = await runEvidenceExpirySweep(org.id);
       summary.notified = await notifyUnnotifiedExpiredEvidence(org.id);
-      if (summary.newly_expired > 0 || summary.notified > 0) {
+      summary.archived = await archiveExpiredEvidence(org.id);
+      if (summary.newly_expired > 0 || summary.notified > 0 || summary.archived > 0) {
         logger.info(
-          `Evidence expiry sweep org ${org.id}: newly_expired=${summary.newly_expired} notified=${summary.notified}`,
+          `Evidence expiry sweep org ${org.id}: newly_expired=${summary.newly_expired} notified=${summary.notified} archived=${summary.archived}`,
         );
       }
     } catch (error) {

--- a/Servers/services/automations/actions/evidenceExpirySweep.ts
+++ b/Servers/services/automations/actions/evidenceExpirySweep.ts
@@ -79,9 +79,7 @@ const formatExpiryDate = (value: unknown): string => {
  * expiry_notified_at only after a record's notifications succeed, so a
  * failure is retried on the next daily run.
  */
-async function notifyUnnotifiedExpiredEvidence(
-  organizationId: number,
-): Promise<number> {
+async function notifyUnnotifiedExpiredEvidence(organizationId: number): Promise<number> {
   const baseUrl = process.env.FRONTEND_URL || "http://localhost:3000";
 
   const records = (await sequelize.query(

--- a/Servers/services/automations/automationProducer.ts
+++ b/Servers/services/automations/automationProducer.ts
@@ -427,6 +427,25 @@ export async function scheduleMrmRetentionPrune() {
   );
 }
 
+export async function scheduleEvidenceExpirySweep() {
+  logger.info("Adding Evidence Hub expiry sweep job to the queue...");
+  // Daily at 4:30 AM (2/3/4 AM slots are taken by other jobs — kept distinct).
+  // Flags evidence_hub records past their expiry_date as expired and notifies.
+  // No obliterate here — the repeatable add is idempotent by repeat key.
+  await automationQueue.upsertJobScheduler(
+    "evidence_expiry_sweep",
+    { pattern: "30 4 * * *" },
+    {
+      name: "evidence_expiry_sweep",
+      data: { type: "evidence_retention" },
+      opts: {
+        removeOnComplete: true,
+        removeOnFail: false,
+      },
+    },
+  );
+}
+
 export async function scheduleAiTrustIndexSync() {
   logger.info("Adding AI Trust Index weekly sync job to the queue...");
   // Monday 06:00 UTC. jobId keyed weekly is set at runtime is not needed here;

--- a/Servers/services/automations/automationWorker.ts
+++ b/Servers/services/automations/automationWorker.ts
@@ -25,6 +25,7 @@ import { processScheduledAiDetectionScans } from "../aiDetection/scheduledScanPr
 import { syncAiTrustIndex } from "./actions/syncAiTrustIndex";
 import { runRevalidationSweepAllOrgs } from "./actions/mrmRevalidationSweep";
 import { runRetentionPruneAllOrgs } from "./actions/mrmRetentionPrune";
+import { runEvidenceExpirySweepAllOrgs } from "./actions/evidenceExpirySweep";
 // AI Gateway budget/risk jobs — call AIGateway HTTP endpoints via internal API
 const AI_GATEWAY_URL = process.env.AI_GATEWAY_URL || "http://127.0.0.1:8100";
 const AI_GATEWAY_KEY = process.env.AI_GATEWAY_INTERNAL_KEY || "";
@@ -683,6 +684,8 @@ export const createAutomationWorker = () => {
           await runRevalidationSweepAllOrgs();
         } else if (name === "mrm_retention_prune") {
           await runRetentionPruneAllOrgs();
+        } else if (name === "evidence_expiry_sweep") {
+          await runEvidenceExpirySweepAllOrgs();
         } else if (name === "mcp_audit_cleanup") {
           try {
             const [auditResult, approvalResult] = await Promise.all([

--- a/Servers/services/automations/tests/automationProducer.spec.ts
+++ b/Servers/services/automations/tests/automationProducer.spec.ts
@@ -41,6 +41,7 @@ import {
   scheduleAiGatewayRiskDetection,
   scheduleAiGatewayCacheCleanup,
   scheduleMcpGatewayCleanup,
+  scheduleEvidenceExpirySweep,
 } from "../automationProducer";
 
 const mockAdd = automationQueue.add as jest.MockedFunction<typeof automationQueue.add>;
@@ -198,6 +199,15 @@ describe("automationProducer", () => {
       await scheduleMcpGatewayCleanup();
 
       expectSchedulerCall("mcp_audit_cleanup", { type: "mcp_gateway" }, "0 3 * * *");
+    });
+  });
+
+  describe("scheduleEvidenceExpirySweep", () => {
+    it("should add a repeating job at 4:30 AM daily without obliterating", async () => {
+      await scheduleEvidenceExpirySweep();
+
+      expect(mockObliterate).not.toHaveBeenCalled();
+      expectSchedulerCall("evidence_expiry_sweep", { type: "evidence_retention" }, "30 4 * * *");
     });
   });
 });

--- a/Servers/services/inAppNotification.service.ts
+++ b/Servers/services/inAppNotification.service.ts
@@ -40,6 +40,8 @@ const buildEntityUrl = (entityType: NotificationEntityType, entityId: number): s
       return `/project-view?projectId=${entityId}`;
     case NotificationEntityType.FILE:
       return `/file-manager?fileId=${entityId}`;
+    case NotificationEntityType.EVIDENCE:
+      return `/model-inventory/evidence-hub?evidenceId=${entityId}`;
     case NotificationEntityType.SHADOW_AI_TOOL:
       return `/shadow-ai/tools/${entityId}`;
     case NotificationEntityType.AI_GATEWAY:
@@ -942,6 +944,47 @@ export const notifyPolicyDueSoon = async (
         project_name: policy.projectName,
         due_date: policy.dueDate,
         policy_url: `${baseUrl}${buildEntityUrl(NotificationEntityType.POLICY, policy.id)}`,
+      },
+    },
+  );
+};
+
+/**
+ * Notify evidence expired (Evidence Hub retention sweep)
+ */
+export const notifyEvidenceExpired = async (
+  organizationId: number,
+  recipientId: number,
+  evidence: {
+    id: number;
+    name: string;
+    expiryDate: string;
+  },
+  baseUrl: string,
+): Promise<void> => {
+  const recipient = await getUserById(recipientId);
+
+  await sendInAppNotification(
+    organizationId,
+    {
+      user_id: recipientId,
+      type: NotificationType.EVIDENCE_EXPIRED,
+      title: "Evidence expired",
+      message: `Evidence "${evidence.name}" expired on ${evidence.expiryDate}`,
+      entity_type: NotificationEntityType.EVIDENCE,
+      entity_id: evidence.id,
+      entity_name: evidence.name,
+      action_url: buildEntityUrl(NotificationEntityType.EVIDENCE, evidence.id),
+    },
+    true,
+    {
+      template: EMAIL_TEMPLATES.EVIDENCE_EXPIRED,
+      subject: `Evidence expired: ${evidence.name}`,
+      variables: {
+        recipient_name: recipient ? `${recipient.name}` : "there",
+        evidence_name: evidence.name,
+        expiry_date: evidence.expiryDate,
+        evidence_url: `${baseUrl}${buildEntityUrl(NotificationEntityType.EVIDENCE, evidence.id)}`,
       },
     },
   );

--- a/Servers/swagger.yaml
+++ b/Servers/swagger.yaml
@@ -17129,6 +17129,14 @@ paths:
       security:
         -
           bearerAuth: []
+      parameters:
+        -
+          name: includeArchived
+          in: query
+          required: false
+          description: 'Include archived (soft-archived expired) records. Default false.'
+          schema:
+            type: boolean
       responses:
         '200':
           description: Success
@@ -17152,6 +17160,53 @@ paths:
       responses:
         '201':
           description: 'Created successfully'
+        '401':
+          description: Unauthorized
+        '500':
+          description: 'Internal server error'
+  /evidenceHub/settings:
+    get:
+      tags:
+        - Evidence
+      summary: 'Get Evidence Hub Org Settings'
+      description: 'Org-level Evidence Hub retention settings. A missing settings row resolves to defaults (no default retention period, archival off).'
+      operationId: getEvidenceHubSettings
+      security:
+        -
+          bearerAuth: []
+      responses:
+        '200':
+          description: Success
+        '401':
+          description: Unauthorized
+        '500':
+          description: 'Internal server error'
+    put:
+      tags:
+        - Evidence
+      summary: 'Update Evidence Hub Org Settings'
+      description: 'PARTIAL update. default_retention_period: one of 30_days, 90_days, 6_months, 1_year, 3_years, 5_years, 7_years, indefinite, or null to clear. archive_on_expiry only takes effect when the server also sets EVIDENCE_RETENTION_ARCHIVE_ENABLED=true; archival is a soft archive, never a delete.'
+      operationId: updateEvidenceHubSettings
+      security:
+        -
+          bearerAuth: []
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                default_retention_period:
+                  type: string
+                  nullable: true
+                  enum: [30_days, 90_days, 6_months, 1_year, 3_years, 5_years, 7_years, indefinite]
+                archive_on_expiry:
+                  type: boolean
+      responses:
+        '200':
+          description: Success
+        '400':
+          description: 'Bad request'
         '401':
           description: Unauthorized
         '500':

--- a/Servers/swagger.yaml
+++ b/Servers/swagger.yaml
@@ -17120,6 +17120,53 @@ paths:
           description: Unauthorized
         '500':
           description: 'Internal server error'
+  /evidenceHub/settings:
+    get:
+      tags:
+        - Evidence
+      summary: 'Get Evidence Hub Org Settings'
+      description: 'Org-level Evidence Hub retention settings. A missing settings row resolves to defaults (no default retention period, archival off).'
+      operationId: getEvidenceHubSettingsHandler
+      security:
+        -
+          bearerAuth: []
+      responses:
+        '200':
+          description: Success
+        '401':
+          description: Unauthorized
+        '500':
+          description: 'Internal server error'
+    put:
+      tags:
+        - Evidence
+      summary: 'Update Evidence Hub Org Settings'
+      description: 'PARTIAL update. default_retention_period: one of 30_days, 90_days, 6_months, 1_year, 3_years, 5_years, 7_years, indefinite, or null to clear. archive_on_expiry only takes effect when the server also sets EVIDENCE_RETENTION_ARCHIVE_ENABLED=true; archival is a soft archive, never a delete.'
+      operationId: updateEvidenceHubSettingsHandler
+      security:
+        -
+          bearerAuth: []
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                default_retention_period:
+                  type: string
+                  nullable: true
+                  enum: [30_days, 90_days, 6_months, 1_year, 3_years, 5_years, 7_years, indefinite]
+                archive_on_expiry:
+                  type: boolean
+      responses:
+        '200':
+          description: Success
+        '400':
+          description: 'Bad request'
+        '401':
+          description: Unauthorized
+        '500':
+          description: 'Internal server error'
   /evidenceHub:
     get:
       tags:
@@ -17160,53 +17207,6 @@ paths:
       responses:
         '201':
           description: 'Created successfully'
-        '401':
-          description: Unauthorized
-        '500':
-          description: 'Internal server error'
-  /evidenceHub/settings:
-    get:
-      tags:
-        - Evidence
-      summary: 'Get Evidence Hub Org Settings'
-      description: 'Org-level Evidence Hub retention settings. A missing settings row resolves to defaults (no default retention period, archival off).'
-      operationId: getEvidenceHubSettings
-      security:
-        -
-          bearerAuth: []
-      responses:
-        '200':
-          description: Success
-        '401':
-          description: Unauthorized
-        '500':
-          description: 'Internal server error'
-    put:
-      tags:
-        - Evidence
-      summary: 'Update Evidence Hub Org Settings'
-      description: 'PARTIAL update. default_retention_period: one of 30_days, 90_days, 6_months, 1_year, 3_years, 5_years, 7_years, indefinite, or null to clear. archive_on_expiry only takes effect when the server also sets EVIDENCE_RETENTION_ARCHIVE_ENABLED=true; archival is a soft archive, never a delete.'
-      operationId: updateEvidenceHubSettings
-      security:
-        -
-          bearerAuth: []
-      requestBody:
-        content:
-          application/json:
-            schema:
-              type: object
-              properties:
-                default_retention_period:
-                  type: string
-                  nullable: true
-                  enum: [30_days, 90_days, 6_months, 1_year, 3_years, 5_years, 7_years, indefinite]
-                archive_on_expiry:
-                  type: boolean
-      responses:
-        '200':
-          description: Success
-        '400':
-          description: 'Bad request'
         '401':
           description: Unauthorized
         '500':

--- a/Servers/templates/evidence-expired.mjml
+++ b/Servers/templates/evidence-expired.mjml
@@ -1,0 +1,46 @@
+<mjml>
+<mj-head>
+  <mj-font name="Inter" href="https://fonts.googleapis.com/css?family=Inter:400,500,600"></mj-font>
+  <mj-attributes>
+    <mj-all font-family="Geist, Inter, system-ui, -apple-system, BlinkMacSystemFont, Helvetica, Arial, sans-serif" color="#344054"></mj-all>
+    <mj-text font-size="15px" line-height="24px" color="#344054" padding="0"></mj-text>
+    <mj-section padding="0px"></mj-section>
+    <mj-column padding="0px"></mj-column>
+    <mj-button background-color="#13715B" color="#ffffff" border-radius="4px" font-size="14px" font-weight="500" padding="0" height="44px"></mj-button>
+  </mj-attributes>
+  <mj-style inline="inline">
+    .email-card { background-color: #ffffff; border: 1px solid #eaecf0; border-radius: 10px; overflow: hidden; }
+    .email-heading { color: #1c2130; font-size: 22px; font-weight: 600; line-height: 1.35; margin: 0 0 24px 0; letter-spacing: -0.2px; }
+    .email-body { color: #344054; font-size: 15px; line-height: 24px; margin: 0 0 20px 0; }
+    .email-footer { color: #838c99; font-size: 13px; line-height: 20px; text-align: center; }
+    a { color: #13715B; text-decoration: none; }
+    .btn { display: inline-block; padding: 12px 24px; border-radius: 4px; text-decoration: none; font-size: 14px; font-weight: 500; color: #ffffff; }
+    .btn-info { background-color: #1565C0; }
+  </mj-style>
+</mj-head>
+  <mj-body background-color="#f4f6f8">
+    <mj-section padding="32px 20px 20px">
+      <mj-column width="100%">
+        <mj-text align="center" padding="0 0 24px 0">
+          <span style="color: #13715B; font-size: 22px; font-weight: 600; letter-spacing: -0.5px;">VerifyWise</span>
+        </mj-text>
+      </mj-column>
+    </mj-section>
+    <mj-wrapper css-class="email-card" padding="40px">
+      <mj-section>
+        <mj-column width="100%">
+          <mj-text>
+                <h2 class="email-heading">Evidence "{{evidence_name}}" has expired</h2><p class="email-body">Hi {{recipient_name}},</p><p class="email-body">The evidence <strong>{{evidence_name}}</strong> passed its expiry date on <strong>{{expiry_date}}</strong> and has been flagged as expired in the Evidence Hub.</p><p class="email-body"><strong>Recommended next steps:</strong></p><ul><li>Review the evidence and upload a refreshed version, or</li><li>Extend the expiry date / update the retention policy if still valid</li></ul><p style="margin: 28px 0 24px 0;"><a href="{{evidence_url}}" class="btn btn-info">Open Evidence Hub</a></p>
+          </mj-text>
+        </mj-column>
+      </mj-section>
+    </mj-wrapper>
+    <mj-section padding="32px 20px">
+      <mj-column width="100%">
+        <mj-text css-class="email-footer" align="center">
+          Sent with care from VerifyWise
+        </mj-text>
+      </mj-column>
+    </mj-section>
+  </mj-body>
+</mjml>

--- a/Servers/tests/integration/tenant-isolation/evidence-hub-retention.isolation.test.ts
+++ b/Servers/tests/integration/tenant-isolation/evidence-hub-retention.isolation.test.ts
@@ -1,0 +1,92 @@
+jest.setTimeout(60000);
+
+import { cleanupDatabase } from "../helpers";
+import { sequelize } from "../../../database/db";
+import { QueryTypes } from "sequelize";
+import { seedTwoTenantContexts } from "./tenantIsolation.harness";
+import { createTestEvidenceHub } from "../../factories";
+import { runEvidenceExpirySweep } from "../../../services/automations/actions/evidenceExpirySweep";
+import {
+  getEvidenceHubOrgSettings,
+  upsertEvidenceHubOrgSettings,
+} from "../../../utils/evidenceHubSettings.utils";
+
+/**
+ * Evidence Hub retention — tenant isolation.
+ *
+ * Org settings (default retention period, archival opt-in) must be scoped to
+ * the caller's org with a defaults fallback, and the daily expiry sweep for
+ * one org must never flag another org's evidence.
+ */
+
+describe("Evidence Hub retention tenant isolation", () => {
+  afterEach(async () => {
+    await cleanupDatabase();
+  });
+
+  it("returns defaults when no settings row exists and scopes upserts per org", async () => {
+    const { owner, attacker } = await seedTwoTenantContexts();
+
+    const before = await getEvidenceHubOrgSettings(owner.orgId);
+    expect(before.default_retention_period).toBeNull();
+    expect(before.archive_on_expiry).toBe(false);
+
+    await upsertEvidenceHubOrgSettings(owner.orgId, { default_retention_period: "1_year" });
+    const ownerAfter = await getEvidenceHubOrgSettings(owner.orgId);
+    expect(ownerAfter.default_retention_period).toBe("1_year");
+
+    // The other org still sees defaults — settings are org-scoped.
+    const attackerView = await getEvidenceHubOrgSettings(attacker.orgId);
+    expect(attackerView.default_retention_period).toBeNull();
+    expect(attackerView.archive_on_expiry).toBe(false);
+
+    // A partial update never touches unset fields.
+    await upsertEvidenceHubOrgSettings(owner.orgId, { archive_on_expiry: true });
+    const partial = await getEvidenceHubOrgSettings(owner.orgId);
+    expect(partial.default_retention_period).toBe("1_year");
+    expect(partial.archive_on_expiry).toBe(true);
+  });
+
+  it("scopes the settings endpoints to the caller's org", async () => {
+    const { owner, attacker } = await seedTwoTenantContexts();
+    await upsertEvidenceHubOrgSettings(owner.orgId, { default_retention_period: "90_days" });
+
+    // The attacker sees their own (default) settings, not the owner's.
+    const attackerGet = await attacker.request.get("/api/evidenceHub/settings");
+    expect(attackerGet.status).toBe(200);
+    const attackerSettings = attackerGet.body?.data ?? attackerGet.body;
+    expect(attackerSettings.default_retention_period).toBeNull();
+
+    // The attacker's write lands on their own org and leaves the owner's intact.
+    const attackerPut = await attacker.request
+      .put("/api/evidenceHub/settings")
+      .send({ default_retention_period: "7_years" });
+    expect(attackerPut.status).toBe(200);
+
+    const ownerAfter = await getEvidenceHubOrgSettings(owner.orgId);
+    expect(ownerAfter.default_retention_period).toBe("90_days");
+  });
+
+  it("org A's expiry sweep never flags org B's evidence", async () => {
+    const { owner, attacker } = await seedTwoTenantContexts();
+    const ownerExpired = await createTestEvidenceHub(owner.orgId);
+    const attackerExpired = await createTestEvidenceHub(attacker.orgId);
+    await sequelize.query(
+      `UPDATE evidence_hub
+          SET expiry_date = now() - interval '1 day'
+        WHERE id IN (:ownerId, :attackerId)`,
+      { replacements: { ownerId: ownerExpired, attackerId: attackerExpired } },
+    );
+
+    const { summary } = await runEvidenceExpirySweep(owner.orgId);
+    expect(summary.newly_expired).toBe(1);
+
+    const rows = (await sequelize.query(`SELECT id, expired_at FROM evidence_hub ORDER BY id`, {
+      type: QueryTypes.SELECT,
+    })) as { id: number; expired_at: string | null }[];
+    const ownerRow = rows.find((r) => r.id === ownerExpired);
+    const attackerRow = rows.find((r) => r.id === attackerExpired);
+    expect(ownerRow?.expired_at).not.toBeNull();
+    expect(attackerRow?.expired_at).toBeNull();
+  });
+});

--- a/Servers/tests/integration/tenant-isolation/tenantIsolation.registry.ts
+++ b/Servers/tests/integration/tenant-isolation/tenantIsolation.registry.ts
@@ -78,6 +78,11 @@ export const tenantIsolationRegistry: IsolationEntity[] = [
     baseRoute: "/api/evidenceHub",
   },
   {
+    name: "evidence_hub_org_settings",
+    tables: ["evidence_hub_org_settings"],
+    baseRoute: "/api/evidenceHub/settings",
+  },
+  {
     name: "audit_ledger",
     tables: ["audit_ledger"],
     baseRoute: "/api/audit-ledger",

--- a/Servers/utils/__tests__/evidenceRetention.utils.test.ts
+++ b/Servers/utils/__tests__/evidenceRetention.utils.test.ts
@@ -1,0 +1,81 @@
+import { computeExpiryDate, resolveEvidenceExpiryDate } from "../evidenceRetention.utils";
+import { getEvidenceHubOrgSettings } from "../evidenceHubSettings.utils";
+
+jest.mock("../evidenceHubSettings.utils", () => ({
+  getEvidenceHubOrgSettings: jest.fn(),
+}));
+
+const mockGetSettings = getEvidenceHubOrgSettings as jest.Mock;
+
+const BASE = new Date("2026-01-15T12:00:00.000Z");
+
+describe("computeExpiryDate", () => {
+  it("adds day-based periods", () => {
+    expect(computeExpiryDate("30_days", BASE)?.toISOString()).toBe("2026-02-14T12:00:00.000Z");
+    expect(computeExpiryDate("90_days", BASE)?.toISOString()).toBe("2026-04-15T12:00:00.000Z");
+  });
+
+  it("adds month-based periods", () => {
+    expect(computeExpiryDate("6_months", BASE)?.toISOString()).toBe("2026-07-15T12:00:00.000Z");
+    expect(computeExpiryDate("1_year", BASE)?.toISOString()).toBe("2027-01-15T12:00:00.000Z");
+    expect(computeExpiryDate("7_years", BASE)?.toISOString()).toBe("2033-01-15T12:00:00.000Z");
+  });
+
+  it("treats indefinite, null, undefined, and unknown values as no expiry", () => {
+    expect(computeExpiryDate("indefinite", BASE)).toBeNull();
+    expect(computeExpiryDate(null, BASE)).toBeNull();
+    expect(computeExpiryDate(undefined, BASE)).toBeNull();
+    expect(computeExpiryDate("not_a_period", BASE)).toBeNull();
+  });
+
+  it("does not mutate the base date", () => {
+    const base = new Date(BASE);
+    computeExpiryDate("1_year", base);
+    expect(base.toISOString()).toBe(BASE.toISOString());
+  });
+});
+
+describe("resolveEvidenceExpiryDate", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockGetSettings.mockResolvedValue({
+      organization_id: 1,
+      default_retention_period: "1_year",
+      archive_on_expiry: false,
+    });
+  });
+
+  it("explicit expiry_date always wins and never reads org settings", async () => {
+    const result = await resolveEvidenceExpiryDate(1, "2030-06-01", "30_days", BASE);
+    expect(result?.toISOString()).toBe("2030-06-01T00:00:00.000Z");
+    expect(mockGetSettings).not.toHaveBeenCalled();
+  });
+
+  it("falls back to the per-evidence retention policy", async () => {
+    const result = await resolveEvidenceExpiryDate(1, null, "90_days", BASE);
+    expect(result?.toISOString()).toBe("2026-04-15T12:00:00.000Z");
+    expect(mockGetSettings).not.toHaveBeenCalled();
+  });
+
+  it("falls back to the org default when no policy is given", async () => {
+    const result = await resolveEvidenceExpiryDate(1, null, null, BASE);
+    expect(result?.toISOString()).toBe("2027-01-15T12:00:00.000Z");
+  });
+
+  it("returns null when neither policy nor org default exists", async () => {
+    mockGetSettings.mockResolvedValue({
+      organization_id: 1,
+      default_retention_period: null,
+      archive_on_expiry: false,
+    });
+    expect(await resolveEvidenceExpiryDate(1, null, null, BASE)).toBeNull();
+  });
+
+  it("treats an invalid explicit expiry as no expiry rather than erroring", async () => {
+    expect(await resolveEvidenceExpiryDate(1, "not-a-date", "30_days", BASE)).toBeNull();
+  });
+
+  it("indefinite per-evidence policy overrides the org default to no expiry", async () => {
+    expect(await resolveEvidenceExpiryDate(1, null, "indefinite", BASE)).toBeNull();
+  });
+});

--- a/Servers/utils/evidenceHub.utils.ts
+++ b/Servers/utils/evidenceHub.utils.ts
@@ -7,6 +7,7 @@ import {
   createFileEntityLink,
   deleteFileEntityLink,
 } from "./files/evidenceFiles.utils";
+import { resolveEvidenceExpiryDate } from "./evidenceRetention.utils";
 
 // Helper to normalize a date value to an ISO string or null
 const toISO = (d: any): string | null => {
@@ -86,6 +87,8 @@ export const getAllEvidencesQuery = async (organizationId: number) => {
       evidence_type: record.evidence_type,
       description: record.description,
       expiry_date: toISO(record.expiry_date),
+      expired_at: toISO(record.expired_at),
+      archived_at: toISO(record.archived_at),
       mapped_model_ids: record.mapped_model_ids,
       mapped_training_ids: record.mapped_training_ids,
       tags: record.tags,
@@ -106,6 +109,8 @@ export const getAllEvidencesQuery = async (organizationId: number) => {
       evidence_type: "NIST AI RMF",
       description: record.description,
       expiry_date: null,
+      expired_at: null,
+      archived_at: null,
       mapped_model_ids: null,
       mapped_training_ids: null,
       tags: [],
@@ -153,6 +158,15 @@ export const createNewEvidenceQuery = async (
 ) => {
   const created_at = new Date();
   try {
+    // expiry_date precedence: explicit value > per-evidence retention_policy
+    // > org default retention. All-absent resolves to null = "no expiry".
+    const expiry_date = await resolveEvidenceExpiryDate(
+      organizationId,
+      evidence.expiry_date ?? null,
+      evidence.retention_policy ?? null,
+      created_at,
+    );
+
     // Insert without evidence_files (now managed via file_entity_links)
     const result = await sequelize.query(
       `INSERT INTO evidence_hub (
@@ -161,6 +175,7 @@ export const createNewEvidenceQuery = async (
                 evidence_type,
                 description,
                 expiry_date,
+                retention_policy,
                 mapped_model_ids,
                 mapped_training_ids,
                 created_at,
@@ -171,6 +186,7 @@ export const createNewEvidenceQuery = async (
                 :evidence_type,
                 :description,
                 :expiry_date,
+                :retention_policy,
                 :mapped_model_ids,
                 :mapped_training_ids,
                 :created_at,
@@ -182,7 +198,8 @@ export const createNewEvidenceQuery = async (
           evidence_name: evidence.evidence_name,
           evidence_type: evidence.evidence_type,
           description: evidence.description ?? null,
-          expiry_date: evidence.expiry_date ?? null,
+          expiry_date,
+          retention_policy: evidence.retention_policy ?? null,
           mapped_model_ids: evidence.mapped_model_ids
             ? `{${evidence.mapped_model_ids.join(",")}}`
             : null,
@@ -246,13 +263,19 @@ export const updateEvidenceByIdQuery = async (
   const updated_at = new Date();
 
   try {
-    // Update without evidence_files (now managed via file_entity_links)
+    // Update without evidence_files (now managed via file_entity_links).
+    // When expiry_date changes, clear the sweep flags so a re-dated record
+    // is un-flagged/un-archived and eligible for a fresh expiry evaluation.
     await sequelize.query(
       `UPDATE evidence_hub SET
                 evidence_name = :evidence_name,
                 evidence_type = :evidence_type,
                 description = :description,
                 expiry_date = :expiry_date,
+                retention_policy = :retention_policy,
+                expired_at = CASE WHEN expiry_date IS DISTINCT FROM :expiry_date THEN NULL ELSE expired_at END,
+                expiry_notified_at = CASE WHEN expiry_date IS DISTINCT FROM :expiry_date THEN NULL ELSE expiry_notified_at END,
+                archived_at = CASE WHEN expiry_date IS DISTINCT FROM :expiry_date THEN NULL ELSE archived_at END,
                 mapped_model_ids = :mapped_model_ids,
                 mapped_training_ids = :mapped_training_ids,
                 updated_at = :updated_at
@@ -264,7 +287,8 @@ export const updateEvidenceByIdQuery = async (
           evidence_name: evidence.evidence_name,
           evidence_type: evidence.evidence_type,
           description: evidence.description,
-          expiry_date: evidence.expiry_date,
+          expiry_date: evidence.expiry_date ?? null,
+          retention_policy: evidence.retention_policy ?? null,
           mapped_model_ids: evidence.mapped_model_ids
             ? `{${evidence.mapped_model_ids.join(",")}}`
             : null,

--- a/Servers/utils/evidenceHub.utils.ts
+++ b/Servers/utils/evidenceHub.utils.ts
@@ -17,12 +17,20 @@ const toISO = (d: any): string | null => {
 };
 
 // Get all evidences (includes evidence_hub records + NIST AI RMF virtual records)
-export const getAllEvidencesQuery = async (organizationId: number) => {
+// Archived records (archived_at set by the retention sweep) are hidden unless
+// includeArchived is true. NIST virtual records are never archived.
+export const getAllEvidencesQuery = async (
+  organizationId: number,
+  includeArchived: boolean = false,
+) => {
   // 1. Fetch evidence_hub records as plain objects
   const evidenceHubRecords = (await sequelize.query(
-    `SELECT * FROM evidence_hub WHERE organization_id = :organizationId ORDER BY created_at DESC, id ASC`,
+    `SELECT * FROM evidence_hub
+      WHERE organization_id = :organizationId
+        AND (:includeArchived OR archived_at IS NULL)
+      ORDER BY created_at DESC, id ASC`,
     {
-      replacements: { organizationId },
+      replacements: { organizationId, includeArchived },
       type: QueryTypes.SELECT,
     },
   )) as any[];

--- a/Servers/utils/evidenceHubSettings.utils.ts
+++ b/Servers/utils/evidenceHubSettings.utils.ts
@@ -1,0 +1,39 @@
+import { QueryTypes } from "sequelize";
+import { sequelize } from "../database/db";
+
+/**
+ * Evidence Hub org-wide settings (evidence_hub_org_settings). One row per
+ * org, lazily created — a missing row means defaults. Follows the
+ * mrm_org_settings pattern (see utils/mrmSettings.utils.ts).
+ */
+
+export interface EvidenceHubOrgSettings {
+  organization_id: number;
+  default_retention_period: string | null;
+  archive_on_expiry: boolean;
+}
+
+export const DEFAULT_EVIDENCE_HUB_ORG_SETTINGS: Omit<
+  EvidenceHubOrgSettings,
+  "organization_id"
+> = {
+  default_retention_period: null, // no org-level default retention
+  archive_on_expiry: false, // archival is opt-in, never on by default
+};
+
+/** Read the org's Evidence Hub settings; a missing row resolves to defaults. */
+export const getEvidenceHubOrgSettings = async (
+  organizationId: number,
+): Promise<EvidenceHubOrgSettings> => {
+  const rows = (await sequelize.query(
+    `SELECT organization_id, default_retention_period, archive_on_expiry
+       FROM evidence_hub_org_settings
+      WHERE organization_id = :organizationId
+      LIMIT 1`,
+    {
+      replacements: { organizationId },
+      type: QueryTypes.SELECT,
+    },
+  )) as EvidenceHubOrgSettings[];
+  return rows[0] ?? { organization_id: organizationId, ...DEFAULT_EVIDENCE_HUB_ORG_SETTINGS };
+};

--- a/Servers/utils/evidenceHubSettings.utils.ts
+++ b/Servers/utils/evidenceHubSettings.utils.ts
@@ -13,10 +13,7 @@ export interface EvidenceHubOrgSettings {
   archive_on_expiry: boolean;
 }
 
-export const DEFAULT_EVIDENCE_HUB_ORG_SETTINGS: Omit<
-  EvidenceHubOrgSettings,
-  "organization_id"
-> = {
+export const DEFAULT_EVIDENCE_HUB_ORG_SETTINGS: Omit<EvidenceHubOrgSettings, "organization_id"> = {
   default_retention_period: null, // no org-level default retention
   archive_on_expiry: false, // archival is opt-in, never on by default
 };

--- a/Servers/utils/evidenceHubSettings.utils.ts
+++ b/Servers/utils/evidenceHubSettings.utils.ts
@@ -1,4 +1,4 @@
-import { QueryTypes } from "sequelize";
+import { QueryTypes, Transaction } from "sequelize";
 import { sequelize } from "../database/db";
 
 /**
@@ -21,6 +21,16 @@ export const DEFAULT_EVIDENCE_HUB_ORG_SETTINGS: Omit<
   archive_on_expiry: false, // archival is opt-in, never on by default
 };
 
+/**
+ * PARTIAL update semantics: only fields present (!== undefined) change.
+ * default_retention_period may be explicitly set to null to clear the org
+ * default, so it uses a "provided" flag instead of COALESCE.
+ */
+export interface EvidenceHubOrgSettingsUpdate {
+  default_retention_period?: string | null;
+  archive_on_expiry?: boolean;
+}
+
 /** Read the org's Evidence Hub settings; a missing row resolves to defaults. */
 export const getEvidenceHubOrgSettings = async (
   organizationId: number,
@@ -36,4 +46,44 @@ export const getEvidenceHubOrgSettings = async (
     },
   )) as EvidenceHubOrgSettings[];
   return rows[0] ?? { organization_id: organizationId, ...DEFAULT_EVIDENCE_HUB_ORG_SETTINGS };
+};
+
+/**
+ * Create-or-update the org's Evidence Hub settings row. Only fields present
+ * in `update` change; absent fields keep their current value (or the column
+ * default on first insert). Caller validates the values.
+ */
+export const upsertEvidenceHubOrgSettings = async (
+  organizationId: number,
+  update: EvidenceHubOrgSettingsUpdate,
+  transaction?: Transaction,
+): Promise<EvidenceHubOrgSettings> => {
+  const rows = (await sequelize.query(
+    `INSERT INTO evidence_hub_org_settings
+       (organization_id, default_retention_period, archive_on_expiry)
+     VALUES
+       (:organizationId,
+        :defaultRetentionPeriod,
+        COALESCE(:archiveOnExpiry, false))
+     ON CONFLICT (organization_id)
+     DO UPDATE SET
+       default_retention_period = CASE
+         WHEN :defaultRetentionProvided THEN :defaultRetentionPeriod
+         ELSE evidence_hub_org_settings.default_retention_period
+       END,
+       archive_on_expiry = COALESCE(:archiveOnExpiry, evidence_hub_org_settings.archive_on_expiry),
+       updated_at = now()
+     RETURNING organization_id, default_retention_period, archive_on_expiry`,
+    {
+      replacements: {
+        organizationId,
+        defaultRetentionProvided: update.default_retention_period !== undefined,
+        defaultRetentionPeriod: update.default_retention_period ?? null,
+        archiveOnExpiry: update.archive_on_expiry ?? null,
+      },
+      type: QueryTypes.SELECT,
+      transaction,
+    },
+  )) as EvidenceHubOrgSettings[];
+  return rows[0];
 };

--- a/Servers/utils/evidenceRetention.utils.ts
+++ b/Servers/utils/evidenceRetention.utils.ts
@@ -1,0 +1,81 @@
+import { getEvidenceHubOrgSettings } from "./evidenceHubSettings.utils";
+
+/**
+ * Evidence Hub retention periods — mirrors the RETENTION_OPTIONS enum in
+ * Clients/src/presentation/components/Modals/EvidenceHub/index.tsx.
+ */
+export const EVIDENCE_RETENTION_PERIODS = [
+  "30_days",
+  "90_days",
+  "6_months",
+  "1_year",
+  "3_years",
+  "5_years",
+  "7_years",
+  "indefinite",
+] as const;
+
+export type EvidenceRetentionPeriod = (typeof EVIDENCE_RETENTION_PERIODS)[number];
+
+const RETENTION_DAYS: Partial<Record<EvidenceRetentionPeriod, number>> = {
+  "30_days": 30,
+  "90_days": 90,
+};
+
+const RETENTION_MONTHS: Partial<Record<EvidenceRetentionPeriod, number>> = {
+  "6_months": 6,
+  "1_year": 12,
+  "3_years": 36,
+  "5_years": 60,
+  "7_years": 84,
+};
+
+/**
+ * Compute the expiry date for a retention period relative to baseDate.
+ * "indefinite", null/undefined, and unrecognized values all mean "no
+ * expiry" and return null — never an error, never already-expired.
+ */
+export const computeExpiryDate = (
+  retentionPeriod: string | null | undefined,
+  baseDate: Date = new Date(),
+): Date | null => {
+  if (!retentionPeriod || retentionPeriod === "indefinite") return null;
+
+  const days = RETENTION_DAYS[retentionPeriod as EvidenceRetentionPeriod];
+  if (days !== undefined) {
+    const expiry = new Date(baseDate);
+    expiry.setDate(expiry.getDate() + days);
+    return expiry;
+  }
+
+  const months = RETENTION_MONTHS[retentionPeriod as EvidenceRetentionPeriod];
+  if (months !== undefined) {
+    const expiry = new Date(baseDate);
+    expiry.setMonth(expiry.getMonth() + months);
+    return expiry;
+  }
+
+  return null;
+};
+
+/**
+ * Resolve the expiry date for an evidence record. Precedence:
+ *   explicit expiry_date > per-evidence retention_policy > org default > null
+ * A null result means "no expiry" and is valid everywhere downstream.
+ */
+export const resolveEvidenceExpiryDate = async (
+  organizationId: number,
+  explicitExpiryDate: Date | string | null | undefined,
+  retentionPolicy: string | null | undefined,
+  baseDate: Date = new Date(),
+): Promise<Date | null> => {
+  if (explicitExpiryDate) {
+    const parsed = new Date(explicitExpiryDate);
+    return isNaN(parsed.getTime()) ? null : parsed;
+  }
+
+  const period =
+    retentionPolicy ??
+    (await getEvidenceHubOrgSettings(organizationId)).default_retention_period;
+  return computeExpiryDate(period, baseDate);
+};

--- a/Servers/utils/evidenceRetention.utils.ts
+++ b/Servers/utils/evidenceRetention.utils.ts
@@ -75,7 +75,6 @@ export const resolveEvidenceExpiryDate = async (
   }
 
   const period =
-    retentionPolicy ??
-    (await getEvidenceHubOrgSettings(organizationId)).default_retention_period;
+    retentionPolicy ?? (await getEvidenceHubOrgSettings(organizationId)).default_retention_period;
   return computeExpiryDate(period, baseDate);
 };

--- a/docs/api-docs/src/config/endpoints.ts
+++ b/docs/api-docs/src/config/endpoints.ts
@@ -3227,9 +3227,43 @@ export const evidenceAiEndpoints: Endpoint[] = [
 export const evidenceHubEndpoints: Endpoint[] = [
   {
     method: 'GET',
+    path: '/evidenceHub/settings',
+    summary: "Get Evidence Hub Org Settings",
+    description: "Org-level Evidence Hub retention settings. A missing settings row resolves to defaults (no default retention period, archival off).",
+    requiresAuth: true,
+    responses: [
+      { status: 200, description: "Success" },
+      { status: 401, description: "Unauthorized" },
+      { status: 500, description: "Internal server error" },
+    ],
+    tag: "Evidence",
+  },
+  {
+    method: 'PUT',
+    path: '/evidenceHub/settings',
+    summary: "Update Evidence Hub Org Settings",
+    description: "PARTIAL update. default_retention_period: one of 30_days, 90_days, 6_months, 1_year, 3_years, 5_years, 7_years, indefinite, or null to clear. archive_on_expiry only takes effect when the server also sets EVIDENCE_RETENTION_ARCHIVE_ENABLED=true; archival is a soft archive, never a delete.",
+    requiresAuth: true,
+    requestBody: {
+      "default_retention_period": "30_days | 90_days | 6_months | 1_year | 3_years | 5_years | 7_years | indefinite (optional, nullable)",
+      "archive_on_expiry": "boolean (optional)",
+    },
+    responses: [
+      { status: 200, description: "Success" },
+      { status: 400, description: "Bad request" },
+      { status: 401, description: "Unauthorized" },
+      { status: 500, description: "Internal server error" },
+    ],
+    tag: "Evidence",
+  },
+  {
+    method: 'GET',
     path: '/evidenceHub',
     summary: "Get All Evidences",
     requiresAuth: true,
+    parameters: [
+      { name: 'includeArchived', in: 'query', type: 'boolean', required: false, description: "Include archived (soft-archived expired) records. Default false." },
+    ],
     responses: [
       { status: 200, description: "Success" },
       { status: 401, description: "Unauthorized" },


### PR DESCRIPTION
## Describe your changes

Adds a configurable retention policy for Evidence Hub records: an org level default and per evidence override compute expiry dates, and a daily BullMQ sweep flags expired records and notifies the reviewer or org admins. Soft archival of expired evidence is available behind explicit env and org opt ins, with expired and expiring soon indicators in the Evidence Hub list.

Fixes #4582 

## Please ensure all items are checked off before requesting a review:

- [x] I deployed the code locally.
- [x] I have performed a self-review of my code.
- [x] I have included the issue # in the PR.
- [x] I have labelled the PR correctly.
- [x] The issue I am working on is assigned to me.
- [x] I have avoided using hardcoded values to ensure scalability and maintain consistency across the application.
- [x] I have ensured that font sizes, color choices, and other UI elements are referenced from the theme.
- [x] My pull request is focused and addresses a single, specific feature.
- [ ] If there are UI changes, I have attached a screenshot or video to this PR.
- [ ] If I added or modified an API endpoint, the change is reflected in the generated OpenAPI spec (`npm run generate:swagger`).
- [ ] If the endpoint requires authentication, it uses `authenticateJWT` and the generated spec declares `bearerAuth` security.
- [ ] I ran `npm run check:api-drift` and committed the regenerated `swagger.yaml` and `endpoints.ts`.
- [ ] If this PR adds or modifies an organization-scoped table, the [tenant isolation registry](Servers/tests/integration/tenant-isolation/tenantIsolation.registry.ts) and [test matrix](Servers/tests/integration/tenant-isolation) are updated. See the [tenant isolation runbook](docs/technical/security/tenant-isolation.md) for details.
