### PR TITLE
refactor(ui): format dashboard and table dates with useFormattedDate

### DIFF
--- a/Clients/src/presentation/components/EvidenceAnalysisPanel/index.tsx
+++ b/Clients/src/presentation/components/EvidenceAnalysisPanel/index.tsx
@@ -32,6 +32,7 @@ import {
   background,
 } from "../../themes/palette";
 import { getGradeColor, getGradeLabel, type QualityGrade } from "../EvidenceQualityBadge";
+import useFormattedDate from "../../../application/hooks/useFormattedDate";
 
 interface QualityScore {
   relevance: QualityGrade | null;
@@ -217,6 +218,7 @@ export default function EvidenceAnalysisPanel({
   hasLLMKey,
 }: EvidenceAnalysisPanelProps) {
   const theme = useTheme();
+  const formatDate = useFormattedDate();
 
   if (isLoading) {
     // Content shape is known (hero + 5-dimension grid), so skeleton loaders
@@ -696,7 +698,7 @@ export default function EvidenceAnalysisPanel({
       <Box sx={{ pt: "12px", borderTop: `1px solid ${borderPalette.light}` }}>
         <Typography sx={{ fontSize: 11, color: textColors.accent }}>
           Analyzed by {analysis.analysis_model} (v{analysis.analysis_version}) ·{" "}
-          {new Date(analysis.analyzed_at).toLocaleString()}
+          {formatDate(new Date(analysis.analyzed_at), { includeTime: true })}
           {auditMetadata?.analyzer_version ? ` · ${auditMetadata.analyzer_version}` : ""}
         </Typography>
       </Box>

--- a/Clients/src/presentation/components/ReportAnalysisPanel/index.tsx
+++ b/Clients/src/presentation/components/ReportAnalysisPanel/index.tsx
@@ -16,6 +16,7 @@ import type {
   SectionSummariesPayload,
   VendorRiskPayload,
 } from "../../../domain/interfaces/i.reporting";
+import useFormattedDate from "../../../application/hooks/useFormattedDate";
 
 interface ReportAnalysisPanelProps {
   /** Rows from GET /reporting/runs/:id/analyses. The caller owns the hook. */
@@ -301,6 +302,7 @@ function SummaryList({ entries }: { entries: Array<[string, string]> }) {
 
 function AnalysisCard({ analysis }: { analysis: ReportRunAnalysis }) {
   const theme = useTheme();
+  const formatDate = useFormattedDate();
   const label = SECTION_LABELS[analysis.section_key] ?? analysis.section_key;
   const abstainReason = abstainReasonOf(analysis.payload);
   const body = sectionBody(analysis.section_key, analysis.payload);
@@ -340,7 +342,7 @@ function AnalysisCard({ analysis }: { analysis: ReportRunAnalysis }) {
         <Box sx={{ pt: "12px", borderTop: `1px solid ${theme.palette.border.light}` }}>
           <Typography sx={{ fontSize: 11, color: theme.palette.text.accent, lineHeight: 1.4 }}>
             {analysis.analysis_model ?? "Model not recorded"} ·{" "}
-            {new Date(analysis.analyzed_at).toLocaleString()}
+            {formatDate(new Date(analysis.analyzed_at), { includeTime: true })}
           </Typography>
         </Box>
       </Stack>

--- a/Clients/src/presentation/pages/AIAuditDashboard/index.tsx
+++ b/Clients/src/presentation/pages/AIAuditDashboard/index.tsx
@@ -49,6 +49,7 @@ import {
 import Chip from "../../components/Chip";
 import { cardStyles, tableStyles } from "../../themes/components";
 import { useAuditLog, useAuditAnalytics } from "../../../application/hooks/useAIAudit";
+import useFormattedDate from "../../../application/hooks/useFormattedDate";
 import {
   exportAuditLog,
   getActionAuditTrail,
@@ -116,6 +117,7 @@ const ACTOR_TYPE_OPTIONS = [
 
 export default function AIAuditDashboard() {
   const theme = useTheme();
+  const formatDate = useFormattedDate();
   const [period, setPeriod] = useState("30d");
   const [actorType, setActorType] = useState<string>("all");
   const [page, setPage] = useState(0);
@@ -542,7 +544,7 @@ export default function AIAuditDashboard() {
                 (logData?.rows || []).map((row: any, i: number) => (
                   <TableRow key={row.id || i} hover sx={tableStyles.bodyRow(theme)}>
                     <TableCell sx={{ ...tableStyles.bodyCell(theme), color: textColors.secondary }}>
-                      {new Date(row.created_at).toLocaleString()}
+                      {formatDate(new Date(row.created_at), { includeTime: true })}
                     </TableCell>
                     <TableCell
                       sx={{
@@ -672,7 +674,8 @@ export default function AIAuditDashboard() {
                       )}
                     </Stack>
                     <Typography sx={{ fontSize: 11, color: textColors.secondary }}>
-                      {new Date(entry.created_at).toLocaleString()} — {entry.actor_type}
+                      {formatDate(new Date(entry.created_at), { includeTime: true })} —{" "}
+                      {entry.actor_type}
                       {entry.rule_name && ` (rule: ${entry.rule_name})`}
                     </Typography>
                   </Stack>

--- a/Clients/src/presentation/pages/AIDetection/ScanDetails/__tests__/ScanDetailsHeader.test.tsx
+++ b/Clients/src/presentation/pages/AIDetection/ScanDetails/__tests__/ScanDetailsHeader.test.tsx
@@ -1,4 +1,5 @@
-import { render, screen, fireEvent } from "@testing-library/react";
+import { screen, fireEvent } from "@testing-library/react";
+import { renderWithProviders } from "../../../../../test/renderWithProviders";
 import { ScanDetailsHeader } from "../ScanDetailsHeader";
 import type { ScanResponse, Scan } from "../../../../../domain/ai-detection/types";
 
@@ -32,7 +33,7 @@ function makeScanResponse(overrides: Partial<Scan> = {}): ScanResponse {
 describe("ScanDetailsHeader", () => {
   it("renders the repository name and back button", () => {
     const onBack = vi.fn();
-    render(
+    renderWithProviders(
       <ScanDetailsHeader
         scan={makeScanResponse()}
         onBack={onBack}
@@ -49,7 +50,7 @@ describe("ScanDetailsHeader", () => {
   });
 
   it("formats duration in minutes and seconds", () => {
-    render(
+    renderWithProviders(
       <ScanDetailsHeader
         scan={makeScanResponse({ duration_ms: 125000 })}
         onBack={vi.fn()}
@@ -64,7 +65,7 @@ describe("ScanDetailsHeader", () => {
   });
 
   it("formats duration in milliseconds when under 1 second", () => {
-    render(
+    renderWithProviders(
       <ScanDetailsHeader
         scan={makeScanResponse({ duration_ms: 500 })}
         onBack={vi.fn()}
@@ -79,7 +80,7 @@ describe("ScanDetailsHeader", () => {
   });
 
   it("shows a dash when duration is missing", () => {
-    render(
+    renderWithProviders(
       <ScanDetailsHeader
         scan={makeScanResponse({ duration_ms: undefined })}
         onBack={vi.fn()}
@@ -94,7 +95,7 @@ describe("ScanDetailsHeader", () => {
   });
 
   it("shows a Failed chip and error banner for failed scans", () => {
-    render(
+    renderWithProviders(
       <ScanDetailsHeader
         scan={makeScanResponse({ status: "failed", error_message: "Clone failed: timeout" })}
         onBack={vi.fn()}
@@ -111,7 +112,7 @@ describe("ScanDetailsHeader", () => {
   });
 
   it("shows an Incremental chip and changed files count for incremental scans", () => {
-    render(
+    renderWithProviders(
       <ScanDetailsHeader
         scan={makeScanResponse({ scan_mode: "incremental", changed_files_count: 7 })}
         onBack={vi.fn()}
@@ -130,7 +131,7 @@ describe("ScanDetailsHeader", () => {
     const onRecalculate = vi.fn();
     const onExport = vi.fn();
 
-    render(
+    renderWithProviders(
       <ScanDetailsHeader
         scan={makeScanResponse({ status: "completed" })}
         onBack={vi.fn()}
@@ -149,7 +150,7 @@ describe("ScanDetailsHeader", () => {
   });
 
   it("does not show action buttons for non-completed scans", () => {
-    render(
+    renderWithProviders(
       <ScanDetailsHeader
         scan={makeScanResponse({ status: "scanning" })}
         onBack={vi.fn()}
@@ -165,7 +166,7 @@ describe("ScanDetailsHeader", () => {
   });
 
   it("renders the RiskScoreCard for completed scans with a score", () => {
-    render(
+    renderWithProviders(
       <ScanDetailsHeader
         scan={makeScanResponse({ status: "completed", risk_score: 90, risk_score_grade: "A" })}
         onBack={vi.fn()}
@@ -180,7 +181,7 @@ describe("ScanDetailsHeader", () => {
   });
 
   it("does not render the RiskScoreCard for non-completed scans", () => {
-    render(
+    renderWithProviders(
       <ScanDetailsHeader
         scan={makeScanResponse({ status: "cancelled" })}
         onBack={vi.fn()}

--- a/Clients/src/presentation/pages/AIDetection/components/RiskScoreCard.tsx
+++ b/Clients/src/presentation/pages/AIDetection/components/RiskScoreCard.tsx
@@ -37,6 +37,7 @@ import {
   DIMENSION_ORDER,
   getGradeLabel,
 } from "../../../../domain/ai-detection/riskScoringTypes";
+import useFormattedDate from "../../../../application/hooks/useFormattedDate";
 
 // ============================================================================
 // Types
@@ -338,6 +339,7 @@ export function RiskScoreCard({
   isRecalculating = false,
 }: RiskScoreCardProps) {
   const theme = useTheme();
+  const formatDate = useFormattedDate();
 
   // Not scored yet
   if (score === null || grade === null) {
@@ -396,7 +398,9 @@ export function RiskScoreCard({
         <RiskStatCard
           title="Grade"
           value={`${grade} — ${gradeLabel}`}
-          subtitle={calculatedAt ? new Date(calculatedAt).toLocaleString() : undefined}
+          subtitle={
+            calculatedAt ? formatDate(new Date(calculatedAt), { includeTime: true }) : undefined
+          }
           Icon={Award}
           valueColor={gradeColor}
         />

--- a/Clients/src/presentation/pages/AIDetection/components/__tests__/RiskScoreCard.test.tsx
+++ b/Clients/src/presentation/pages/AIDetection/components/__tests__/RiskScoreCard.test.tsx
@@ -1,4 +1,5 @@
-import { render, screen, fireEvent } from "@testing-library/react";
+import { screen, fireEvent } from "@testing-library/react";
+import { renderWithProviders } from "../../../../../test/renderWithProviders";
 import { RiskScoreCard } from "../RiskScoreCard";
 import type { RiskScoreDetails } from "../../../../../domain/ai-detection/riskScoringTypes";
 
@@ -22,7 +23,9 @@ function makeDetails(overrides: Partial<RiskScoreDetails> = {}): RiskScoreDetail
 
 describe("RiskScoreCard", () => {
   it("shows the not-scored state when score/grade are null", () => {
-    render(<RiskScoreCard score={null} grade={null} details={null} calculatedAt={null} />);
+    renderWithProviders(
+      <RiskScoreCard score={null} grade={null} details={null} calculatedAt={null} />,
+    );
 
     expect(
       screen.getByText(/No risk score has been calculated for this scan yet/),
@@ -30,7 +33,7 @@ describe("RiskScoreCard", () => {
   });
 
   it("renders overall score, grade and dimensions-at-risk cards for a scored scan", () => {
-    render(
+    renderWithProviders(
       <RiskScoreCard
         score={82}
         grade="B"
@@ -47,7 +50,7 @@ describe("RiskScoreCard", () => {
   });
 
   it("labels moderate and high risk score bands correctly", () => {
-    const { rerender } = render(
+    const { rerender } = renderWithProviders(
       <RiskScoreCard score={65} grade="C" details={makeDetails()} calculatedAt={null} />,
     );
     expect(screen.getByText("Moderate risk")).toBeInTheDocument();
@@ -57,7 +60,9 @@ describe("RiskScoreCard", () => {
   });
 
   it("renders the dimension breakdown labels", () => {
-    render(<RiskScoreCard score={82} grade="B" details={makeDetails()} calculatedAt={null} />);
+    renderWithProviders(
+      <RiskScoreCard score={82} grade="B" details={makeDetails()} calculatedAt={null} />,
+    );
 
     expect(screen.getByText("Data sovereignty")).toBeInTheDocument();
     expect(screen.getByText("Transparency")).toBeInTheDocument();
@@ -67,7 +72,9 @@ describe("RiskScoreCard", () => {
   });
 
   it("does not render the AI analysis section when llm_enhanced is false", () => {
-    render(<RiskScoreCard score={82} grade="B" details={makeDetails()} calculatedAt={null} />);
+    renderWithProviders(
+      <RiskScoreCard score={82} grade="B" details={makeDetails()} calculatedAt={null} />,
+    );
 
     expect(screen.queryByText("AI analysis")).not.toBeInTheDocument();
   });
@@ -79,7 +86,9 @@ describe("RiskScoreCard", () => {
       llm_recommendations: ["Rotate leaked credentials", "Add **input validation**"],
     });
 
-    render(<RiskScoreCard score={55} grade="C" details={details} calculatedAt={null} />);
+    renderWithProviders(
+      <RiskScoreCard score={55} grade="C" details={details} calculatedAt={null} />,
+    );
 
     expect(screen.getByText("AI analysis")).toBeInTheDocument();
     // Recommendations are inside a Collapse that starts closed
@@ -100,7 +109,9 @@ describe("RiskScoreCard", () => {
       llm_narrative: longSentence,
     });
 
-    render(<RiskScoreCard score={55} grade="C" details={details} calculatedAt={null} />);
+    renderWithProviders(
+      <RiskScoreCard score={55} grade="C" details={details} calculatedAt={null} />,
+    );
     fireEvent.click(screen.getByText("AI analysis"));
 
     // Just verify narrative content rendered somewhere without throwing
@@ -108,7 +119,7 @@ describe("RiskScoreCard", () => {
   });
 
   it("shows a step progress dialog while recalculating", () => {
-    render(
+    renderWithProviders(
       <RiskScoreCard
         score={null}
         grade={null}

--- a/Clients/src/presentation/pages/AIGateway/MCPRuns/index.tsx
+++ b/Clients/src/presentation/pages/AIGateway/MCPRuns/index.tsx
@@ -9,6 +9,7 @@ import RunDetailDrawer from "./RunDetailDrawer";
 import palette from "../../../themes/palette";
 import { CustomizableButton } from "../../../components/button/customizable-button";
 import CustomizableSkeleton from "../../../components/Skeletons";
+import useFormattedDate from "../../../../application/hooks/useFormattedDate";
 
 interface RunRow {
   agent_run_id: string;
@@ -34,6 +35,7 @@ const COLUMNS: MCPTableColumn[] = [
 ];
 
 export default function MCPRuns() {
+  const formatDate = useFormattedDate();
   const [rows, setRows] = useState<RunRow[]>([]);
   const [loading, setLoading] = useState(true);
   const [loadError, setLoadError] = useState<string | null>(null);
@@ -94,7 +96,7 @@ export default function MCPRuns() {
               renderRow={(r) => [
                 r.agent_run_id.slice(0, 12) + "…",
                 r.agent_key_name ?? "—",
-                new Date(r.started_at).toLocaleString(),
+                formatDate(new Date(r.started_at), { includeTime: true }),
                 r.model_count,
                 r.tool_count,
                 r.denied_count || "—",

--- a/Clients/src/presentation/pages/AIObservability/index.tsx
+++ b/Clients/src/presentation/pages/AIObservability/index.tsx
@@ -38,6 +38,7 @@ import {
 } from "../../themes/palette";
 import Chip from "../../components/Chip";
 import { useTraces, useObservabilityMetrics } from "../../../application/hooks/useObservability";
+import useFormattedDate from "../../../application/hooks/useFormattedDate";
 import { getTraceDetail } from "../../../application/repository/observability.repository";
 
 // Consistent card style matching AIAuditDashboard / DashboardCard
@@ -80,6 +81,7 @@ function getStatusBg(traceStatus: string | undefined): string {
 }
 
 export default function AIObservability() {
+  const formatDate = useFormattedDate();
   const [period, setPeriod] = useState("30d");
   const [page, setPage] = useState(0);
   const [rowsPerPage, setRowsPerPage] = useState(25);
@@ -389,7 +391,9 @@ export default function AIObservability() {
                         borderBottom: `1px solid ${borderPalette.light}`,
                       }}
                     >
-                      {row.created_at ? new Date(row.created_at).toLocaleString() : "—"}
+                      {row.created_at
+                        ? formatDate(new Date(row.created_at), { includeTime: true })
+                        : "—"}
                     </TableCell>
                     <TableCell
                       sx={{

--- a/Clients/src/presentation/pages/Reporting/ReportRunsTable.tsx
+++ b/Clients/src/presentation/pages/Reporting/ReportRunsTable.tsx
@@ -38,6 +38,7 @@ import {
   useDeleteRun,
   useRunAnalyses,
 } from "../../../application/hooks/useReporting";
+import useFormattedDate from "../../../application/hooks/useFormattedDate";
 import { downloadReportRun } from "../../../application/repository/reporting.repository";
 
 const ROWS_PER_PAGE_DEFAULT = 10;
@@ -108,6 +109,7 @@ const scopeLabel = (r: any): string => {
 
 export default function ReportRunsTable({ variant }: { variant: "live" | "archived" }) {
   const theme = useTheme();
+  const formatDate = useFormattedDate();
   const [page, setPage] = useState(0);
   const [rowsPerPage, setRowsPerPage] = useState(ROWS_PER_PAGE_DEFAULT);
   // Which run's analyses the drawer is showing. null = drawer closed, which also
@@ -238,7 +240,7 @@ export default function ReportRunsTable({ variant }: { variant: "live" | "archiv
                   {scopeLabel(r)}
                 </TableCell>
                 <TableCell sx={{ ...bodyCell, color: textColors.secondary }}>
-                  {new Date(r.created_at).toLocaleString()}
+                  {formatDate(new Date(r.created_at), { includeTime: true })}
                 </TableCell>
                 <TableCell sx={{ ...bodyCell, color: textColors.secondary }}>
                   {r.triggered_by}

--- a/Clients/src/presentation/pages/Reporting/ScheduledReportsTab.tsx
+++ b/Clients/src/presentation/pages/Reporting/ScheduledReportsTab.tsx
@@ -26,6 +26,7 @@ import {
   useUpdateScheduledReport,
   useDeleteScheduledReport,
 } from "../../../application/hooks/useReporting";
+import useFormattedDate from "../../../application/hooks/useFormattedDate";
 import { showAlert } from "../../../infrastructure/api/customAxios";
 
 const FREQUENCIES = ["daily", "weekly", "monthly"];
@@ -57,6 +58,7 @@ type Draft = {
 
 export default function ScheduledReportsTab() {
   const { data: rows = [] } = useScheduledReports();
+  const formatDate = useFormattedDate();
   const runNow = useRunNow();
   const setActive = useSetActive();
   const updateReport = useUpdateScheduledReport();
@@ -133,7 +135,7 @@ export default function ScheduledReportsTab() {
                   {scopeLabel(r.scope)}
                 </TableCell>
                 <TableCell sx={{ ...bodyCell, color: textColors.secondary }}>
-                  {r.next_run_at ? new Date(r.next_run_at).toLocaleString() : "—"}
+                  {r.next_run_at ? formatDate(new Date(r.next_run_at), { includeTime: true }) : "—"}
                 </TableCell>
                 <TableCell sx={bodyCell}>
                   <Chip

--- a/Clients/src/presentation/pages/ShadowAI/RulesPage.tsx
+++ b/Clients/src/presentation/pages/ShadowAI/RulesPage.tsx
@@ -42,6 +42,7 @@ import {
   getAlertHistory,
 } from "../../../application/repository/shadowAi.repository";
 import { useAuth } from "../../../application/hooks/useAuth";
+import useFormattedDate from "../../../application/hooks/useFormattedDate";
 import {
   IShadowAiRule,
   IShadowAiAlertHistory,
@@ -94,6 +95,7 @@ const BASE_TABS = [
 export default function RulesPage() {
   const location = useLocation();
   const navigate = useNavigate();
+  const formatDate = useFormattedDate();
 
   const viewMode: ViewMode = location.pathname.includes("/rules/alerts") ? "history" : "rules";
 
@@ -560,7 +562,7 @@ export default function RulesPage() {
                       />
                     </TableCell>
                     <TableCell sx={singleTheme.tableStyles.primary.body.cell}>
-                      {a.fired_at ? new Date(a.fired_at).toLocaleString() : "—"}
+                      {a.fired_at ? formatDate(new Date(a.fired_at), { includeTime: true }) : "—"}
                     </TableCell>
                   </TableRow>
                 ))}


### PR DESCRIPTION

## Describe your changes

- Replace leftover toLocaleString() dates on dashboards and analysis panels with useFormattedDate(..., { includeTime: true }).
- Those screens now follow the user’s Settings → Preferences date format instead of the browser locale.
- 9 files: reporting tables, Shadow AI alert history, observability, AI audit, MCP runs, risk score card, report/evidence analysis footers.

## Write your issue number after "Fixes "

Fixes #6454

## Please ensure all items are checked off before requesting a review:

- [x] I deployed the code locally.
- [x] I have performed a self-review of my code.
- [x] I have included the issue # in the PR.
- [x] I have labelled the PR correctly.
- [x] The issue I am working on is assigned to me.
- [x] I have avoided using hardcoded values to ensure scalability and maintain consistency across the application.
- [x] I have ensured that font sizes, color choices, and other UI elements are referenced from the theme.
- [ ] My pull request is focused and addresses a single, specific feature.
- [ ] If there are UI changes, I have attached a screenshot or video to this PR.
- [ ] If I added or modified an API endpoint, the change is reflected in the generated OpenAPI spec (`npm run generate:swagger`).
- [ ] If the endpoint requires authentication, it uses `authenticateJWT` and the generated spec declares `bearerAuth` security.
- [ ] I ran `npm run check:api-drift` and committed the regenerated `swagger.yaml` and `endpoints.ts`.
- [ ] If this PR adds or modifies an organization-scoped table, the [tenant isolation registry](Servers/tests/integration/tenant-isolation/tenantIsolation.registry.ts) and [test matrix](Servers/tests/integration/tenant-isolation) are updated. See the [tenant isolation runbook](docs/technical/security/tenant-isolation.md) for details.
