### PR TITLE
refactor(extensions): format dates with useFormattedDate

### DIFF
--- a/Clients/src/presentation/pages/Extensions/azure-ai-foundry/AzureAIFoundryTab.tsx
+++ b/Clients/src/presentation/pages/Extensions/azure-ai-foundry/AzureAIFoundryTab.tsx
@@ -21,6 +21,7 @@ import {
 import { RefreshCw, X, ChevronsUpDown } from "lucide-react";
 import { colors, borderRadius, chipStyles, buttonStyles, tableStyles } from "../theme";
 import { apiServices } from "../../../../infrastructure/api/networkServices";
+import useFormattedDate from "../../../../application/hooks/useFormattedDate";
 
 const SelectorVertical = (props: any) => <ChevronsUpDown size={16} {...props} />;
 
@@ -43,15 +44,6 @@ interface AzureModel {
   created_at: string;
   updated_at: string;
 }
-
-const formatDate = (dateString: string | null) => {
-  if (!dateString) return "—";
-  return new Date(dateString).toLocaleDateString("en-US", {
-    year: "numeric",
-    month: "short",
-    day: "numeric",
-  });
-};
 
 const DetailRow = ({ label, value }: { label: string; value: string }) => (
   <Box>
@@ -81,6 +73,7 @@ const StatCard = ({ label, value, color }: { label: string; value: number; color
 );
 
 export default function AzureAIFoundryTab() {
+  const formatDate = useFormattedDate();
   const [loading, setLoading] = useState(false);
   const [warning, setWarning] = useState<string | null>(null);
   const [selectedModel, setSelectedModel] = useState<AzureModel | null>(null);
@@ -262,7 +255,9 @@ export default function AzureAIFoundryTab() {
                   </TableCell>
                   <TableCell sx={tableStyles.cell}>{model.sku_name || "—"}</TableCell>
                   <TableCell sx={tableStyles.cell}>{model.sku_capacity ?? "—"}</TableCell>
-                  <TableCell sx={tableStyles.cell}>{formatDate(model.last_synced_at)}</TableCell>
+                  <TableCell sx={tableStyles.cell}>
+                    {formatDate(new Date(model.last_synced_at))}
+                  </TableCell>
                 </TableRow>
               ))}
             </TableBody>
@@ -364,12 +359,26 @@ export default function AzureAIFoundryTab() {
                 )}
               </Box>
 
-              <DetailRow label="Azure created" value={formatDate(selectedModel.azure_created_at)} />
+              <DetailRow
+                label="Azure created"
+                value={
+                  selectedModel.azure_created_at
+                    ? formatDate(new Date(selectedModel.azure_created_at))
+                    : "—"
+                }
+              />
               <DetailRow
                 label="Azure modified"
-                value={formatDate(selectedModel.azure_modified_at)}
+                value={
+                  selectedModel.azure_modified_at
+                    ? formatDate(new Date(selectedModel.azure_modified_at))
+                    : "—"
+                }
               />
-              <DetailRow label="Last synced" value={formatDate(selectedModel.last_synced_at)} />
+              <DetailRow
+                label="Last synced"
+                value={formatDate(new Date(selectedModel.last_synced_at))}
+              />
             </Stack>
           </>
         )}

--- a/Clients/src/presentation/pages/Extensions/jira-assets/JiraAssetsConfiguration.tsx
+++ b/Clients/src/presentation/pages/Extensions/jira-assets/JiraAssetsConfiguration.tsx
@@ -21,6 +21,7 @@ import {
 import { RefreshCw, Download } from "lucide-react";
 import { VWField, VWSelect, VWToggle } from "./VWComponents";
 import { apiServices } from "../../../../infrastructure/api/networkServices";
+import useFormattedDate from "../../../../application/hooks/useFormattedDate";
 
 interface Schema {
   id: string;
@@ -55,6 +56,7 @@ interface ImportedUseCase {
 }
 
 export const JiraAssetsConfiguration: React.FC = () => {
+  const formatDate = useFormattedDate();
   const pluginApiCall = useCallback(async (method: string, path: string, body?: any) => {
     const url = `/extensions/jira-assets${path.startsWith("/") ? path : `/${path}`}`;
     let response: any;
@@ -771,7 +773,7 @@ export const JiraAssetsConfiguration: React.FC = () => {
             severity={localConfig.last_sync_status === "success" ? "success" : "warning"}
             sx={{ fontSize: "13px" }}
           >
-            Last sync: {new Date(localConfig.last_sync_at).toLocaleString()} -{" "}
+            Last sync: {formatDate(new Date(localConfig.last_sync_at), { includeTime: true })} -{" "}
             {localConfig.last_sync_status === "success"
               ? "Successful"
               : localConfig.last_sync_message}
@@ -793,7 +795,7 @@ export const JiraAssetsConfiguration: React.FC = () => {
               <Typography variant="body2" fontSize={12} color="text.secondary">
                 {importedUseCases.length} use cases imported
                 {localConfig.last_sync_at &&
-                  ` • Last sync: ${new Date(localConfig.last_sync_at).toLocaleString()}`}
+                  ` • Last sync: ${formatDate(new Date(localConfig.last_sync_at), { includeTime: true })}`}
               </Typography>
             </Box>
             <Box sx={{ display: "flex", gap: 1 }}>

--- a/Clients/src/presentation/pages/Extensions/jira-assets/JiraUseCaseOverview.tsx
+++ b/Clients/src/presentation/pages/Extensions/jira-assets/JiraUseCaseOverview.tsx
@@ -21,6 +21,7 @@ import {
   infoCardTitleStyle,
   infoCardbodyStyle,
 } from "../../../components/Cards/InfoCard/style";
+import useFormattedDate from "../../../../application/hooks/useFormattedDate";
 
 interface JiraData {
   id?: string;
@@ -51,19 +52,6 @@ interface JiraUseCaseOverviewProps {
     framework?: ProjectFramework[];
   } | null;
 }
-
-const formatDate = (dateStr?: string): string => {
-  if (!dateStr) return "-";
-  try {
-    return new Date(dateStr).toLocaleDateString("en-US", {
-      year: "numeric",
-      month: "short",
-      day: "numeric",
-    });
-  } catch {
-    return dateStr;
-  }
-};
 
 const formatValue = (value: any): string => {
   if (value === null || value === undefined) return "-";
@@ -247,6 +235,7 @@ function GroupStatsCard({
 }
 
 export const JiraUseCaseOverview: React.FC<JiraUseCaseOverviewProps> = ({ project }) => {
+  const formatDate = useFormattedDate();
   const [jiraData, setJiraData] = useState<JiraData | null>(null);
   const [syncStatus, setSyncStatus] = useState<string>("synced");
   const [loading, setLoading] = useState(true);
@@ -453,12 +442,12 @@ export const JiraUseCaseOverview: React.FC<JiraUseCaseOverviewProps> = ({ projec
         <Stack className="vw-project-overview-row" sx={rowStyle}>
           <InfoCard
             title="Created in JIRA"
-            body={formatDate(jiraData?.created)}
+            body={jiraData?.created ? formatDate(new Date(jiraData.created)) : "—"}
             icon={<CalendarIcon size={16} />}
           />
           <InfoCard
             title="Last Updated in JIRA"
-            body={formatDate(jiraData?.updated)}
+            body={jiraData?.updated ? formatDate(new Date(jiraData.updated)) : "—"}
             icon={<ClockIcon size={16} />}
           />
           <InfoCard

--- a/Clients/src/presentation/pages/Extensions/mlflow/MLFlowTab.tsx
+++ b/Clients/src/presentation/pages/Extensions/mlflow/MLFlowTab.tsx
@@ -41,6 +41,7 @@ import {
   modalStyles,
 } from "../theme";
 import { apiServices } from "../../../../infrastructure/api/networkServices";
+import useFormattedDate from "../../../../application/hooks/useFormattedDate";
 
 const SelectorVertical = (props: any) => <ChevronsUpDown size={16} {...props} />;
 
@@ -347,6 +348,7 @@ interface MLFlowModel {
 }
 
 export default function MLFlowTab() {
+  const formatDate = useFormattedDate();
   const [loading, setLoading] = useState(false);
   const [warning, setWarning] = useState<string | null>(null);
   const [selectedModel, setSelectedModel] = useState<MLFlowModel | null>(null);
@@ -379,8 +381,6 @@ export default function MLFlowTab() {
       experiments,
     };
   }, [mlflowData]);
-
-  const formatDate = (timestamp: number) => new Date(timestamp).toLocaleDateString();
 
   const fetchMLFlowData = async () => {
     setLoading(true);
@@ -656,10 +656,10 @@ export default function MLFlowTab() {
                             />
                           </TableCell>
                           <TableCell sx={tableStyles.cell}>
-                            {formatDate(model.creation_timestamp)}
+                            {formatDate(new Date(model.creation_timestamp))}
                           </TableCell>
                           <TableCell sx={tableStyles.cell}>
-                            {formatDate(model.last_updated_timestamp)}
+                            {formatDate(new Date(model.last_updated_timestamp))}
                           </TableCell>
                           <TableCell
                             sx={{
@@ -777,7 +777,8 @@ export default function MLFlowTab() {
                       <strong>Run ID:</strong> {selectedModel.run_id}
                     </Typography>
                     <Typography variant="body2">
-                      <strong>Created:</strong> {formatDate(selectedModel.creation_timestamp)}
+                      <strong>Created:</strong>{" "}
+                      {formatDate(new Date(selectedModel.creation_timestamp))}
                     </Typography>
                   </Box>
                 </Grid>

--- a/Clients/src/presentation/pages/Extensions/slack/SlackConfiguration.tsx
+++ b/Clients/src/presentation/pages/Extensions/slack/SlackConfiguration.tsx
@@ -22,6 +22,7 @@ import {
 import { SlidersHorizontal, Trash2, ToggleLeft, ToggleRight, MessageSquare, X } from "lucide-react";
 import { apiServices } from "../../../../infrastructure/api/networkServices";
 import { ENV_VARs } from "../../../../../env.vars";
+import useFormattedDate from "../../../../application/hooks/useFormattedDate";
 
 const colors = {
   primary: "#13715B",
@@ -73,6 +74,7 @@ interface SlackWorkspace {
 }
 
 export default function SlackConfiguration() {
+  const formatDate = useFormattedDate();
   const [slackWorkspaces, setSlackWorkspaces] = useState<SlackWorkspace[]>([]);
   const [loadingWorkspaces, setLoadingWorkspaces] = useState(false);
   const [globalRoutingTypes, setGlobalRoutingTypes] = useState<string[]>([]);
@@ -247,9 +249,7 @@ export default function SlackConfiguration() {
                       <TableCell sx={{ ...tableStyles.cell }}>{workspace.team_name}</TableCell>
                       <TableCell sx={{ ...tableStyles.cell }}>#{workspace.channel}</TableCell>
                       <TableCell sx={{ ...tableStyles.cell }}>
-                        {workspace.created_at
-                          ? new Date(workspace.created_at).toLocaleDateString()
-                          : "-"}
+                        {workspace.created_at ? formatDate(new Date(workspace.created_at)) : "—"}
                       </TableCell>
                       <TableCell sx={{ ...tableStyles.cell }}>
                         <Box


### PR DESCRIPTION
## Describe your changes

Replace leftover toLocale date formatting on Slack, Jira Assets, MLflow, and Azure AI Foundry so those screens follow the user's date preference.

## Write your issue number after "Fixes "

Fixes #4657 

## Please ensure all items are checked off before requesting a review:

- [x] I deployed the code locally.
- [x] I have performed a self-review of my code.
- [x] I have included the issue # in the PR.
- [x] I have labelled the PR correctly.
- [x] The issue I am working on is assigned to me.
- [x] I have avoided using hardcoded values to ensure scalability and maintain consistency across the application.
- [x] I have ensured that font sizes, color choices, and other UI elements are referenced from the theme.
- [x] My pull request is focused and addresses a single, specific feature.
- [ ] If there are UI changes, I have attached a screenshot or video to this PR.
- [ ] If I added or modified an API endpoint, the change is reflected in the generated OpenAPI spec (`npm run generate:swagger`).
- [ ] If the endpoint requires authentication, it uses `authenticateJWT` and the generated spec declares `bearerAuth` security.
- [ ] I ran `npm run check:api-drift` and committed the regenerated `swagger.yaml` and `endpoints.ts`.
- [ ] If this PR adds or modifies an organization-scoped table, the [tenant isolation registry](Servers/tests/integration/tenant-isolation/tenantIsolation.registry.ts) and [test matrix](Servers/tests/integration/tenant-isolation) are updated. See the [tenant isolation runbook](docs/technical/security/tenant-isolation.md) for details.
