### PR TITLE
fix(page-tour): match onboarding tooltip arrow colour to card

### DIFF
--- a/Clients/src/presentation/components/PageTour/index.tsx
+++ b/Clients/src/presentation/components/PageTour/index.tsx
@@ -44,8 +44,15 @@ const PageTour: React.FC<IPageTourProps> = ({ steps, run, onFinish, tourKey }) =
     <>
       <Global
         styles={{
-          ".__floater__arrow polygon": {
-            fill: "#1f1f23 !important",
+          // react-joyride 3.x renders the arrow as `.react-joyride__arrow`
+          // (the old `.__floater__arrow` class no longer exists) and its
+          // polygon uses `fill="currentColor"`, so drive it via `color` and
+          // match the tooltip card's top-left gradient colour (#1f1f23).
+          ".react-joyride__arrow": {
+            color: "#1f1f23 !important",
+          },
+          ".react-joyride__arrow polygon": {
+            fill: "currentColor !important",
           },
           ".react-joyride__beacon": {
             zIndex: "900 !important",


### PR DESCRIPTION
## Summary

The onboarding/product-tour tooltip rendered a **white arrow** pointing at the target element while the tooltip card itself is dark, producing a visible colour mismatch at the tip.

**Cause:** the arrow styling targeted `.__floater__arrow polygon` — a class from react-joyride 2.x. The installed version is **3.1.0**, where the arrow is rendered as `.react-joyride__arrow` containing a `<polygon fill="currentColor">`. The old selector matched nothing, so the polygon fell back to its default white fill.

**Fix:** target the correct `.react-joyride__arrow` class and drive the colour via `currentColor` (which the polygon reads), set to the tooltip card's top-left gradient colour `#1f1f23` (`linear-gradient(135deg, #1f1f23 0%, #252530 100%)`). The arrow now matches the card, removing the mismatch.

Single-file CSS-only change in `Clients/src/presentation/components/PageTour/index.tsx`. No behavioural change, no new strings.