### PR TITLE
refactor(ui): format leftover date helpers with useFormattedDate

### DIFF
--- a/Clients/src/presentation/components/AdvisorChat/CustomMessage.tsx
+++ b/Clients/src/presentation/components/AdvisorChat/CustomMessage.tsx
@@ -10,18 +10,8 @@ import ConfirmationToolUI from "./ConfirmationToolUI";
 import VWAvatar from "../Avatar/VWAvatar";
 import { VerifyWiseContext } from "../../../application/contexts/VerifyWise.context";
 import { useProfilePhotoFetch } from "../../../application/hooks/useProfilePhotoFetch";
+import useFormattedDate from "../../../application/hooks/useFormattedDate";
 import { User } from "../../../domain/types/User";
-
-const formatTimestamp = (date: Date): string => {
-  return date.toLocaleString(undefined, {
-    month: "short",
-    day: "numeric",
-    year: "numeric",
-    hour: "numeric",
-    minute: "2-digit",
-    hour12: true,
-  });
-};
 
 // Create markdown styles with theme. Tables follow the VerifyWise list
 // conventions (thin borders, subtle header fill, 13/12px type) so an
@@ -232,6 +222,7 @@ const useAssistantTurnHasVisibleOutput = (): boolean => {
 
 const MessageTimestamp: FC = () => {
   const theme = useTheme();
+  const formatDate = useFormattedDate();
   const message = useAuiState((s) => s.message);
 
   // Skip welcome message (id: 'welcome') which is generated client-side
@@ -254,7 +245,7 @@ const MessageTimestamp: FC = () => {
         ml: 0.5,
       }}
     >
-      Answered: {formatTimestamp(new Date(message.createdAt))}
+      Answered: {formatDate(new Date(message.createdAt), { includeTime: true })}
     </Typography>
   );
 };

--- a/Clients/src/presentation/components/Table/LogsTable/index.tsx
+++ b/Clients/src/presentation/components/Table/LogsTable/index.tsx
@@ -22,6 +22,7 @@ import {
   setPaginationRowCount,
 } from "../../../../application/utils/paginationStorage";
 import { text, status } from "../../../themes/palette";
+import useFormattedDate from "../../../../application/hooks/useFormattedDate";
 
 const LOGS_TABLE_SORTING_KEY = "verifywise_logs_table_sorting";
 
@@ -137,6 +138,7 @@ const StateBadge: React.FC<{ state: string }> = ({ state }) => {
 
 const LogsTable: React.FC<LogsTableProps> = ({ data, isLoading = false, paginated = true }) => {
   const theme = useTheme();
+  const formatDate = useFormattedDate();
   const [page, setPage] = useState(0);
   const [rowsPerPage, setRowsPerPage] = useState(() =>
     getPaginationRowCount("logsTable", DEFAULT_ROWS_PER_PAGE),
@@ -240,20 +242,9 @@ const LogsTable: React.FC<LogsTableProps> = ({ data, isLoading = false, paginate
   }, [parsedLogs, sortConfig]);
 
   const formatTimestamp = (timestamp: string): string => {
-    try {
-      const date = new Date(timestamp);
-      if (isNaN(date.getTime())) return timestamp;
-      return date.toLocaleString(undefined, {
-        month: "short",
-        day: "numeric",
-        year: "numeric",
-        hour: "2-digit",
-        minute: "2-digit",
-        second: "2-digit",
-      });
-    } catch {
-      return timestamp;
-    }
+    const date = new Date(timestamp);
+    if (isNaN(date.getTime())) return timestamp;
+    return formatDate(date, { includeTime: true, includeSeconds: true });
   };
 
   const tableHeader = useMemo(

--- a/Clients/src/presentation/pages/Automations/components/AutomationHistory/index.tsx
+++ b/Clients/src/presentation/pages/Automations/components/AutomationHistory/index.tsx
@@ -41,6 +41,7 @@ import { EmptyState } from "../../../../components/EmptyState";
 import singleTheme from "../../../../themes/v1SingleTheme";
 import { ChevronsUpDown } from "lucide-react";
 import { status, background } from "../../../../themes/palette";
+import useFormattedDate from "../../../../../application/hooks/useFormattedDate";
 
 interface AutomationHistoryProps {
   automationId: string;
@@ -48,6 +49,7 @@ interface AutomationHistoryProps {
 
 const AutomationHistory: React.FC<AutomationHistoryProps> = ({ automationId }) => {
   const theme = useTheme();
+  const formatDate = useFormattedDate();
   const [logs, setLogs] = useState<AutomationExecutionLog[]>([]);
   const [expandedRows, setExpandedRows] = useState<Set<string>>(new Set());
   const [page, setPage] = useState(0);
@@ -116,10 +118,6 @@ const AutomationHistory: React.FC<AutomationHistoryProps> = ({ automationId }) =
       failure: "Failure",
     };
     return labels[status];
-  };
-
-  const formatDate = (date: Date | string) => {
-    return new Date(date).toLocaleString();
   };
 
   const formatActionType = (actionType: string) => {
@@ -379,7 +377,7 @@ const AutomationHistory: React.FC<AutomationHistoryProps> = ({ automationId }) =
                         <Stack direction="row" spacing={1} alignItems="center">
                           <Clock size={14} color="#8594AC" />
                           <Typography sx={{ fontSize: 13 }}>
-                            {formatDate(log.triggered_at)}
+                            {formatDate(new Date(log.triggered_at), { includeTime: true })}
                           </Typography>
                         </Stack>
                       </TableCell>
@@ -449,7 +447,9 @@ const AutomationHistory: React.FC<AutomationHistoryProps> = ({ automationId }) =
                                           try {
                                             const date = new Date(value as string);
                                             if (!isNaN(date.getTime())) {
-                                              displayValue = formatDate(date);
+                                              displayValue = formatDate(date, {
+                                                includeTime: true,
+                                              });
                                             } else {
                                               displayValue = String(value);
                                             }
@@ -631,7 +631,9 @@ const AutomationHistory: React.FC<AutomationHistoryProps> = ({ automationId }) =
                                                     <Typography
                                                       sx={{ fontSize: 12, color: "#8594AC" }}
                                                     >
-                                                      {formatDate(action.executed_at)}
+                                                      {formatDate(new Date(action.executed_at), {
+                                                        includeTime: true,
+                                                      })}
                                                     </Typography>
                                                   </Stack>
                                                 )}

--- a/Clients/src/presentation/pages/ProjectView/Fria/FriaVersionHistory.tsx
+++ b/Clients/src/presentation/pages/ProjectView/Fria/FriaVersionHistory.tsx
@@ -16,7 +16,12 @@ import { useTheme } from "@mui/material/styles";
 import { History, ChevronDown, ChevronUp, ChevronRight } from "lucide-react";
 import Chip from "../../../components/Chip";
 import { friaRepository } from "../../../../application/repository/fria.repository";
+import useFormattedDate from "../../../../application/hooks/useFormattedDate";
 import { brand } from "../../../themes/palette";
+
+// The diff helpers below are pure, so the preference-aware formatter is passed
+// in rather than read from a hook they cannot call.
+type DateFormatter = ReturnType<typeof useFormattedDate>;
 
 interface FriaVersionSnapshot {
   id: number;
@@ -97,19 +102,14 @@ const SKIP_FIELDS = new Set([
 // Fields that contain ISO date strings
 const DATE_FIELDS = new Set(["assessment_date", "first_use_date"]);
 
-function formatDateValue(iso: string): string {
-  const d = new Date(iso);
-  if (isNaN(d.getTime())) return iso;
-  return `${d.getDate()} ${d.toLocaleString("en-GB", { month: "short" })} ${d.getFullYear()}`;
-}
-
-function formatValue(value: unknown, fieldKey?: string): string {
+function formatValue(value: unknown, formatDate: DateFormatter, fieldKey?: string): string {
   if (value === null || value === undefined || value === "") return "—";
   if (Array.isArray(value)) return value.length === 0 ? "—" : value.join(", ");
   if (typeof value === "object") return JSON.stringify(value);
   const str = String(value);
   if (fieldKey && DATE_FIELDS.has(fieldKey) && str.includes("T")) {
-    return formatDateValue(str);
+    const parsed = new Date(str);
+    return isNaN(parsed.getTime()) ? str : formatDate(parsed);
   }
   return str;
 }
@@ -117,6 +117,7 @@ function formatValue(value: unknown, fieldKey?: string): string {
 function computeDiffs(
   oldAssessment: Record<string, unknown> | null,
   newAssessment: Record<string, unknown>,
+  formatDate: DateFormatter,
 ): FieldDiff[] {
   const diffs: FieldDiff[] = [];
 
@@ -124,8 +125,8 @@ function computeDiffs(
     if (SKIP_FIELDS.has(key)) continue;
 
     const oldVal = oldAssessment ? oldAssessment[key] : undefined;
-    const oldStr = formatValue(oldVal, key);
-    const newStr = formatValue(newVal, key);
+    const oldStr = formatValue(oldVal, formatDate, key);
+    const newStr = formatValue(newVal, formatDate, key);
 
     if (oldStr === newStr) continue;
 
@@ -186,23 +187,13 @@ function computeRightsDiffs(
   return diffs;
 }
 
-function formatTimestamp(iso: string): string {
-  const d = new Date(iso);
-  if (isNaN(d.getTime())) return iso;
-  const day = d.getDate();
-  const month = d.toLocaleString("en-GB", { month: "short" });
-  const year = d.getFullYear();
-  const hh = String(d.getHours()).padStart(2, "0");
-  const mm = String(d.getMinutes()).padStart(2, "0");
-  return `${day} ${month} ${year}, ${hh}:${mm}`;
-}
-
 const FriaVersionHistory = ({
   friaId,
   currentVersion,
   inline = false,
 }: FriaVersionHistoryProps) => {
   const theme = useTheme();
+  const formatDate = useFormattedDate();
 
   const [panelOpen, setPanelOpen] = useState(false);
   const [expandedRow, setExpandedRow] = useState<number | null>(null);
@@ -246,7 +237,7 @@ const FriaVersionHistory = ({
 
     const previousAssessment =
       (previousSnapshot?.snapshot_data?.assessment as Record<string, unknown> | null) ?? null;
-    const assessmentDiffs = computeDiffs(previousAssessment, assessment);
+    const assessmentDiffs = computeDiffs(previousAssessment, assessment, formatDate);
 
     // Rights diffs
     const newRights = (snapshot.snapshot_data.rights || []) as Record<string, unknown>[];
@@ -517,7 +508,9 @@ const FriaVersionHistory = ({
                         padding: "10px 16px",
                       }}
                     >
-                      {v.created_at ? formatTimestamp(v.created_at) : "—"}
+                      {v.created_at
+                        ? formatDate(new Date(v.created_at), { includeTime: true })
+                        : "—"}
                     </TableCell>
                     <TableCell sx={{ width: 36, padding: "10px 8px", textAlign: "center" }}>
                       {v.snapshot_data && (

--- a/Clients/src/presentation/pages/SettingsPage/AuditLedger/index.tsx
+++ b/Clients/src/presentation/pages/SettingsPage/AuditLedger/index.tsx
@@ -38,6 +38,7 @@ import TablePaginationActions from "../../../components/TablePagination";
 import singleTheme from "../../../themes/v1SingleTheme";
 import { useAuditLedger } from "./hooks/useAuditLedger";
 import { useFeatureSettings } from "../../../../application/hooks/useFeatureSettings";
+import useFormattedDate from "../../../../application/hooks/useFormattedDate";
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 const SelectorVertical = (props: any) => <ChevronsUpDown size={16} {...props} />;
@@ -61,18 +62,6 @@ const ENTRY_TYPE_ITEMS = [
   { _id: "change_history", name: "Change history" },
 ];
 
-function formatTimestamp(iso: string): string {
-  const d = new Date(iso);
-  return d.toLocaleString(undefined, {
-    year: "numeric",
-    month: "short",
-    day: "numeric",
-    hour: "2-digit",
-    minute: "2-digit",
-    second: "2-digit",
-  });
-}
-
 function getUserDisplay(name: string | null, surname: string | null): string {
   if (name || surname) {
     return `${name ?? ""} ${surname ?? ""}`.trim();
@@ -82,6 +71,7 @@ function getUserDisplay(name: string | null, surname: string | null): string {
 
 export default function AuditLedger() {
   const theme = useTheme();
+  const formatDate = useFormattedDate();
   const { settings, isLoading: featureLoading, update: updateFeature } = useFeatureSettings();
   const isEnabled = settings?.audit_ledger_enabled ?? true;
 
@@ -322,7 +312,10 @@ export default function AuditLedger() {
                   {entries.map((entry) => (
                     <TableRow key={entry.id} sx={singleTheme.tableStyles.primary.body.row}>
                       <TableCell sx={singleTheme.tableStyles.primary.body.cell}>
-                        {formatTimestamp(entry.occurred_at)}
+                        {formatDate(new Date(entry.occurred_at), {
+                          includeTime: true,
+                          includeSeconds: true,
+                        })}
                       </TableCell>
                       <TableCell sx={singleTheme.tableStyles.primary.body.cell}>
                         {getUserDisplay(entry.user_name, entry.user_surname)}


### PR DESCRIPTION
## Describe your changes

Route logs, audit ledger, advisor, automation history, and FRIA version dates through the user preference instead of toLocaleString month-name formats.

## Write your issue number after "Fixes "

Fixes #4664 

## Please ensure all items are checked off before requesting a review:

- [x] I deployed the code locally.
- [x] I have performed a self-review of my code.
- [x] I have included the issue # in the PR.
- [x] I have labelled the PR correctly.
- [x] The issue I am working on is assigned to me.
- [x] I have avoided using hardcoded values to ensure scalability and maintain consistency across the application.
- [x] I have ensured that font sizes, color choices, and other UI elements are referenced from the theme.
- [x] My pull request is focused and addresses a single, specific feature.
- [ ] If there are UI changes, I have attached a screenshot or video to this PR.
- [ ] If I added or modified an API endpoint, the change is reflected in the generated OpenAPI spec (`npm run generate:swagger`).
- [ ] If the endpoint requires authentication, it uses `authenticateJWT` and the generated spec declares `bearerAuth` security.
- [ ] I ran `npm run check:api-drift` and committed the regenerated `swagger.yaml` and `endpoints.ts`.
- [ ] If this PR adds or modifies an organization-scoped table, the [tenant isolation registry](Servers/tests/integration/tenant-isolation/tenantIsolation.registry.ts) and [test matrix](Servers/tests/integration/tenant-isolation) are updated. See the [tenant isolation runbook](docs/technical/security/tenant-isolation.md) for details.
