### PR TITLE
fix(a11y): trap keyboard focus in modal, drawer, and lightbox

### DIFF
--- a/Clients/src/presentation/components/AnalyticsDrawer/__tests__/AnalyticsDrawer.test.tsx
+++ b/Clients/src/presentation/components/AnalyticsDrawer/__tests__/AnalyticsDrawer.test.tsx
@@ -18,7 +18,9 @@ vi.mock("../../button-toggle", () => ({
   ),
 }));
 
-import { screen } from "@testing-library/react";
+import { screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { useState } from "react";
 import { renderWithProviders } from "../../../../test/renderWithProviders";
 import AnalyticsDrawer from "../index";
 
@@ -48,5 +50,80 @@ describe("AnalyticsDrawer", () => {
   it("does not show content when closed", () => {
     renderWithProviders(<AnalyticsDrawer {...defaultProps} open={false} />);
     expect(screen.queryByText("Analytics & Trends")).not.toBeInTheDocument();
+  });
+
+  describe("keyboard navigation", () => {
+    it("exposes a modal dialog labelled by the title", () => {
+      renderWithProviders(<AnalyticsDrawer {...defaultProps} />);
+
+      const dialog = screen.getByRole("dialog", { name: "Analytics & Trends" });
+      expect(dialog).toHaveAttribute("aria-modal", "true");
+      expect(
+        screen.getByRole("heading", { name: "Analytics & Trends", level: 2 }),
+      ).toBeInTheDocument();
+    });
+
+    it("calls onClose when Escape is pressed", async () => {
+      const onClose = vi.fn();
+      const user = userEvent.setup();
+
+      renderWithProviders(<AnalyticsDrawer {...defaultProps} onClose={onClose} />);
+
+      await user.keyboard("{Escape}");
+      expect(onClose).toHaveBeenCalledTimes(1);
+    });
+
+    it("keeps Tab focus inside the drawer", async () => {
+      const user = userEvent.setup();
+      renderWithProviders(
+        <>
+          <button type="button">Outside</button>
+          <AnalyticsDrawer {...defaultProps} />
+        </>,
+      );
+
+      const dialog = screen.getByRole("dialog", { name: "Analytics & Trends" });
+      const outside = screen.getByRole("button", { name: "Outside", hidden: true });
+
+      expect(outside.closest("[aria-hidden='true']")).not.toBeNull();
+
+      for (let i = 0; i < 8; i++) {
+        await user.tab();
+        expect(outside).not.toHaveFocus();
+        expect(dialog.contains(document.activeElement)).toBe(true);
+      }
+    });
+
+    it("returns focus to the trigger when closed with Escape", async () => {
+      const user = userEvent.setup();
+
+      function Harness() {
+        const [open, setOpen] = useState(false);
+        return (
+          <>
+            <button type="button" onClick={() => setOpen(true)}>
+              Open analytics
+            </button>
+            <AnalyticsDrawer {...defaultProps} open={open} onClose={() => setOpen(false)} />
+          </>
+        );
+      }
+
+      renderWithProviders(<Harness />);
+
+      const trigger = screen.getByRole("button", { name: "Open analytics" });
+      await user.click(trigger);
+
+      expect(screen.getByRole("dialog", { name: "Analytics & Trends" })).toBeInTheDocument();
+
+      await user.keyboard("{Escape}");
+
+      await waitFor(() => {
+        expect(
+          screen.queryByRole("dialog", { name: "Analytics & Trends" }),
+        ).not.toBeInTheDocument();
+      });
+      expect(trigger).toHaveFocus();
+    });
   });
 });

--- a/Clients/src/presentation/components/AnalyticsDrawer/index.tsx
+++ b/Clients/src/presentation/components/AnalyticsDrawer/index.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, memo } from "react";
+import React, { useState, useEffect, useId, memo } from "react";
 import { Drawer, Box, Typography, Stack, IconButton, useTheme } from "@mui/material";
 import { X as CloseIcon } from "lucide-react";
 import { ModelInventoryHistoryChart } from "../Charts/ModelInventoryHistoryChart";
@@ -63,6 +63,7 @@ const AnalyticsDrawer: React.FC<AnalyticsDrawerProps> = ({
   chartType = "model", // Default to model chart for backward compatibility
 }) => {
   const theme = useTheme();
+  const titleId = useId();
   // Create localStorage key based on chartType for persistence
   const storageKey = `analytics_parameter_${chartType}`;
 
@@ -95,7 +96,13 @@ const AnalyticsDrawer: React.FC<AnalyticsDrawerProps> = ({
       anchor="right"
       open={open}
       onClose={onClose}
-      aria-label={`${title} drawer`}
+      slotProps={{
+        paper: {
+          "role": "dialog",
+          "aria-modal": "true",
+          "aria-labelledby": titleId,
+        },
+      }}
       sx={{
         "& .MuiDrawer-paper": {
           width: { xs: "100%", sm: "600px", md: "800px" },
@@ -108,6 +115,8 @@ const AnalyticsDrawer: React.FC<AnalyticsDrawerProps> = ({
         <Stack direction="row" justifyContent="space-between" alignItems="center" sx={{ mb: 3 }}>
           <Box>
             <Typography
+              id={titleId}
+              component="h2"
               sx={{
                 fontSize: theme.typography.body1.fontSize,
                 fontWeight: 700,

--- a/Clients/src/presentation/components/Modals/StandardModal/__tests__/StandardModal.test.tsx
+++ b/Clients/src/presentation/components/Modals/StandardModal/__tests__/StandardModal.test.tsx
@@ -1,5 +1,6 @@
-import { screen, within, fireEvent } from "@testing-library/react";
+import { screen, within, fireEvent, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
+import { useState } from "react";
 import { vi } from "vitest";
 import { renderWithProviders } from "../../../../../test/renderWithProviders";
 import StandardModal from "../index";
@@ -427,6 +428,77 @@ describe("StandardModal", () => {
 
       const modal = baseElement.querySelector("[role='presentation']") as HTMLElement;
       expect(modal.contains(document.activeElement)).toBe(true);
+    });
+
+    it("exposes a modal dialog for assistive technology", () => {
+      renderWithProviders(
+        <StandardModal {...baseProps} onClose={vi.fn()}>
+          <div>Modal content</div>
+        </StandardModal>,
+      );
+
+      const dialog = screen.getByRole("dialog", { name: "Test Modal" });
+      expect(dialog).toHaveAttribute("aria-modal", "true");
+    });
+
+    it("keeps Tab focus inside the dialog", async () => {
+      const user = userEvent.setup();
+      renderWithProviders(
+        <>
+          <button type="button">Outside</button>
+          <StandardModal {...baseProps} onClose={vi.fn()} onSubmit={vi.fn()}>
+            <input aria-label="Name" />
+          </StandardModal>
+        </>,
+      );
+
+      const dialog = screen.getByRole("dialog", { name: "Test Modal" });
+      const outside = screen.getByRole("button", { name: "Outside", hidden: true });
+
+      expect(outside.closest("[aria-hidden='true']")).not.toBeNull();
+
+      for (let i = 0; i < 12; i++) {
+        await user.tab();
+        expect(outside).not.toHaveFocus();
+        expect(dialog.contains(document.activeElement)).toBe(true);
+      }
+    });
+
+    it("returns focus to the trigger when closed with Escape", async () => {
+      const user = userEvent.setup();
+
+      function Harness() {
+        const [open, setOpen] = useState(false);
+        return (
+          <>
+            <button type="button" onClick={() => setOpen(true)}>
+              Open modal
+            </button>
+            <StandardModal
+              {...baseProps}
+              isOpen={open}
+              onClose={() => setOpen(false)}
+              onSubmit={vi.fn()}
+            >
+              <input aria-label="Name" />
+            </StandardModal>
+          </>
+        );
+      }
+
+      renderWithProviders(<Harness />);
+
+      const trigger = screen.getByRole("button", { name: "Open modal" });
+      await user.click(trigger);
+
+      expect(screen.getByRole("dialog", { name: "Test Modal" })).toBeInTheDocument();
+
+      await user.keyboard("{Escape}");
+
+      await waitFor(() => {
+        expect(screen.queryByRole("dialog", { name: "Test Modal" })).not.toBeInTheDocument();
+      });
+      expect(trigger).toHaveFocus();
     });
 
     it("hides the Enter-key helper submit button from assistive technology", () => {

--- a/Clients/src/presentation/components/Modals/StandardModal/index.tsx
+++ b/Clients/src/presentation/components/Modals/StandardModal/index.tsx
@@ -181,6 +181,11 @@ const StandardModal: React.FC<StandardModalProps> = ({
       }}
     >
       <Stack
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby={titleId}
+        aria-describedby={descriptionId}
+        tabIndex={-1}
         sx={{
           width: maxWidth,
           minWidth: "min(600px, 100%)",

--- a/Clients/src/presentation/components/UserGuide/ImageLightbox.tsx
+++ b/Clients/src/presentation/components/UserGuide/ImageLightbox.tsx
@@ -38,6 +38,7 @@ const ImageLightbox: React.FC<ImageLightboxProps> = ({ src, alt, caption, onClos
         role="dialog"
         aria-modal="true"
         aria-labelledby="image-lightbox-title"
+        aria-describedby={caption ? "image-lightbox-caption" : undefined}
         sx={{
           maxWidth: "90vw",
           maxHeight: "90vh",
@@ -54,6 +55,7 @@ const ImageLightbox: React.FC<ImageLightboxProps> = ({ src, alt, caption, onClos
 
         <IconButton
           onClick={onClose}
+          autoFocus
           aria-label="Close image lightbox"
           sx={{
             "position": "absolute",

--- a/Clients/src/presentation/components/UserGuide/__tests__/ImageLightbox.test.tsx
+++ b/Clients/src/presentation/components/UserGuide/__tests__/ImageLightbox.test.tsx
@@ -1,0 +1,118 @@
+import { useState } from "react";
+import { screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { vi } from "vitest";
+import { renderWithProviders } from "../../../../test/renderWithProviders";
+import ImageLightbox from "../ImageLightbox";
+
+const TINY_GIF = "data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///ywAAAAAAQABAAACAUwAOw==";
+
+describe("ImageLightbox", () => {
+  it("exposes a modal dialog labelled by the image alt text", () => {
+    renderWithProviders(
+      <ImageLightbox src={TINY_GIF} alt="Architecture diagram" onClose={vi.fn()} />,
+    );
+
+    const dialog = screen.getByRole("dialog", { name: "Architecture diagram" });
+    expect(dialog).toHaveAttribute("aria-modal", "true");
+    expect(screen.getByRole("img", { name: "Architecture diagram" })).toBeInTheDocument();
+  });
+
+  it("describes the dialog with the caption when one is provided", () => {
+    renderWithProviders(
+      <ImageLightbox
+        src={TINY_GIF}
+        alt="Architecture diagram"
+        caption="VerifyWise architecture"
+        onClose={vi.fn()}
+      />,
+    );
+
+    const dialog = screen.getByRole("dialog", { name: "Architecture diagram" });
+    const caption = screen.getByText("VerifyWise architecture");
+    expect(dialog).toHaveAttribute("aria-describedby", caption.id);
+  });
+
+  it("calls onClose when Escape is pressed", async () => {
+    const onClose = vi.fn();
+    const user = userEvent.setup();
+
+    renderWithProviders(
+      <ImageLightbox src={TINY_GIF} alt="Architecture diagram" onClose={onClose} />,
+    );
+
+    await user.keyboard("{Escape}");
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it("calls onClose when the close button is activated", async () => {
+    const onClose = vi.fn();
+    const user = userEvent.setup();
+
+    renderWithProviders(
+      <ImageLightbox src={TINY_GIF} alt="Architecture diagram" onClose={onClose} />,
+    );
+
+    await user.click(screen.getByRole("button", { name: "Close image lightbox" }));
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it("keeps Tab focus inside the dialog", async () => {
+    const user = userEvent.setup();
+    renderWithProviders(
+      <>
+        <button type="button">Outside</button>
+        <ImageLightbox src={TINY_GIF} alt="Architecture diagram" onClose={vi.fn()} />
+      </>,
+    );
+
+    const dialog = screen.getByRole("dialog", { name: "Architecture diagram" });
+    const outside = screen.getByRole("button", { name: "Outside", hidden: true });
+
+    expect(outside.closest("[aria-hidden='true']")).not.toBeNull();
+
+    for (let i = 0; i < 6; i++) {
+      await user.tab();
+      expect(outside).not.toHaveFocus();
+      expect(dialog.contains(document.activeElement)).toBe(true);
+    }
+  });
+
+  it("returns focus to the trigger when closed with Escape", async () => {
+    const user = userEvent.setup();
+
+    function Harness() {
+      const [open, setOpen] = useState(false);
+      return (
+        <>
+          <button type="button" onClick={() => setOpen(true)}>
+            Open image
+          </button>
+          {open && (
+            <ImageLightbox
+              src={TINY_GIF}
+              alt="Architecture diagram"
+              onClose={() => setOpen(false)}
+            />
+          )}
+        </>
+      );
+    }
+
+    renderWithProviders(<Harness />);
+
+    const trigger = screen.getByRole("button", { name: "Open image" });
+    await user.click(trigger);
+
+    expect(screen.getByRole("dialog", { name: "Architecture diagram" })).toBeInTheDocument();
+
+    await user.keyboard("{Escape}");
+
+    await waitFor(() => {
+      expect(
+        screen.queryByRole("dialog", { name: "Architecture diagram" }),
+      ).not.toBeInTheDocument();
+    });
+    expect(trigger).toHaveFocus();
+  });
+});


### PR DESCRIPTION
## Describe your changes

StandardModal, AnalyticsDrawer, and ImageLightbox now expose aria-modal dialogs so Esc, Tab, and close restore focus to the trigger.

## Write your issue number after "Fixes "

Fixes #4669 

## Please ensure all items are checked off before requesting a review:

- [x] I deployed the code locally.
- [x] I have performed a self-review of my code.
- [x] I have included the issue # in the PR.
- [x] I have labelled the PR correctly.
- [x] The issue I am working on is assigned to me.
- [x] I have avoided using hardcoded values to ensure scalability and maintain consistency across the application.
- [x] I have ensured that font sizes, color choices, and other UI elements are referenced from the theme.
- [x] My pull request is focused and addresses a single, specific feature.
- [ ] If there are UI changes, I have attached a screenshot or video to this PR.
- [ ] If I added or modified an API endpoint, the change is reflected in the generated OpenAPI spec (`npm run generate:swagger`).
- [ ] If the endpoint requires authentication, it uses `authenticateJWT` and the generated spec declares `bearerAuth` security.
- [ ] I ran `npm run check:api-drift` and committed the regenerated `swagger.yaml` and `endpoints.ts`.
- [ ] If this PR adds or modifies an organization-scoped table, the [tenant isolation registry](Servers/tests/integration/tenant-isolation/tenantIsolation.registry.ts) and [test matrix](Servers/tests/integration/tenant-isolation) are updated. See the [tenant isolation runbook](docs/technical/security/tenant-isolation.md) for details.
