### PR TITLE
test(commands): lock Wise Search command IDs and labels

### DIFF
--- a/Clients/src/application/commands/tests/registry.test.ts
+++ b/Clients/src/application/commands/tests/registry.test.ts
@@ -444,4 +444,57 @@ describe("commandRegistry (registry.ts)", () => {
       expect(commandRegistry.commands.length).toBe(initialCount);
     });
   });
+
+  describe("stable command contracts", () => {
+    const STABLE_COMMANDS: Record<string, string> = {
+      "nav-dashboard": "Dashboard",
+      "nav-tasks": "Tasks",
+      "nav-project-view": "Project oriented view",
+      "nav-framework": "Organizational view",
+      "nav-vendors": "Vendors",
+      "nav-model-inventory": "Model Inventory",
+      "nav-risk-management": "Risk Management",
+      "nav-training": "Training Registry",
+      "nav-file-manager": "Evidence",
+      "nav-reporting": "Reporting",
+      "nav-ai-trust": "AI Trust Center",
+      "nav-policies": "Policy Manager",
+      "nav-event-tracker": "Event Tracker",
+      "nav-settings": "Settings",
+      "nav-incident-management": "Incident Management",
+      "admin-team": "Manage Team",
+    };
+
+    it("keeps built-in command IDs and labels stable for Wise Search", async () => {
+      const { commandRegistry } = await loadRegistryModule();
+      const byId = Object.fromEntries(commandRegistry.commands.map((c) => [c.id, c.label]));
+
+      expect(Object.keys(byId)).toEqual(expect.arrayContaining(Object.keys(STABLE_COMMANDS)));
+
+      for (const [id, label] of Object.entries(STABLE_COMMANDS)) {
+        expect(byId[id]).toBe(label);
+      }
+    });
+
+    it("keeps command IDs unique and non-empty", async () => {
+      const { commandRegistry } = await loadRegistryModule();
+      const ids = commandRegistry.commands.map((c) => c.id);
+
+      expect(ids.every((id) => id.trim().length > 0)).toBe(true);
+      expect(new Set(ids).size).toBe(ids.length);
+    });
+
+    it("keeps command group IDs stable", async () => {
+      const { COMMAND_GROUPS } = await loadRegistryModule();
+
+      expect(COMMAND_GROUPS.map((g) => g.id)).toEqual([
+        "navigation",
+        "actions",
+        "search",
+        "filters",
+        "admin",
+        "help",
+      ]);
+    });
+  });
 });


### PR DESCRIPTION

## Describe your changes

This PR closes the [Task 6 item. ](https://github.com/verifywise-ai/verifywise/issues/4151)

Palette keyboard tests depend on stable registry ids; this contract fails if a built-in command is renamed or duplicated.

## Write your issue number after "Fixes "

Fixes #4673 

## Please ensure all items are checked off before requesting a review:

- [x] I deployed the code locally.
- [x] I have performed a self-review of my code.
- [x] I have included the issue # in the PR.
- [x] I have labelled the PR correctly.
- [x] The issue I am working on is assigned to me.
- [x] I have avoided using hardcoded values to ensure scalability and maintain consistency across the application.
- [ ] I have ensured that font sizes, color choices, and other UI elements are referenced from the theme.
- [x] My pull request is focused and addresses a single, specific feature.
- [ ] If there are UI changes, I have attached a screenshot or video to this PR.
- [ ] If I added or modified an API endpoint, the change is reflected in the generated OpenAPI spec (`npm run generate:swagger`).
- [ ] If the endpoint requires authentication, it uses `authenticateJWT` and the generated spec declares `bearerAuth` security.
- [ ] I ran `npm run check:api-drift` and committed the regenerated `swagger.yaml` and `endpoints.ts`.
- [ ] If this PR adds or modifies an organization-scoped table, the [tenant isolation registry](Servers/tests/integration/tenant-isolation/tenantIsolation.registry.ts) and [test matrix](Servers/tests/integration/tenant-isolation) are updated. See the [tenant isolation runbook](docs/technical/security/tenant-isolation.md) for details.
